### PR TITLE
cf-core: Use inherit instead of initial on heading mixins

### DIFF
--- a/packages/cfpb-core/src/base.less
+++ b/packages/cfpb-core/src/base.less
@@ -34,9 +34,9 @@ b {
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
     font-weight: normal;
-    letter-spacing: initial;
+    letter-spacing: inherit;
     line-height: 1.25;
-    text-transform: initial;
+    text-transform: inherit;
 }
 
 .heading-2( @fs: @size-ii ) {
@@ -45,9 +45,9 @@ b {
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
     font-weight: normal;
-    letter-spacing: initial;
+    letter-spacing: inherit;
     line-height: 1.25;
-    text-transform: initial;
+    text-transform: inherit;
 }
 
 .heading-3( @fs: @size-iii ) {
@@ -56,9 +56,9 @@ b {
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
     font-weight: normal;
-    letter-spacing: initial;
+    letter-spacing: inherit;
     line-height: 1.25;
-    text-transform: initial;
+    text-transform: inherit;
 }
 
 .heading-4( @fs: @size-iv ) {
@@ -67,9 +67,9 @@ b {
     margin-bottom: unit( 15px / @font-size, em );
     font-size: unit( @font-size / @base-font-size-px, em );
     font-weight: 500;
-    letter-spacing: initial;
+    letter-spacing: inherit;
     line-height: 1.25;
-    text-transform: initial;
+    text-transform: inherit;
 }
 
 .heading-5( @fs: @size-v, @text-shadow: @text ) {


### PR DESCRIPTION
Because IE does not support the `initial` value, and `inherit` works just fine.

These were added in https://github.com/cfpb/capital-framework/pull/784 in order to prevent H5s and H6s styled as larger headings from being uppercased and letter-spaced.

## Changes

- `letter-spacing` and `text-transform` resets in `heading-` mixins now use `inherit` instead of `initial`

## Testing

I had difficulty getting the Design System site running locally, but I tested the changes by manually editing the `node_modules/@cfpb/cfpb-core/src/base.less` file in cfgov-refresh.

## Screenshots

### Before

![Screenshot showing heading in uppercase and letter-spaced](https://user-images.githubusercontent.com/1044670/73694629-720a1400-46a6-11ea-86ad-c0500893736e.png)

### After

![Screenshot showing heading set normally](https://user-images.githubusercontent.com/1044670/73694703-9c5bd180-46a6-11ea-9229-e2a2733e1555.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 11
- [x] Safari on iOS
- [x] Chrome on Android