### PR TITLE
Replace Proposed statuses with Released

### DIFF
--- a/docs/components/atomic-components.md
+++ b/docs/components/atomic-components.md
@@ -3,7 +3,7 @@ title: Atomic Components
 layout: variation
 section: components
 secondary_section: Core development
-status: Proposed
+status: Released
 description: >-
   Atomic Component is a micro framework for building Atomic Design components
   that utilize JavaScript. It is a dependency of other packages and isn’t used

--- a/docs/components/bar-charts.md
+++ b/docs/components/bar-charts.md
@@ -3,7 +3,7 @@ title: Bar Charts
 layout: variation
 section: components
 secondary_section: Data visualization
-status: Proposed
+status: Released
 description: >-
   Use bar or column charts to show comparisons of different discrete items,
   factors or categories. Comparisons could include items that can be counted and

--- a/docs/components/blocks.md
+++ b/docs/components/blocks.md
@@ -3,7 +3,7 @@ title: Blocks
 layout: variation
 section: components
 secondary_section: Core development
-status: Proposed
+status: Released
 description: >-
   `.block` is a base class with several modifiers that help you separate chunks
   of content via `margin`, `padding`, `border`, and `background`.

--- a/docs/components/checkboxes.md
+++ b/docs/components/checkboxes.md
@@ -3,7 +3,7 @@ title: Checkboxes
 layout: variation
 section: components
 secondary_section: Forms
-status: Proposed
+status: Released
 description: "Use checkboxes when the user can select more than one option from a list. Make clear with helper text that this is the case.\n\nMore information can be found at:\n\n* http://cfpb.github.io/design-manual/page-components/form-fields.html#checkboxes\t\n* https://cfpb.github.io/capital-framework/components/cf-forms/#basic-checkboxes"
 variations:
   - variation_code_snippet: |-

--- a/docs/components/code-blocks.md
+++ b/docs/components/code-blocks.md
@@ -3,7 +3,7 @@ title: Code blocks
 layout: variation
 section: components
 secondary_section: Text
-status: Proposed
+status: Released
 description: ' '
 variations:
   - variation_code_snippet: >-

--- a/docs/components/column-dividers.md
+++ b/docs/components/column-dividers.md
@@ -3,7 +3,7 @@ title: Column dividers
 layout: variation
 section: components
 secondary_section: Core development
-status: Proposed
+status: Released
 description: |-
   Information about Dividers can be found at:
 

--- a/docs/components/contact-information.md
+++ b/docs/components/contact-information.md
@@ -3,7 +3,7 @@ title: Contact Information
 layout: variation
 section: components
 secondary_section: Layout options
-status: Proposed
+status: Released
 description: >-
   The contact information component is used to display phone, email, mailing
   address, and fax information for offices within the Bureau. This pattern may

--- a/docs/components/dropdowns.md
+++ b/docs/components/dropdowns.md
@@ -3,7 +3,7 @@ title: Dropdowns and multi-selects
 layout: variation
 section: components
 secondary_section: Forms
-status: Proposed
+status: Released
 description: "More information can be found at:\n\n* http://cfpb.github.io/design-manual/page-components/form-fields.html#dropdowns\t\n* https://cfpb.github.io/capital-framework/components/cf-forms/#select-dropdown\n* https://cfpb.github.io/capital-framework/components/cf-forms/#basic-multiselect"
 variations:
   - variation_code_snippet: |-

--- a/docs/components/e-mail-signup-forms.md
+++ b/docs/components/e-mail-signup-forms.md
@@ -3,7 +3,7 @@ title: E-mail Signup Forms
 layout: variation
 section: components
 secondary_section: Forms
-status: Proposed
+status: Released
 description: >-
   Email sign-ups are used to add individual email addresses to a specific
   mailing list that is relevant to the content on the page or the section it is

--- a/docs/components/expandables.md
+++ b/docs/components/expandables.md
@@ -3,7 +3,7 @@ title: Expandables
 layout: variation
 section: components
 secondary_section: Layout options
-status: Proposed
+status: Released
 description: >-
   Expandables are components that have additional content that can be opened
   (expanded) and closed (collapsed). They can appear on their own or in groups.

--- a/docs/components/featured-content-modules.md
+++ b/docs/components/featured-content-modules.md
@@ -3,7 +3,7 @@ title: Featured Content Module
 layout: variation
 section: components
 secondary_section: Layout options
-status: Proposed
+status: Released
 description: >-
   Featured content modules (FCMs) highlight a specific piece of content at the
   top of a page. It’s meant to call attention to a related piece of content that

