### PR TITLE
Change label to Page title for CMS

### DIFF
--- a/docs/admin/config.yml
+++ b/docs/admin/config.yml
@@ -24,7 +24,7 @@ collections:
     slug: '{{slug}}'
     fields:
       - name: 'title'
-        label: 'Title'
+        label: 'Page title'
         widget: 'string'
       - name: 'layout'
         value: 'variation'
@@ -123,7 +123,7 @@ collections:
     slug: '{{slug}}'
     fields:
       - name: 'title'
-        label: 'Title'
+        label: 'Page title'
         widget: 'string'
       - name: 'layout'
         value: 'variation'
@@ -228,7 +228,7 @@ collections:
     slug: '{{slug}}'
     fields:
       - name: 'title'
-        label: 'Title'
+        label: 'Page title'
         widget: 'string'
       - name: 'layout'
         value: 'variation'
@@ -339,7 +339,7 @@ collections:
     slug: '{{slug}}'
     fields:
       - name: 'title'
-        label: 'Title'
+        label: 'Page title'
         widget: 'string'
       - name: 'layout'
         value: 'variation'


### PR DESCRIPTION
Changes the CMS label for the Title field to "Page title."
![Screen Shot 2019-08-21 at 5 29 25 PM](https://user-images.githubusercontent.com/702526/63469896-44ebe100-c439-11e9-82d0-829ff4a5e7b2.png)
