### PR TITLE
Fix misnamed icon utility

### DIFF
--- a/packages/cfpb-forms/src/atoms/select.less
+++ b/packages/cfpb-forms/src/atoms/select.less
@@ -1,3 +1,9 @@
+//
+// Import external dependencies
+//
+
+@import (reference) '../../../cfpb-icons/src/cfpb-icons.less';
+
 .a-select {
     position: relative;
     border: 1px solid @select-border;

--- a/packages/cfpb-icons/src/icons-svg-inline.js
+++ b/packages/cfpb-icons/src/icons-svg-inline.js
@@ -18,7 +18,7 @@ module.exports = {
      * @param {string} svgFillColor - The fill color of the icon (defaults to CFPB Black).
      * @returns {string} SVG icon markup.
      */
-    functions.add( '@cfpb/icons-svg-inline', ( svgName, svgFillColor ) => {
+    functions.add( 'icons-svg-inline', ( svgName, svgFillColor ) => {
       // Retrieve this plugin script's path so we can fake __dirname.
       const thisScriptPath = pluginManager.installedPlugins[0].filename;
 


### PR DESCRIPTION
Somewhere along the way the icon utility got misnamed (maybe in https://github.com/cfpb/design-system/commit/c5ed1312cfa258c407edf429feba33f869c5ff56#diff-6f832afbd954a937aea89c317ed308b0). This fixes it.

## Changes

- Fixes inline icon utility path names.
- Includes cfpb-icons in the select.less by reference, so utility is always available when that file is imported.

## Testing

1. Pull branch and `cd doc && yarn && yarn start` and visit http://localhost:4000/design-system/components/dropdowns-and-multi-selects and see that the drop-down has an icon.