--- a/docs/components/feedback-forms.md
+++ b/docs/components/feedback-forms.md
@@ -3,7 +3,7 @@ title: Feedback Forms
 layout: variation
 section: components
 secondary_section: Forms
-status: Proposed
+status: Released
 description: >-
   Nulla at nulla justo, eget luctus tortor. Nulla facilisi. Duis aliquet egestas purus in blandit. Curabitur vulputate, ligula lacinia scelerisque tempor, lacus lacus ornare ante, ac egestas est urna sit amet arcu. Class aptent taciti sociosqu ad litora torquent per conubia nostra.
 variations:

--- a/docs/components/fieldsets.md
+++ b/docs/components/fieldsets.md
@@ -3,7 +3,7 @@ title: Fieldsets
 layout: variation
 section: components
 secondary_section: Forms
-status: Proposed
+status: Released
 description: "The fieldset element is used to group several controls as well as labels within a web form. The fieldset includes:\n\n* Legend\n* Block helper text (if necessary)\n* Inline labels\n* Set of controls\n\nMore information can be found at:\n* http://cfpb.github.io/design-manual/page-components/form-fields.html\t\n* https://cfpb.github.io/capital-framework/components/cf-forms/#fieldsets\n\n*NOTE: The code doesn't match description in that the code doesn't include a legend, block helper text, or inline labels."
 variations:
   - variation_code_snippet: |-

--- a/docs/components/filterable-list-control-panels.md
+++ b/docs/components/filterable-list-control-panels.md
@@ -3,7 +3,7 @@ title: Filterable List Control Panels
 layout: variation
 section: components
 secondary_section: Layout options
-status: Proposed
+status: Released
 description: >-
   The filter control panel allows users to whittle down number of items in a
   list to help them focus in on a specific piece of content they may be looking

--- a/docs/components/heading-hierarchy.md
+++ b/docs/components/heading-hierarchy.md
@@ -3,7 +3,7 @@ title: Headings
 layout: variation
 section: components
 secondary_section: Text
-status: Proposed
+status: Released
 description: >-
   Hierarchy refers to the difference in type size and weight between text
   elements. A successful hierarchy establishes the order of importance of

--- a/docs/components/helper-text.md
+++ b/docs/components/helper-text.md
@@ -3,7 +3,7 @@ title: Helper text
 layout: variation
 section: components
 secondary_section: Text
-status: Proposed
+status: Released
 description: ' '
 variations:
   - variation_code_snippet: |-

--- a/docs/components/heroes.md
+++ b/docs/components/heroes.md
@@ -3,7 +3,7 @@ title: Heroes
 layout: variation
 section: components
 secondary_section: Layout options
-status: Proposed
+status: Released
 description: >-
   Heroes function as a primary focal point on a page, often used to introduce a
   collection of pages by combining a brief description of the goals of that

--- a/docs/components/introductions.md
+++ b/docs/components/introductions.md
@@ -3,7 +3,7 @@ title: Introductions
 layout: variation
 section: components
 secondary_section: Layout options
-status: Proposed
+status: Released
 description: >-
   Information about Introductions can be found at:
 

--- a/docs/components/labels.md
+++ b/docs/components/labels.md
@@ -3,7 +3,7 @@ title: Labels and legends
 layout: variation
 section: components
 secondary_section: Text
-status: Proposed
+status: Released
 description: "The legend serves as the heading for a [fieldset](https://cfpb.github.io/design-system/components/fieldsets).\n\nMore information can be found at:\n* http://cfpb.github.io/design-manual/page-components/form-fields.html\t\n* https://cfpb.github.io/capital-framework/components/cf-forms/#labels"
 variations:
   - variation_code_snippet: |-

--- a/docs/components/left-hand-navigation.md
+++ b/docs/components/left-hand-navigation.md
@@ -3,7 +3,7 @@ title: Left Hand Navigation
 layout: variation
 section: components
 secondary_section: Navigation
-status: Proposed
+status: Released
 description: >-
   More information can be found at:
 

--- a/docs/components/line-charts.md
+++ b/docs/components/line-charts.md
@@ -3,7 +3,7 @@ title: Line Charts
 layout: variation
 section: components
 secondary_section: Data visualization
-status: Proposed
+status: Released
 description: >-
   Use when you have one factor over time to show change. Start your axis at 0
   and label your axis to avoid confusion.

--- a/docs/components/links.md
+++ b/docs/components/links.md
@@ -3,7 +3,7 @@ title: Links
 layout: variation
 section: components
 secondary_section: Text
