### PR TITLE
Re-style tabs, make them responsive

### DIFF
--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -89,21 +89,18 @@
             {% if variation.variation_code_snippet or variation.variation_jinja_code_snippet %}
 
             <div class="govuk-tabs u-mt30" data-module="tabs"  data-toggle-code>
-                <h5 class="govuk-tabs__title">
-                Code snippets
-                </h5>
-
                 <ul class="govuk-tabs__list">
                     {% if variation.variation_code_snippet and variation.variation_code_snippet != '' %}
                     <li class="govuk-tabs__list-item">
                         <a class="govuk-tabs__tab govuk-tabs__tab--selected" href="#html-code-snippet-{{ forloop.index }}">
-                        HTML                        </a>
+                            HTML code snippet
+                        </a>
                     </li>
                     {% endif %}
                     {% if variation.variation_jinja_code_snippet and variation.variation_jinja_code_snippet != '' %}
                     <li class="govuk-tabs__list-item">
                         <a class="govuk-tabs__tab" href="#jinja-code-snippet-{{ forloop.index }}">
-                        Jinja
+                            Jinja code snippet
                         </a>
                     </li>
                     {% endif %}
@@ -113,7 +110,7 @@
                 {% if variation.variation_code_snippet and variation.variation_code_snippet != '' %}
                 <section class="govuk-tabs__panel" id="html-code-snippet-{{ forloop.index }}">
                     <div class="variation-code-snippet">
-                        <h5 class="variation-code-snippet-title">HTML</h5>
+                        <h5 class="variation-code-snippet-title">HTML code snippet</h5>
                         <div class="source-code">
                             <pre><code class="language-html">{{ variation.variation_code_snippet | xml_escape }}</code></pre>
                         </div>
@@ -125,7 +122,7 @@
                 {% if variation.variation_jinja_code_snippet and variation.variation_jinja_code_snippet != '' %}
                 <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="jinja-code-snippet-{{ forloop.index }}">
                     <div class="variation-jinja-code-snippet">
-                        <h5 class="variation-jinja-code-snippet-title">Jinja</h5>
+                        <h5 class="variation-jinja-code-snippet-title">Jinja code snippet</h5>
                         <div class="source-code">
                             <pre><code class="language-html">{{ variation.variation_jinja_code_snippet | xml_escape }}</code></pre>
                         </div>

--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -113,7 +113,7 @@
                 {% if variation.variation_code_snippet and variation.variation_code_snippet != '' %}
                 <section class="govuk-tabs__panel" id="html-code-snippet-{{ forloop.index }}">
                     <div class="variation-code-snippet">
-                        <h6 class="variation-code-snippet-title">HTML</h6>
+                        <h5 class="variation-code-snippet-title">HTML</h5>
                         <div class="source-code">
                             <pre><code class="language-html">{{ variation.variation_code_snippet | xml_escape }}</code></pre>
                         </div>
@@ -125,7 +125,7 @@
                 {% if variation.variation_jinja_code_snippet and variation.variation_jinja_code_snippet != '' %}
                 <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="jinja-code-snippet-{{ forloop.index }}">
                     <div class="variation-jinja-code-snippet">
-                        <h6 class="variation-jinja-code-snippet-title">Jinja</h6>
+                        <h5 class="variation-jinja-code-snippet-title">Jinja</h5>
                         <div class="source-code">
                             <pre><code class="language-html">{{ variation.variation_jinja_code_snippet | xml_escape }}</code></pre>
                         </div>
@@ -194,36 +194,38 @@
                     <div class="variation-code-specs" data-toggle-code>
                         <h5>Specifications</h5>
 
