### PR TITLE
Fix edit button URLs

### DIFF
--- a/docs/_layouts/variation.html
+++ b/docs/_layouts/variation.html
@@ -9,7 +9,7 @@ layout: default
     </aside>
         {% include variation-content.html %}
         <div class="o-editor_link" id="edit-page">
-            <a class="a-btn" href="{{ site.baseurl }}/admin/#/collections/{{ page.section }}/entries/{{ page.title | slugify }}" title="Edit this page in Netlify CMS">
+            <a class="a-btn" href="{{ site.baseurl }}/admin/#/collections/{{ page.section }}/entries/{{ page.path | split: '/' | last | replace: '.md', '' }}" title="Edit this page in Netlify CMS">
                 <span class="a-btn_text">Edit this page</span>
                 <span class="a-btn_icon">{% include icons/edit.svg %}</span>
             </a>


### PR DESCRIPTION
Instead of generating an edit URL by slugifying the page's title, get
the page's markdown filename by removing directories and the file
extension from the page's path.

See hubcap/issues/286 for context.

## Testing

1. Go to https://cfpb.github.io/design-system/components/headings and click the edit button.
1. Note how you 404 because it took you to `/admin/#/collections/components/entries/headings` and the markdown filename is `heading-hierarchy.md` not `headings.md`.
1. Go to https://deploy-preview-243--cfpb-design-system.netlify.com/design-system/components/headings and click the edit button.
1. It should correctly load because it took you to `/admin/#/collections/components/entries/heading-hierarchy`.