-status: Proposed
+status: Released
 description: "Links lead users to a different page or further information. In contrast, buttons are used to signal actions. Users should be able to identify links without relying on color or styling alone.\n\nMore information can be found at:\n* http://cfpb.github.io/design-manual/page-components/links.html\t\n* https://cfpb.github.io/capital-framework/components/cf-core/#default-links\n* https://cfpb.github.io/capital-framework/components/cf-typography/#link-patterns\""
 variations:
   - variation_code_snippet: >-

--- a/docs/components/lists.md
+++ b/docs/components/lists.md
@@ -3,7 +3,7 @@ title: Lists
 layout: variation
 section: components
 secondary_section: Layout options
-status: Proposed
+status: Released
 description: "Lists are an effective way to visually highlight important information so that it can be more easily scanned and read. Before writing a list, it’s important to identify the best style needed for the information being presented.\n\nList items should:\n\n* Be capitalized\n* Avoid unnecessary repetition\n* Have a parallel structure\n* Start with an introductory clause or sentence\n* Use consistent punctuation\n\nIf the list items are complete sentences, the introductory clause should also be a complete sentence, followed by a colon. These list items should end with a period.\n\nIf the list items are a group of short fragments that each work to complete an introductory clause, the introductory clause should also be a short fragment, followed by a colon. These list items should end with no punctuation.\n\nMore information can be found at:\n* http://cfpb.github.io/design-manual/brand-guidelines/typography.html\t\n* https://cfpb.github.io/capital-framework/components/cf-typography/#lists"
 variations:
   - variation_code_snippet: |-

--- a/docs/components/maps.md
+++ b/docs/components/maps.md
@@ -3,7 +3,7 @@ title: Maps
 layout: variation
 section: components
 secondary_section: Data visualization
-status: Proposed
+status: Released
 description: >-
   Nulla at nulla justo, eget luctus tortor. Nulla facilisi. Duis aliquet egestas purus in blandit. Curabitur vulputate, ligula lacinia scelerisque tempor, lacus lacus ornare ante, ac egestas est urna sit amet arcu. Class aptent taciti sociosqu ad litora torquent per conubia nostra.
 variations:

--- a/docs/components/media-queries.md
+++ b/docs/components/media-queries.md
@@ -3,7 +3,7 @@ title: Media queries
 layout: variation
 section: components
 secondary_section: Core development
-status: Proposed
+status: Released
 description: >-
   Mixins for consistent media queries that take `px` values and convert them to
   ems.

--- a/docs/components/megamenu.md
+++ b/docs/components/megamenu.md
@@ -3,7 +3,7 @@ title: Megamenu
 layout: variation
 section: components
 secondary_section: Navigation
-status: Proposed
+status: Released
 description: >-
   Nulla at nulla justo, eget luctus tortor. Nulla facilisi. Duis aliquet egestas purus in blandit. Curabitur vulputate, ligula lacinia scelerisque tempor, lacus lacus ornare ante, ac egestas est urna sit amet arcu. Class aptent taciti sociosqu ad litora torquent per conubia nostra.
 variations:

--- a/docs/components/modals.md
+++ b/docs/components/modals.md
@@ -3,7 +3,7 @@ title: Modals
 layout: variation
 section: components
 secondary_section: Alerts
-status: Proposed
+status: Released
 description: >-
   Modal windows (also known as dialog boxes or lightboxes) are “pop-up” elements
   that appear in front of a web page, blocking the main page below. Similar to

--- a/docs/components/notifications.md
+++ b/docs/components/notifications.md
@@ -3,7 +3,7 @@ title: Notifications
 layout: variation
 section: components
 secondary_section: Alerts
-status: Proposed
+status: Released
 description: >-
 
   This component provides notification boxes. Form alerts provide a light-touch

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -3,7 +3,7 @@ title: Pagination
 layout: variation
 section: components
 secondary_section: Navigation
-status: Proposed
+status: Released
 description: "Default pagination consists of “Older” and “Newer” links, styled as buttons, and an inline form (input, submit button) that allows users to navigate to specific pages by number. When appropriate, the buttons may be labeled “Previous” and “Next”.\n\nMore information can be found at:\n* http://cfpb.github.io/design-manual/page-components/tables.html#behavior\t\n* https://cfpb.github.io/capital-framework/components/cf-pagination/"
 variations:
   - variation_code_snippet: |-

--- a/docs/components/paragraphs.md
+++ b/docs/components/paragraphs.md
@@ -3,7 +3,7 @@ title: Paragraphs
 layout: variation
 section: components
 secondary_section: Text
-status: Proposed
+status: Released
 description: >-
   This page is under active development. Information is being moved into it from
   these pages:

