### PR TITLE
Ensure live code examples have no anchor links

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -4,7 +4,10 @@ import Expandable from '@cfpb/cfpb-expandables/src/Expandable';
 import Table from '@cfpb/cfpb-tables/src/Table';
 
 const anchors = new AnchorJS();
+// Add anchors to all headings (except page title headings)
 anchors.add('h2:not(.title_heading), h3, h4, h5');
+// Ensure there are no anchors in the live code examples
+anchors.remove('.live-code-example h2, .live-code-example h3, .live-code-example h4, .live-code-example h5');
 
 Expandable.init();
 Table.init();


### PR DESCRIPTION
See https://github.com/cfpb/design-system/pull/438#issuecomment-612189098.

## Testing

1. Compare the [live site](https://cfpb.github.io/design-system/components/cards) to this PR's [preview site](https://deploy-preview-443--cfpb-design-system.netlify.com/design-system/components/cards)
1. When you hover over "Bank accounts" there should be no link icon.

## Notes

- The library used is https://www.bryanbraun.com/anchorjs/.