### PR TITLE
Ensure collapsed expandable is visible when overflow is overridden

### DIFF
--- a/docs/assets/css/secondary-nav.less
+++ b/docs/assets/css/secondary-nav.less
@@ -7,7 +7,7 @@
         .o-expandable__padded
         .o-expandable__background
     And use these for child div where the navigation links are:
-        .o-expandable_content 
+        .o-expandable_content
         .nav-secondary
    ========================================================================== */
 
@@ -32,6 +32,7 @@
             .respond-to-min(@bp-med-min, {
                 max-height: initial !important;
                 overflow: visible;
+                display: block;
             });
         }
     }
@@ -158,7 +159,7 @@
 
     // Add custom border with smaller gutter between sidebar and main content for secondary nav
     .respond-to-min(@bp-med-min, {
-        
+
         .content_sidebar {
             border-right-color: @content_sidebar-bg;
         }
@@ -173,5 +174,5 @@
         }
 
     });
-        
+
 }


### PR DESCRIPTION
Fixes sidebar that was hidden from the change in https://github.com/cfpb/design-system/pull/406

## Changes

- Ensure collapsed expandable is visible when overflow is overridden

## Testing

1. Sidebar in e.g. https://cfpb.github.io/design-system/components/expandables should be visible.
