### PR TITLE
Hide empty variations

### DIFF
--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -4,7 +4,7 @@
         <h1>
             {{ page.title }}
         </h1>
-    {% if page.variations %}
+    {% if page.variations and page.variations.size > 0 %}
 
         <div id="toggle-code">
             <a class="a-btn" id="toggle-code-btn" href="#">
@@ -28,7 +28,7 @@
     </div>
 
     <ul class="m-list m-list__horizontal u-mb30">
-        {% if page.variations %}
+        {% if page.variations and page.variations.size > 0 %}
         <li class="m-list_item">
             <a class="m-list_link" href="#variations">Variations</a>
         </li>
@@ -61,7 +61,7 @@
         </section>
     {% endif %}
 
-    {% if page.variations %}
+    {% if page.variations and page.variations.size > 0 %}
     <section class="sticky-header u-mb45">
         <h2 id="variations">Variations</h2>
         <div class="content_line__wide content_line content_line u-mb20"></div>


### PR DESCRIPTION
## Changes

- Checks if the variations array is empty before showing it.

## Testing

1. Check https://cfpb.github.io/design-system/components/atomic-components and see that there's an empty variation section. Compare to the same page in the preview branch in this PR. 
2. Check that the buttons page still has the variations.

## Screenshots

<img width="608" alt="Screen Shot 2020-04-10 at 3 22 04 PM" src="https://user-images.githubusercontent.com/704760/79017332-0e391700-7b3f-11ea-90e9-657e29db8b74.png">
