### PR TITLE
Check that not found element is null not undefined

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -25,7 +25,7 @@ const showEls = els => els.forEach( el => el.classList.remove( HIDDEN_CLASS ) );
 
 // This is the "Hide/show code & specs" button on component pages.
 
-if ( typeof toggleButton !== 'undefined' ) {
+if ( toggleButton !== null ) {
   toggleButton.addEventListener( 'click', ev => {
     ev.preventDefault();
     const codeIsHidden = toggleButton.getAttribute( 'data-code-hidden' );


### PR DESCRIPTION
Was checking for `undefined` on DOM query that returned no results, but the result in that case would actually be `null`.

## Changes

- Check that not found element is `null` not `undefined`.
