### PR TITLE
Separate CMS button shortcuts

### DIFF
--- a/docs/_layouts/component.html
+++ b/docs/_layouts/component.html
@@ -8,14 +8,16 @@ layout: default
         {% include sidebar.html %}
     </aside>
         {% include component.html %}
-        <div id="edit-page">
-            <a class="a-btn add-new" href="{{ site.baseurl }}/admin/#/collections/{{ page.collection_name }}/new" title="Add a new component page in Netlify CMS">
-                <span class="a-btn_text">Add new component page</span>
-                <span class="a-btn_icon">{% include icons/plus.svg %}</span>
-            </a>
+        <div class="cms-shortcut" id="edit-page">
             <a class="a-btn" href="{{ site.baseurl }}/admin/#/collections/{{ page.collection_name }}/entries/{{ page.title | slugify }}" title="Edit this page in Netlify CMS">
                 <span class="a-btn_text">Edit this page</span>
                 <span class="a-btn_icon">{% include icons/edit.svg %}</span>
+            </a>
+        </div>
+        <div class="cms-shortcut" id="add-page">
+            <a class="a-btn add-new" href="{{ site.baseurl }}/admin/#/collections/{{ page.collection_name }}/new" title="Add a new Design System page in Netlify CMS">
+                <span class="a-btn_text">Add new page</span>
+                <span class="a-btn_icon">{% include icons/plus.svg %}</span>
             </a>
         </div>
   </div>

--- a/docs/_layouts/component.html
+++ b/docs/_layouts/component.html
@@ -8,14 +8,14 @@ layout: default
         {% include sidebar.html %}
     </aside>
         {% include component.html %}
-        <div class="cms-shortcut" id="edit-page">
+        <div class="o-editor_link" id="edit-page">
             <a class="a-btn" href="{{ site.baseurl }}/admin/#/collections/{{ page.collection_name }}/entries/{{ page.title | slugify }}" title="Edit this page in Netlify CMS">
                 <span class="a-btn_text">Edit this page</span>
                 <span class="a-btn_icon">{% include icons/edit.svg %}</span>
             </a>
         </div>
-        <div class="cms-shortcut" id="add-page">
-            <a class="a-btn add-new" href="{{ site.baseurl }}/admin/#/collections/{{ page.collection_name }}/new" title="Add a new Design System page in Netlify CMS">
+        <div class="o-editor_link" id="add-page">
+            <a class="a-btn" href="{{ site.baseurl }}/admin/#/collections/{{ page.collection_name }}/new" title="Add a new Design System page in Netlify CMS">
                 <span class="a-btn_text">Add new page</span>
                 <span class="a-btn_icon">{% include icons/plus.svg %}</span>
             </a>

--- a/docs/_layouts/generic-page.html
+++ b/docs/_layouts/generic-page.html
@@ -8,14 +8,6 @@ layout: default
         {% include sidebar.html %}
     </aside>
     <section class="content_main">
-
-        <section id="edit-page">
-            <a class="a-btn" href="{{ site.baseurl }}/admin/#/collections/{{ page.collection_name }}/entries/{{ page.title | slugify }}" title="Edit this page in Netlify CMS">
-                <span class="a-btn_text">Edit this page</span>
-                <span class="a-btn_icon">{% include icons/edit.svg %}</span>
-            </a>
-        </section>
-
         <h2>{{ page.title }}</h2>
 
         {% capture content %}{{ page.content | markdownify }}{% endcapture %}

--- a/docs/_layouts/homepage.html
+++ b/docs/_layouts/homepage.html
@@ -4,14 +4,6 @@ layout: default
 <main class="content" id="main" role="main">
     <div class="content_wrapper">
         <section class="content_main">
-
-            <section id="edit-page">
-                <a class="a-btn" href="{{ site.baseurl }}/admin/#/collections/{{ page.collection_name }}/entries/{{ page.title | slugify }}" title="Edit this page in Netlify CMS">
-                    <span class="a-btn_text">Edit this page</span>
-                    <span class="a-btn_icon">{% include icons/edit.svg %}</span>
-                </a>
-            </section>
-
             <h2>{{ page.title }}</h2>
 
             {{ content }}

--- a/docs/assets/css/netlify.less
+++ b/docs/assets/css/netlify.less
@@ -1,7 +1,11 @@
-#edit-page {
+.cms-shortcut {
 	position: fixed;
-	bottom: 40px;
-	right: 40px;
+	bottom: 30px;
+	right: 30px;
+
+    &#edit-page {
+    	bottom: 75px;
+    }
 
 	.a-btn {
 		border-radius: 8px;
@@ -9,10 +13,6 @@
 	}
 
 	.a-btn_text {
-		display: none;
-	}
-
-	.add-new {
 		display: none;
 	}
 

--- a/docs/assets/css/netlify.less
+++ b/docs/assets/css/netlify.less
@@ -1,4 +1,4 @@
-.cms-shortcut {
+.o-editor_link {
 	position: fixed;
 	bottom: 30px;
 	right: 30px;


### PR DESCRIPTION
Moves the "add" button into its own fixed location below the edit button.

![cms-buttons](https://user-images.githubusercontent.com/1060248/62489103-e7e30080-b793-11e9-8002-6fca606825bf.gif)
