### PR TITLE
Fix links from design-manual to design-system

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -22,7 +22,7 @@ Our design system has been created to work with a wide range of devices and brow
 As a work of the United States government, all code is open source and in the public domain. We encourage you to use this framework in your own projects and to contribute back.
 
 ## Help us make improvements
-Since the start of the CFPB, our design system has evolved, and will continue to evolve, as we learn what works best for the CFPB and the people we serve. Our design system is open for the public, which allows you to help us make improvements by [filing an issue](https://github.com/cfpb/design-manual/issues?milestone=&page=1&state=open) or [submitting a pull request](https://github.com/cfpb/design-manual/pulls) on GitHub. Not on GitHub? Email us your suggestions at [tech@consumerfinance.gov](tech@consumerfinance.gov).
+Since the start of the CFPB, our design system has evolved, and will continue to evolve, as we learn what works best for the CFPB and the people we serve. Our design system is open for the public, which allows you to help us make improvements by [filing an issue](https://github.com/cfpb/design-system/issues?milestone=&page=1&state=open) or [submitting a pull request](https://github.com/cfpb/design-system/pulls) on GitHub. Not on GitHub? Email us your suggestions at [tech@consumerfinance.gov](tech@consumerfinance.gov).
 
 All content has been released as open source under the CC0 1.0 Universal Public Domain Dedication, and we’d love for other agencies, developers, or groups to adapt it for their own use.
 


### PR DESCRIPTION
Fixes links for issues and pull requests

## Changes

- changes links from design-manual to design-system


-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
