### PR TITLE
Fix sidebar template to output slugs as correct URLs

### DIFF
--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -4,14 +4,14 @@
         {% for secondaryNavItem in section.secondaryNavItems %}
         <li>
             {% if secondaryNavItem.slug != '' %}
-                <a href="{{ site.baseurl }}/{{ section.slug }}">{{ secondaryNavItem.label }}</a>
+                <a href="{{ site.baseurl }}/{{ secondaryNavItem.slug }}">{{ secondaryNavItem.label }}</a>
             {% else %}
                 {{ secondaryNavItem.label }}
             {% endif %}
           <ul>
               {% for tertiaryNavItem in secondaryNavItem.tertiaryNavItems %}
               <li>
-                <a class="{% if tertiaryNavItem.label == page.title %}active{% endif %}" href="{{ site.baseurl }}/{{ section.slug }}/{{ tertiaryNavItem.slug }}">
+                <a class="{% if tertiaryNavItem.label == page.title %}active{% endif %}" href="{{ site.baseurl }}/{{ tertiaryNavItem.slug }}">
                     {{ tertiaryNavItem.label }}
                 </a>
               </li>


### PR DESCRIPTION
- fixes secondary nav link with correct slug, before it was outputting the section slug instead of the secondary nav item slug
- fixes tertiary nav link URLs so that it outputs the slug instead of automatically including the section slug in the url

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