-                        <table>
-                            <thead>
-                                <tr>
-                                    {% if columns contains 'Design token name' %}<th>Attribute</th>{% endif %}
-                                    {% if columns contains 'Less variable name' %}<th>Variable</th>{% endif %}
-                                    {% if columns contains 'Less value' %}<th>Value</th>{% endif %}
-                                    {% if columns contains 'Pixels' %}<th>Pixels</th>{% endif %}
-                                    {% if columns contains 'Ems' %}<th>Ems</th>{% endif %}
-                                    {% if columns contains 'Points' %}<th>Points</th>{% endif %}
-                                    {% if columns contains 'Seconds' %}<th>Seconds</th>{% endif %}
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% comment %}
-                                    For each applicable row, print a cell only if the
-                                    relevant column is necessary.
-                                {% endcomment %}
-                                {% for spec in rows %}
-                                <tr>
-                                    {% if columns contains 'Design token name' %}<td>{{ tokens[spec]["Design token name"] }}</td>{% endif %}
-                                    {% if columns contains 'Less variable name' %}<td>{{ tokens[spec]["Less variable name"] }}</td>{% endif %}
-                                    {% if columns contains 'Less value' %}<td>{{ tokens[spec]["Less value"] }}</td>{% endif %}
-                                    {% if columns contains 'Pixels' %}<td>{{ tokens[spec]["Pixels"] }}</td>{% endif %}
-                                    {% if columns contains 'Ems' %}<td>{{ tokens[spec]["Ems"] }}</td>{% endif %}
-                                    {% if columns contains 'Points' %}<td>{{ tokens[spec]["Points"] }}</td>{% endif %}
-                                    {% if columns contains 'Seconds' %}<td>{{ tokens[spec]["Seconds"] }}</td>{% endif %}
-                                </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
+                        <div class="o-table o-table-wrapper__scrolling">
+                            <table>
+                                <thead>
+                                    <tr>
+                                        {% if columns contains 'Design token name' %}<th>Attribute</th>{% endif %}
+                                        {% if columns contains 'Less variable name' %}<th>Variable</th>{% endif %}
+                                        {% if columns contains 'Less value' %}<th>Value</th>{% endif %}
+                                        {% if columns contains 'Pixels' %}<th>Pixels</th>{% endif %}
+                                        {% if columns contains 'Ems' %}<th>Ems</th>{% endif %}
+                                        {% if columns contains 'Points' %}<th>Points</th>{% endif %}
+                                        {% if columns contains 'Seconds' %}<th>Seconds</th>{% endif %}
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% comment %}
+                                        For each applicable row, print a cell only if the
+                                        relevant column is necessary.
+                                    {% endcomment %}
+                                    {% for spec in rows %}
+                                    <tr>
+                                        {% if columns contains 'Design token name' %}<td data-label="Design token name">{{ tokens[spec]["Design token name"] }}</td>{% endif %}
+                                        {% if columns contains 'Less variable name' %}<td data-label="Less variable name">{{ tokens[spec]["Less variable name"] }}</td>{% endif %}
+                                        {% if columns contains 'Less value' %}<td data-label="Less value">{{ tokens[spec]["Less value"] }}</td>{% endif %}
+                                        {% if columns contains 'Pixels' %}<td data-label="Pixels">{{ tokens[spec]["Pixels"] }}</td>{% endif %}
+                                        {% if columns contains 'Ems' %}<td data-label="Ems">{{ tokens[spec]["Ems"] }}</td>{% endif %}
+                                        {% if columns contains 'Points' %}<td data-label="Points">{{ tokens[spec]["Points"] }}</td>{% endif %}
+                                        {% if columns contains 'Seconds' %}<td data-label="Seconds">{{ tokens[spec]["Seconds"] }}</td>{% endif %}
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
 
                     </div>
                 {% endif %}

