### PR TITLE
Remove empty restrictions (bug)

### DIFF
--- a/docs/components/e-mail-signup-forms.md
+++ b/docs/components/e-mail-signup-forms.md
@@ -171,8 +171,6 @@ usage: >-
 
   ![Inset breakpoint
   320](/design-system/images/uploads/email-sign-up_learn_320.png)
-restrictions: []
 accessibility: ''
 research: ''
 ---
-

--- a/docs/components/info-unit-groups-image-text.md
+++ b/docs/components/info-unit-groups-image-text.md
@@ -219,7 +219,6 @@ usage: >
 
   * Can be used for an even or odd number of items and may imply a hierarchy of
   information given the list style format.
-restrictions: []
 accessibility: ''
 research: ''
 related_items: '* Link blobs (Design System page in progress)'
@@ -248,4 +247,3 @@ help_us: >-
   [cf-layout](https://cfpb.github.io/capital-framework/components/cf-layout/#custom-content-layouts)
 last_updated: 2019-09-17T14:27:23.333Z
 ---
-

--- a/docs/components/links.md
+++ b/docs/components/links.md
@@ -39,14 +39,14 @@ variations:
               {% include icons/mail.svg %}
               <span class="a-link_text">john.smith@cfpb.gov</span>
           </a>.
-          Documents minicons can emphasize a link that contains a 
+          Documents minicons can emphasize a link that contains a
           <a class="a-link
                     a-link__icon"
              href="#">
               <span class="a-link_text">file or document</span>
               {% include icons/download.svg %}
           </a>.
-          Use the external link minicon to emphasize 
+          Use the external link minicon to emphasize
           <a class="a-link
                     a-link__icon"
              href="#">
@@ -205,9 +205,7 @@ usage: >-
   `aria-label="Learn why some county data are unavailable. (Link opens in new
   tab.)"` This meets [WCAG guideline 3.2 that webpages should work in a
   predictable way](https://www.w3.org/TR/WCAG20-TECHS/G201.html).
-restrictions: []
 accessibility: ''
 research: ''
 last_updated: 2019-09-17T14:52:22.684Z
 ---
-

--- a/docs/components/megamenu.md
+++ b/docs/components/megamenu.md
@@ -108,23 +108,21 @@ usage: >-
 
   ##### Link character counts
 
-  - Links should be 20 characters or less, including spaces. 
+  - Links should be 20 characters or less, including spaces.
 
   - Two exceptions per column can be made for longer links. These longer links
   can be 30-35 characters with spaces **maximum** (e.g. “Managing someone else’s
-  money”).  
-   
+  money”).
+
 
   #### Editorial guidelines
     - Links should be in alphabetical order and written in title case
     - Ampersands ("&") should be used in place of the word "and"
-    - See previous section for link limits and character count guidance 
+    - See previous section for link limits and character count guidance
     - Links should generally be straightforward and self-explanatory, avoiding jargon or brand names that might be difficult for users to understand
     - Links should generally go to [consumerfinance.gov](https://www.consumerfinance.gov) pages only
     - Links should reflect page titles, but don't necessarily have to duplicate them verbatim
-restrictions: []
 accessibility: ''
 research: ''
 last_updated: 2019-09-17T14:36:40.318Z
 ---
-

--- a/docs/components/quotes.md
+++ b/docs/components/quotes.md
@@ -13,7 +13,7 @@ variations:
   - variation_code_snippet: |-
       <aside class="m-pull-quote">
           <p class="m-pull-quote_body">
-             "You miss 100% of the shots you don't take - Wayne Gretzky"  
+             "You miss 100% of the shots you don't take - Wayne Gretzky"
           </p>
           <footer>
               <cite class="m-pull-quote_citation">
@@ -39,8 +39,6 @@ variations:
     variation_description: ''
     variation_name: Large pull quote
 usage: ''
-restrictions: []
 accessibility: ''
 research: ''
 ---
-


### PR DESCRIPTION
Templates that have an empty restrictions array do not show their usage section. 

Fixes https://github.com/cfpb/design-system/issues/357

## Changes

- Remove empty restrictions from component templates.
