### PR TITLE
Add Jekyll post render hook to inline icon SVGs

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,7 +1,4 @@
+source 'https://rubygems.org'
 gem "nokogiri", "~> 1.10"
-
-# Added at 2019-07-26 17:09:24 -0400 by contolinic:
 gem "jekyll", "~> 3.8"
-
-# Added at 2019-07-26 17:09:44 -0400 by contolinic:
 gem "jekyll-redirect-from", "~> 0.15.0"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,2 +1,7 @@
-source 'https://rubygems.org'
-gem 'github-pages', group: :jekyll_plugins
+gem "nokogiri", "~> 1.10"
+
+# Added at 2019-07-26 17:09:24 -0400 by contolinic:
+gem "jekyll", "~> 3.8"
+
+# Added at 2019-07-26 17:09:44 -0400 by contolinic:
+gem "jekyll-redirect-from", "~> 0.15.0"

--- a/docs/_includes/component.html
+++ b/docs/_includes/component.html
@@ -63,7 +63,6 @@
             </div>
             {% endif %}
 
-
             <div class="govuk-tabs u-mt30" data-module="tabs"  data-toggle-code>
                 <h2 class="govuk-tabs__title">
                 Contents

--- a/docs/_includes/component.html
+++ b/docs/_includes/component.html
@@ -58,8 +58,11 @@
 
             <!-- Live code example -->
             {% if variation.variation_code_snippet %}
+            <div class="live-code-example">
                 {{ variation.variation_code_snippet }}
+            </div>
             {% endif %}
+
 
             <div class="govuk-tabs u-mt30" data-module="tabs"  data-toggle-code>
                 <h2 class="govuk-tabs__title">

--- a/docs/_plugins/render_includes.rb
+++ b/docs/_plugins/render_includes.rb
@@ -1,0 +1,20 @@
+require 'nokogiri'
+
+# Inlines SVGs by replacing all instances of {% includes icons/XXXXXXX.svg %}
+# with the SVG pulled from _includes/icons/XXXXXX.svg
+Jekyll::Hooks.register :pages, :post_render do |page|
+    include_tag_regex = /{%\s+include\s+\/?icons\/(?<icon>[\w-]+)\.svg\s+%}/
+    doc = Nokogiri::HTML(page.output)
+    divs = doc.css('div.live-code-example, table.icon-table')
+    divs.each do |div|
+      # Don't touch code in the non-rendered source code examples
+      # next if div.attr('class') == "source-code"
+      div.inner_html = div.inner_html.gsub(include_tag_regex) do |inline_icon|
+        filename = "#{$1}.svg"
+        filepath = File.join(File.dirname(__FILE__), '../_includes/icons/', filename)
+        svg = File.read(filepath)
+        inline_icon = svg
+      end
+    end
+    page.output = doc.to_html
+end

--- a/docs/_plugins/render_includes.rb
+++ b/docs/_plugins/render_includes.rb
@@ -1,14 +1,13 @@
 require 'nokogiri'
 
-# Inlines SVGs by replacing all instances of {% includes icons/XXXXXXX.svg %}
+# Inlines SVGs by replacing all instances of {% include icons/XXXXXXX.svg %}
 # with the SVG pulled from _includes/icons/XXXXXX.svg
 Jekyll::Hooks.register :pages, :post_render do |page|
     include_tag_regex = /{%\s+include\s+\/?icons\/(?<icon>[\w-]+)\.svg\s+%}/
     doc = Nokogiri::HTML(page.output)
-    divs = doc.css('div.live-code-example, table.icon-table')
+    # Elements to search for includes in
+    divs = doc.css('div.live-code-example, table.icon-table, body.t-generic-page')
     divs.each do |div|
-      # Don't touch code in the non-rendered source code examples
-      # next if div.attr('class') == "source-code"
       div.inner_html = div.inner_html.gsub(include_tag_regex) do |inline_icon|
         filename = "#{$1}.svg"
         filepath = File.join(File.dirname(__FILE__), '../_includes/icons/', filename)

--- a/docs/components/buttons.md
+++ b/docs/components/buttons.md
@@ -152,7 +152,7 @@ variations:
       <button class="a-btn">
           <span class="a-btn_icon
                        a-btn_icon__on-left">
-             <img src="/design-system/assets/icons/error.svg" class="cf-icon-svg" />
+             {% include icons/error.svg %}
           </span>
           Close
       </button>
@@ -162,7 +162,7 @@ variations:
           Close
           <span class="a-btn_icon
                        a-btn_icon__on-right">
-              <img src="/design-system/assets/icons/error.svg" class="cf-icon-svg" />
+              {% include icons/error.svg %}
           </span>
       </button>
     variation_description: ''
@@ -173,7 +173,7 @@ variations:
           Submit your complaint
           <span class="a-btn_icon
                        a-btn_icon__on-right">
-              <img src="/design-system/assets/icons/updating.svg" class="cf-icon-svg" />
+              {% include icons/updating.svg %}
           </span>
       </button>
     variation_description: ''
@@ -265,4 +265,3 @@ research: TBD
 related_items: '- related items'
 help_us: "More information can be found at:\n* http://cfpb.github.io/design-manual/page-components/buttons.html\t\n* https://cfpb.github.io/capital-framework/components/cf-buttons/"
 ---
-

--- a/docs/components/iconography.md
+++ b/docs/components/iconography.md
@@ -24,7 +24,7 @@ variations:
   - variation_code_snippet: |-
       <a class="a-link a-link__icon" href="#">
           <span class="a-link_text">Example with icon</span>