--- a/docs/components/pie-charts.md
+++ b/docs/components/pie-charts.md
@@ -3,7 +3,7 @@ title: Pie Charts
 layout: variation
 section: components
 secondary_section: Data visualization
-status: Proposed
+status: Released
 description: >-
   Use when you have less than six things that add up to 100%. Use the middle of
   the doughnut to highlight the number or category type. You could also consider

--- a/docs/components/radio-buttons.md
+++ b/docs/components/radio-buttons.md
@@ -3,7 +3,7 @@ title: Radio Buttons
 layout: variation
 section: components
 secondary_section: Forms
-status: Proposed
+status: Released
 description: >
   Use radio buttons when the user can choose only one option out of a list. Use
   these for a small number of discrete elements—avoid long lists of radio

--- a/docs/components/sidebars-prefooters.md
+++ b/docs/components/sidebars-prefooters.md
@@ -3,7 +3,7 @@ title: Sidebars and Prefooters
 layout: variation
 section: components
 secondary_section: Layout options
-status: Proposed
+status: Released
 description: >-
   Sidebars are present across most page templates to house information related
   to the main content of the page. On pages with leftside sub-navigation,

--- a/docs/components/snippet-lists.md
+++ b/docs/components/snippet-lists.md
@@ -3,7 +3,7 @@ title: Snippet Lists
 layout: variation
 section: components
 secondary_section: Layout options
-status: Proposed
+status: Released
 description: >-
   Nulla at nulla justo, eget luctus tortor. Nulla facilisi. Duis aliquet egestas purus in blandit. Curabitur vulputate, ligula lacinia scelerisque tempor, lacus lacus ornare ante, ac egestas est urna sit amet arcu. Class aptent taciti sociosqu ad litora torquent per conubia nostra.
 variations:

--- a/docs/components/sortable-tables.md
+++ b/docs/components/sortable-tables.md
@@ -2,7 +2,7 @@
 title: Sortable Tables
 layout: variation
 section: components
-status: Proposed
+status: Released
 description: "Sorting allows users to reorder the contents of a table by a sortable column of their choice.\n\nAny column that can sort needs to be specified in the table’s markup. When the table loads, it should be sorted by one of the sortable columns by default and indicate which column is already sorted. Not every column of a table needs to be sortable.\n\nAt large screen sizes, tables can be sorted using the header of any sortable column.\n* The currently sorted column is marked with an up or down triangle for ascending and descending sorts, respectively\n* On hover, the currently sorted column shows the opposite triangle\n* Columns that can sort show an up triangle on hover\n* Columns that cannot sort show nothing on hover\n\nIf sorting is needed for smaller screens, use a filter-like expandable with a sorting control (or add a sorting control to the existing filter if the table has one) that only appears when the table switches from tabular to stacked.\n\nMore information can be found at:\n\n* http://cfpb.github.io/design-manual/page-components/tables.html\t\n* https://cfpb.github.io/capital-framework/components/cf-tables/#sortable-tables"
 variations:
   - variation_code_snippet: |-

--- a/docs/components/tables.md
+++ b/docs/components/tables.md
@@ -3,7 +3,7 @@ title: Tables
 layout: variation
 section: components
 secondary_section: Layout options
-status: Proposed
+status: Released
 description: "Tables divide information into distinct columns and rows to create an intersection “cell” where data is displayed.\n\nMore information can be found at:\n\n* http://cfpb.github.io/design-manual/page-components/tables.html\t\n* https://cfpb.github.io/capital-framework/components/cf-tables/#responsive-tables\n* https://cfpb.github.io/capital-framework/components/cf-tables/#sortable-tables"
 variations:
   - variation_code_snippet: >-

--- a/docs/components/text-inputs.md
+++ b/docs/components/text-inputs.md
@@ -3,7 +3,7 @@ title: Text Inputs
 layout: variation
 section: components
 secondary_section: Forms
-status: Proposed
+status: Released
 description: >-
   This page includes other components like form alerts and buttons. You can
   learn more about these on their respective pages.

--- a/docs/components/wells.md
+++ b/docs/components/wells.md
@@ -3,7 +3,7 @@ title: Wells
 layout: variation
 section: components
 secondary_section: Layout options
-status: Proposed
+status: Released
 description: >-
   Wells are used to highlight specific information within a designated section
   of a page. This breaks up the flow of content on the page and helps to

--- a/docs/foundation/animation.md
+++ b/docs/foundation/animation.md
@@ -3,7 +3,7 @@ title: Animation
 layout: variation
 section: foundation
 secondary_section: Brand guidelines
-status: Proposed
+status: Released
 description: >-
   Animation should be used to bring on-brand illustrations to life. Animation
   can also be used enhance the display of information, such as drawing the

