### PR TITLE
Add "banners" organism component page to design system

### DIFF
--- a/docs/components/banners.md
+++ b/docs/components/banners.md
@@ -1,0 +1,29 @@
+---
+title: Banners
+layout: variation
+section: components
+secondary_section: Alerts
+status: Beta
+description: >-
+  This component provides banner boxes at the top of the page's content.
+  This is similar to a notification, but is intended to be full width.
+variations:
+  - variation_code_snippet: |-
+      <div class="o-banner">
+          <div class="wrapper wrapper__match-content">
+              <div class="m-notification
+                          m-notification__warning
+                          m-notification__visible">
+                  {% include icons/information-round.svg %}
+                  <div class="m-notification_content">
+                      <div class="h4 m-notification_message">
+                          A default banner
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </div>
+    variation_description: Use the default banner by default.
+    variation_name: Default banner
+last_updated: 2020-01-28T15:55:47.394Z
+---

--- a/packages/cfpb-notifications/src/cfpb-notifications.less
+++ b/packages/cfpb-notifications/src/cfpb-notifications.less
@@ -42,3 +42,9 @@
 //
 
 @import (less) './molecules/notification.less';
+
+//
+// Organisms
+//
+
+@import (less) './organisms/banner.less';

--- a/packages/cfpb-notifications/src/organisms/banner.less
+++ b/packages/cfpb-notifications/src/organisms/banner.less
@@ -3,6 +3,9 @@
 // Global banner in the header.
 //
 
+// Import required component dependencies.
+@import (reference) 'cfpb-grid.less';
+
 .o-banner {
     padding: unit( @grid_gutter-width / 2 / @base-font-size-px, em ) 0;
     background: @gold-10;

--- a/packages/cfpb-notifications/src/organisms/banner.less
+++ b/packages/cfpb-notifications/src/organisms/banner.less
@@ -1,0 +1,26 @@
+//
+// Banner
+// Global banner in the header.
+//
+
+.o-banner {
+    padding: unit( @grid_gutter-width / 2 / @base-font-size-px, em ) 0;
+    background: @gold-10;
+    border-bottom: 1px solid @gray-40;
+    font-size: 0.875em;
+
+    // Override notification box styling to align notification in header.
+    .m-notification {
+        border: none;
+        padding: 0;
+
+        &_icon {
+          left: 0;
+          top: 0;
+        }
+    }
+
+    .respond-to-min( @bp-sm-min, {
+        font-size: 1em;
+    } );
+}

--- a/packages/cfpb-notifications/src/organisms/banner.less
+++ b/packages/cfpb-notifications/src/organisms/banner.less
@@ -4,7 +4,7 @@
 //
 
 // Import required component dependencies.
-@import (reference) 'cfpb-grid.less';
+@import (reference) '../../../cfpb-grid/src/cfpb-grid.less';
 
 .o-banner {
     padding: unit( @grid_gutter-width / 2 / @base-font-size-px, em ) 0;


### PR DESCRIPTION
## Additions

- Add "banners" organism component page to design system.

## Testing

1. Pull branch and `cd docs on && yarn && yarn start`
2. Visit http://localhost:4000/design-system/components/banners and see there is a basic default banner shown! Ta-da!

## Screenshots

<img width="1286" alt="Screen Shot 2020-01-28 at 2 52 36 PM" src="https://user-images.githubusercontent.com/704760/73299814-dd9f3d80-41dd-11ea-968f-e61c96dccc31.png">