-          <img src="/design-system/assets/icons/download.svg" class="cf-icon-svg" />
+          {% include icons/download.svg %}
       </a>
 
 

--- a/docs/components/text-inputs.md
+++ b/docs/components/text-inputs.md
@@ -140,7 +140,7 @@ variations:
               title="Test input"
               class="a-text-input">
           <button class="a-btn a-btn__link">
-              <img src="/design-system/assets/icons/error.svg" class="cf-icon-svg" />
+              {% include icons/error.svg %}
               <span class="u-visually-hidden">Clear</span>
           </button>
       </div>
@@ -158,7 +158,7 @@ variations:
                       title="Test input"
                       class="a-text-input">
                   <button class="a-btn a-btn__link">
-                      <img src="/design-system/assets/icons/error.svg" class="cf-icon-svg" />
+                      {% include icons/error.svg %}
                       <span class="u-visually-hidden">Clear</span>
                   </button>
               </div>
@@ -232,4 +232,3 @@ research: TBD
 related_items: '* A related item'
 help_us: '* Help us do a thing'
 ---
-

--- a/docs/package.json
+++ b/docs/package.json
@@ -36,7 +36,7 @@
     "watch": "webpack --watch",
     "build": "yarn run compile-js && yarn run compile-css && bundle exec jekyll build",
     "build-preview": "webpack && yarn run compile-css && bundle exec jekyll build",
-    "install": "yarn run copy-icons && yarn --cwd ../src"
+    "install": "yarn run copy-icons && yarn --cwd ../src && bundle install"
   },
   "dependencies": {
     "@cfpb/netlify-cms": "1.14.0",

--- a/docs/pages/beam-pattern.md
+++ b/docs/pages/beam-pattern.md
@@ -97,7 +97,7 @@ especially well for horizontal layouts.
 
 <div class="content-25" markdown="1">
 
-<h4 class="warning" markdown="1"><img src="/design-system/assets/icons/error-round.svg" class="cf-icon-svg" /> Poor composition</h4>
+<h4 class="warning" markdown="1">{% include icons/error-round.svg %} Poor composition</h4>
 
 Beams float in white space, leaving little room for content. No transparency used.
 
@@ -111,7 +111,7 @@ Beams float in white space, leaving little room for content. No transparency use
 
 <div class="content-25" markdown="1">
 
-<h4 class="warning" markdown="1"><img src="/design-system/assets/icons/error-round.svg" class="cf-icon-svg" /> Poor composition</h4>
+<h4 class="warning" markdown="1">{% include icons/error-round.svg %} Poor composition</h4>
 
 All three beams layer in the same direction, weakening the beam metaphor.
 

--- a/docs/pages/logo.md
+++ b/docs/pages/logo.md
@@ -438,7 +438,7 @@ photo backgrounds logo")
 <div class="content-33 content-first warning" markdown="1">
 
 
-<p><img src="/design-system/assets/icons/error-round.svg" class="cf-icon-svg" /> Don’t remove the light beam. It is
+<p>{% include icons/error-round.svg %} Don’t remove the light beam. It is
 essential to the logo.</p>
 
 
@@ -465,7 +465,7 @@ with no beam")
 <div class="content-33 content-first warning" markdown="1">
 
 
-<p><img src="/design-system/assets/icons/error-round.svg" class="cf-icon-svg" /> Don’t stretch or condense. This weakens
+<p>{% include icons/error-round.svg %} Don’t stretch or condense. This weakens
 the brand.</p>
 
 
@@ -503,7 +503,7 @@ logo](https://cfpb.github.io/design-manual/static/img/logo/Logo24.png
 <div class="content-33 content-first warning" markdown="1">
 
 
-<p><img src="/design-system/assets/icons/error-round.svg" class="cf-icon-svg" /> Don’t apply a drop shadow.</p>
+<p>{% include icons/error-round.svg %} Don’t apply a drop shadow.</p>
 
 
 </div><!-- /.content-33 -->
@@ -527,7 +527,7 @@ shadow logo")
 <div class="content-33 content-first warning" markdown="1">
 
 
-<img src="/design-system/assets/icons/error-round.svg" class="cf-icon-svg" /> Don’t outline the logo or use other
+{% include icons/error-round.svg %} Don’t outline the logo or use other
 colors. This dilutes brand association.
 
 
@@ -564,7 +564,7 @@ logo](https://cfpb.github.io/design-manual/static/img/logo/Logo25.png
 <div class="content-33 content-first warning" markdown="1">
 
 
-<img src="/design-system/assets/icons/error-round.svg" class="cf-icon-svg" /> Don’t rotate the symbol. This changes
+{% include icons/error-round.svg %} Don’t rotate the symbol. This changes
 the connotation of the light.
 
 
@@ -602,7 +602,7 @@ logo")
 <div class="content-33 content-first warning" markdown="1">
 
 
-<img src="/design-system/assets/icons/error-round.svg" class="cf-icon-svg" /> Don’t place the logo directly on a
+{% include icons/error-round.svg %} Don’t place the logo directly on a
 colored background or photo without a white bounding box.
 
 


### PR DESCRIPTION
Jekyll doesn't render our `{% include %}` statements because they're stored as strings in our pages' front matter. Using a Jekyll hook we can swap out our include statements with inline SVGs.

See hubcap issues #240 and #221.

Before: https://cfpb.github.io/design-system/foundation/iconography#variations (scroll down to icon table)
After: https://deploy-preview-166--cfpb-design-system.netlify.com/design-system/foundation/iconography#variations