--- a/docs/foundation/foundation.md
+++ b/docs/foundation/foundation.md
@@ -2,7 +2,7 @@
 title: Foundation
 layout: variation
 section: foundation
-status: Proposed
+status: Released
 description: >-
   <p class="lead-paragraph">Foundation includes our design principles, best
   practices for user experience, and our visual identity standards. Together,

--- a/docs/foundation/iconography.md
+++ b/docs/foundation/iconography.md
@@ -3,7 +3,7 @@ title: Iconography
 layout: variation
 section: foundation
 secondary_section: Brand guidelines
-status: Proposed
+status: Released
 description: >-
   Icons visually reinforce an interface action, file type, status, or category.
 

--- a/docs/foundation/illustration.md
+++ b/docs/foundation/illustration.md
@@ -3,7 +3,7 @@ title: Illustration
 layout: variation
 section: foundation
 secondary_section: Brand guidelines
-status: Proposed
+status: Released
 description: >-
   Illustrations are an important tool for introducing the subject matter of a
   page, event, or topic. Illustrations are vector-based graphics that support

--- a/docs/foundation/photography.md
+++ b/docs/foundation/photography.md
@@ -3,7 +3,7 @@ title: Photography
 layout: variation
 section: foundation
 secondary_section: Brand guidelines
-status: Proposed
+status: Released
 description: >-
   Photography is an important tool that helps us relate to consumers,
   communicate empathy, and build trust. CFPB images should preserve aesthetic

--- a/docs/foundation/typography.md
+++ b/docs/foundation/typography.md
@@ -3,7 +3,7 @@ title: Typography
 layout: variation
 section: foundation
 secondary_section: Brand guidelines
-status: Proposed
+status: Released
 description: >-
   A clear typographic hierarchy is critical to the effective communication of
   our brand. Type should be light and well-spaced to reinforce that we are

--- a/docs/foundation/video.md
+++ b/docs/foundation/video.md
@@ -3,7 +3,7 @@ title: Video
 layout: variation
 section: foundation
 secondary_section: Brand guidelines
-status: Proposed
+status: Released
 description: >-
   Video is a powerful tool that can be used to educate viewers about the
   financial marketplace and the CFPB’s role in regulating it.

--- a/docs/templates/1-landing-pages.md
+++ b/docs/templates/1-landing-pages.md
@@ -3,7 +3,7 @@ title: Landing pages
 layout: variation
 section: templates
 secondary_section: Web templates
-status: Proposed
+status: Released
 description: >-
   Landing page types provide an overview of a main navigation section and helps
   users situate themselves within the site and the subject matter. Their main

--- a/docs/templates/2-sublanding-pages.md
+++ b/docs/templates/2-sublanding-pages.md
@@ -3,7 +3,7 @@ title: Sublanding pages
 layout: variation
 section: templates
 secondary_section: Web templates
-status: Proposed
+status: Released
 description: >-
   This page is under active development. Information is being moved into it from
   this page:

--- a/docs/templates/3-browse-pages.md
+++ b/docs/templates/3-browse-pages.md
@@ -3,7 +3,7 @@ title: Browse pages
 layout: variation
 section: templates
 secondary_section: Web templates
-status: Proposed
+status: Released
 description: >-
   Browse page types provide specific topic or product overviews and information.
   Often these pages contain medium-length content, access to specific documents

--- a/docs/templates/4-learn-pages.md
+++ b/docs/templates/4-learn-pages.md
@@ -3,7 +3,7 @@ title: Learn pages
 layout: variation
 section: templates
 secondary_section: Web templates
-status: Proposed
+status: Released
 description: >-
   Learn page types provide focused, detailed information about a specific topic.
   These pages may contain lengthy text passages or interactive content that

--- a/docs/templates/5-filterable-list-pages.md
+++ b/docs/templates/5-filterable-list-pages.md
@@ -3,7 +3,7 @@ title: Filterable list pages
 layout: variation
 section: templates
 secondary_section: Web templates
-status: Proposed
+status: Released
 description: >-
   Filterable list page types are used to house searchable lists of articles,
   documents, or other resources and publications.

--- a/docs/templates/6-document-detail-pages.md
+++ b/docs/templates/6-document-detail-pages.md
@@ -3,7 +3,7 @@ title: Document detail pages
 layout: variation
 section: templates
 secondary_section: Web templates
-status: Proposed
+status: Released
 description: >-
   Document detail page types provide summary information about a document or
   related group of documents. These pages help users better understand the


### PR DESCRIPTION
Every page that had a `Proposed` tag now has a `Released` tag instead.