--- a/docs/assets/css/code.less
+++ b/docs/assets/css/code.less
@@ -242,11 +242,11 @@ pre {
 
 /* Pygments via Jekyll */
 .highlight {
-  margin-bottom: 1rem;
-  border-radius: 4px;
+    margin-bottom: 1rem;
+    border-radius: 4px;
 }
 .highlight pre {
-  margin-bottom: 0;
+    margin-bottom: 0;
 }
 
 .source-code pre {
@@ -254,5 +254,4 @@ pre {
     clear: both;
     margin-top: 0;
     padding: 40px;
-	overflow-x: scroll;
 }

--- a/docs/assets/css/code.less
+++ b/docs/assets/css/code.less
@@ -11,9 +11,7 @@ pre[class*="language-"] {
 	text-shadow: 0 1px white;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	text-align: left;
-	white-space: pre;
 	word-spacing: normal;
-	word-break: normal;
 	word-wrap: normal;
 	line-height: 1.5;
 
@@ -221,7 +219,6 @@ code {
 
 pre {
   display: block;
-  margin: 1em 0;
   padding: 1em;
   font-size: .8em;
   line-height: 1.4;
@@ -253,5 +250,9 @@ pre {
 }
 
 .source-code pre {
+    background: none;
+    clear: both;
+    margin-top: 0;
+    padding: 40px;
 	overflow-x: scroll;
 }

--- a/docs/assets/css/header.less
+++ b/docs/assets/css/header.less
@@ -28,7 +28,7 @@
 }
 
 .nav-list-item .active {
-    text-decoration: underline;   
+    text-decoration: underline;
 }
 
 @media (min-width: 770px) {

--- a/docs/assets/css/tabs.less
+++ b/docs/assets/css/tabs.less
@@ -8,73 +8,14 @@
 // if we change them in this CSS we also have to fork and release our own JS with updated breakpoints
 
 .govuk-tabs {
-    font-weight: 400;
-    font-size: 16px;
-    font-size: 1rem;
-    line-height: 1.25;
     margin-top: 5px;
     margin-bottom: 20px;
 }
-@media print {
-    .govuk-tabs {
-        font-family: sans-serif;
-    }
-}
-@media (min-width: 40.0625em) {
-    .govuk-tabs {
-        font-size: 19px;
-        font-size: 1.1875rem;
-        line-height: 1.3157894737;
-    }
-}
-@media print {
-    .govuk-tabs {
-        font-size: 14pt;
-        line-height: 1.15;
-    }
-}
-@media print {
-    .govuk-tabs {
-        color: #000000;
-    }
-}
+
 @media (min-width: 40.0625em) {
     .govuk-tabs {
         margin-top: 5px;
-    }
-}
-@media (min-width: 40.0625em) {
-    .govuk-tabs {
         margin-bottom: 30px;
-    }
-}
-
-.govuk-tabs__title {
-    font-family: "nta", Arial, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-weight: 400;
-    font-size: 16px;
-    font-size: 1rem;
-    line-height: 1.25;
-    margin-bottom: 5px;
-}
-@media print {
-    .govuk-tabs__title {
-        font-family: sans-serif;
-    }
-}
-@media (min-width: 40.0625em) {
-    .govuk-tabs__title {
-        font-size: 19px;
-        font-size: 1.1875rem;
-        line-height: 1.3157894737;
-    }
-}
-@media print {
-    .govuk-tabs__title {
-        font-size: 14pt;
-        line-height: 1.15;
     }
 }
 
@@ -97,6 +38,8 @@
 }
 
 .govuk-tabs__list-item {
+    .heading-5();
+    border-bottom: 0;
     margin-left: 25px;
 }
 
@@ -106,137 +49,85 @@
     padding-right: 5px;
 }
 
-.govuk-tabs__tab {
-    font-family: "nta", Arial, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-family: "nta", Arial, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-weight: 400;
-    font-size: 16px;
-    font-size: 1rem;
-    line-height: 1.25;
-    display: inline-block;
-    padding-top: 10px;
-    padding-bottom: 10px;
-}
-@media print {
-    .govuk-tabs__tab {
-        font-family: sans-serif;
-    }
-}
-
 .govuk-tabs__tab:focus {
-    outline: 3px solid #ffbf47;
-    outline-offset: 0;
-    background-color: #ffbf47;
-}
-
-.govuk-tabs__tab:link {
-    color: #005ea5;
-}
-
-.govuk-tabs__tab:visited {
-    color: #4c2c92;
+    outline: 1px dotted @pacific;
+    outline-offset: 3px;
 }
 
 .govuk-tabs__tab:hover {
-    color: #2b8cc4;
+    background-color: @gray-5;
 }
 
 .govuk-tabs__tab:active {
-    color: #2b8cc4;
+    color: @black;
 }
 
 .govuk-tabs__tab:focus {
-    color: #0b0c0c;
-}
-@media print {
-    .govuk-tabs__tab {
-        font-family: sans-serif;
-    }
-}
-@media (min-width: 40.0625em) {
-    .govuk-tabs__tab {
-        font-size: 19px;
-        font-size: 1.1875rem;
-        line-height: 1.3157894737;
-    }
-}
-@media print {
-    .govuk-tabs__tab {
-        font-size: 14pt;
-        line-height: 1.15;
-    }
+    color: @black;
 }
 
 .govuk-tabs__tab[aria-current="true"] {
-    color: #0b0c0c;
+    color: @black;
     text-decoration: none;
 }
 
 .govuk-tabs__panel {
+    background-color: @gray-5;
     margin-bottom: 30px;
 }
 @media (min-width: 40.0625em) {
     .govuk-tabs__panel {
-        margin-bottom: 50px;
+        border-top: 1px solid @gray;
+        margin: -3px 0 50px;
     }
 }
 @media (min-width: 40.0625em) {
-    .js-enabled .govuk-tabs__list {
-        border-bottom: 1px solid #bfc1c3;
-    }
+    .js-enabled {
 
-    .js-enabled .govuk-tabs__list:after {
-        content: "";
-        display: block;
-        clear: both;
-    }
+        .govuk-tabs__list:after {
+            content: "";
+            display: block;
+            clear: both;
+        }
 
-    .js-enabled .govuk-tabs__list-item {
-        margin-left: 0;
-    }
+        .govuk-tabs__list-item {
+            margin-left: 0;
+        }
 
-    .js-enabled .govuk-tabs__list-item::before {
-        content: none;
-    }
+        .govuk-tabs__list-item::before {
+            content: none;
+        }
 
-    .js-enabled .govuk-tabs__title {
-        display: none;
-    }
+        .govuk-tabs__title {
+            display: none;
+        }
 
-    .js-enabled .govuk-tabs__tab {
-        margin-right: 5px;
-        padding-right: 20px;
-        padding-left: 20px;
-        float: left;
-        color: #0b0c0c;
-        background-color: #f8f8f8;
-        text-align: center;
-        text-decoration: none;
-    }
+        .govuk-tabs__tab {
+            border: 0;
+            color: @gray;
+            margin-right: 5px;
+            padding: 20px 40px 7px;
+            float: left;
+            text-align: center;
+            &:hover {
+                border-bottom: 2px solid @gray-5;
+            }
+            &--selected {
+                color: @black;
+                border-bottom: 5px solid @pacific;
+                &:hover {
+                    border-bottom: 5px solid @pacific;
+                }
+            }
+        }
 
-    .js-enabled .govuk-tabs__tab--selected {
-        margin-top: -5px;
-        margin-bottom: -1px;
-        padding: 14px 19px 16px;
-        border: 1px solid #bfc1c3;
-        border-bottom: 0;
-        color: #0b0c0c;
-        background-color: #ffffff;
-    }
+        .govuk-tabs__tab--selected:focus {
+            background-color: transparent;
+        }
 
-    .js-enabled .govuk-tabs__tab--selected:focus {
-        background-color: transparent;
-    }
-
-    .js-enabled .govuk-tabs__panel {
-        margin-bottom: 0;
-        padding: 30px 20px;
-        border: 1px solid #bfc1c3;
-        border-top: 0;
+        .govuk-tabs__panel {
+            margin-bottom: 0;
+        }
     }
 }
 @media (min-width: 40.0625em) and (min-width: 40.0625em) {
@@ -256,5 +147,11 @@
 
 .variation-code-snippet-title,
 .variation-jinja-code-snippet-title {
-    .respond-to-min(641px, { .u-visually-hidden(); });
+    .respond-to-min(641px, {
+        .u-visually-hidden();
+    });
+    background-color: @white;
+    border-bottom: 1px solid @gray;
+    margin: 0;
+    padding: 20px 40px 7px;
 }

--- a/docs/assets/css/variation.less
+++ b/docs/assets/css/variation.less
@@ -19,3 +19,13 @@
         }    
     }
 }
+
+// Override the stripes that appear in responsive tables
+.variation-code-specs {
+    table {
+        border: none;
+    }
+    td {
+        background-color: @white;
+    }
+}

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -58,6 +58,7 @@ function addPermalinks( headings ) {
     }
 
   }
+
   /**
    * Add event listener to copy on click the anchor link href value for permalink icons next to headings.
    */
@@ -88,11 +89,11 @@ function copyAnchorLink( linkEl ) {
 
   try {
     // Now that we've selected the anchor text, execute the copy command
-    var successful = document.execCommand('copy');
-    var msg = successful ? 'successful' : 'unsuccessful';
-    console.log('Copy email command was ' + msg);
-  } catch(err) {
-    console.log('Oops, unable to copy');
+    const successful = document.execCommand( 'copy' );
+    const msg = successful ? 'successful' : 'unsuccessful';
+    console.log( 'Copy email command was ' + msg );
+  } catch ( err ) {
+    console.log( 'Oops, unable to copy' );
   }
 
   // Remove the selections - NOTE: Should use


### PR DESCRIPTION
Applies CFPB styles to the GovUK tabs we're using. We may want to
formally fork their tabs and redesign them for our design system. For
now we're just tweaking their CSS to make it more CFPBy.

See hubcap/issues/291 for context.

Before:

<img width="552" alt="Screen Shot 2019-08-28 at 4 42 27 AM" src="https://user-images.githubusercontent.com/1060248/63839989-44c67680-c94e-11e9-995f-4c96e63990e6.png">

After:

<img width="543" alt="Screen Shot 2019-08-28 at 4 42 17 AM" src="https://user-images.githubusercontent.com/1060248/63839997-498b2a80-c94e-11e9-990b-7f484659d3ce.png">
