### PR TITLE
Clean up CMS navigation link previews

### DIFF
--- a/docs/admin/config.yml
+++ b/docs/admin/config.yml
@@ -26,11 +26,11 @@ collections:
             fields:
               - name: 'label'
                 label: 'Link text'
-                widget: 'string'
+                widget: 'navSectionWidget'
                 required: false
               - name: 'slug'
                 label: 'Slug'
-                widget: 'string'
+                widget: 'noPreviewStringWidget'
                 required: false
               - name: 'secondaryNavItems'
                 label: 'Secondary nav items'
@@ -40,11 +40,11 @@ collections:
                 fields:
                   - name: 'slug'
                     label: 'Slug'
-                    widget: 'string'
+                    widget: 'noPreviewStringWidget'
                     required: false
                   - name: 'label'
                     label: 'Link text'
-                    widget: 'string'
+                    widget: 'navSecondaryWidget'
                     required: false
                   - name: 'tertiaryNavItems'
                     label: 'Tertiary nav items'
@@ -54,11 +54,11 @@ collections:
                     fields:
                       - name: 'slug'
                         label: 'Slug'
-                        widget: 'string'
+                        widget: 'noPreviewStringWidget'
                         required: false
                       - name: 'label'
                         label: 'Link text'
-                        widget: 'string'
+                        widget: 'navTertiaryWidget'
                         required: false
   - name: 'pages'
     label: 'Generic pages'

--- a/docs/admin/src/netlify-cms.js
+++ b/docs/admin/src/netlify-cms.js
@@ -16,6 +16,10 @@ import { Preview as relatedItemsPreview } from './widgets/component/RelatedItems
 import { Preview as helpUsPreview } from './widgets/component/HelpUsPreview';
 import { Preview as bodyPreview } from './widgets/body/Preview';
 import { Preview as permalinkPreview } from './widgets/permalink/Preview';
+import { Preview as navSectionPreview } from './widgets/navigation/sectionPreview';
+import { Preview as navSecondaryPreview } from './widgets/navigation/secondaryPreview';
+import { Preview as navTertiaryPreview } from './widgets/navigation/tertiaryPreview';
+import { Preview as noPreview } from './widgets/noPreview';
 
 CMS.registerWidget( 'introWidget', 'markdown', introPreview );
 CMS.registerWidget( 'slugWidget', 'string', slugPreview );
@@ -33,5 +37,9 @@ CMS.registerWidget( 'relatedItemsWidget', 'markdown', relatedItemsPreview );
 CMS.registerWidget( 'helpUsWidget', 'markdown', helpUsPreview );
 CMS.registerWidget( 'bodyWidget', 'markdown', bodyPreview );
 CMS.registerWidget( 'permalinkWidget', 'string', permalinkPreview );
+CMS.registerWidget( 'navSectionWidget', 'string', navSectionPreview );
+CMS.registerWidget( 'navSecondaryWidget', 'string', navSecondaryPreview );
+CMS.registerWidget( 'navTertiaryWidget', 'string', navTertiaryPreview );
+CMS.registerWidget( 'noPreviewStringWidget', 'string', noPreview );
 
 CMS.registerPreviewStyle( '/design-system/dist/css/main.css' );

--- a/docs/admin/src/widgets/navigation/secondaryPreview.js
+++ b/docs/admin/src/widgets/navigation/secondaryPreview.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const Preview = props => <div>
+    &nbsp;&nbsp;&nbsp;&nbsp;└ {props.value}
+</div>;

--- a/docs/admin/src/widgets/navigation/sectionPreview.js
+++ b/docs/admin/src/widgets/navigation/sectionPreview.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const Preview = props => <div>
+  {props.value}
+</div>;

--- a/docs/admin/src/widgets/navigation/tertiaryPreview.js
+++ b/docs/admin/src/widgets/navigation/tertiaryPreview.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const Preview = props => <div>
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└ {props.value}
+</div>;

--- a/docs/admin/src/widgets/noPreview.js
+++ b/docs/admin/src/widgets/noPreview.js
@@ -1,0 +1,2 @@
+// Don't show a preview
+export const Preview = props => null;


### PR DESCRIPTION
Added a bare bones preview of the nav hierarchy by cheaply adding non-breaking spaces to indent the items. I also created a string widget without a preview for general use.

<img width="962" alt="Screen Shot 2019-07-12 at 9 37 14 AM" src="https://user-images.githubusercontent.com/1060248/61132088-a60eb500-a488-11e9-923c-8809b7a90e81.png">
