### PR TITLE
Improve navigation link colors and add a max line length

### DIFF
--- a/docs/assets/css/header.less
+++ b/docs/assets/css/header.less
@@ -58,11 +58,16 @@
         .u-inline-block;
         margin-right: 20px;
         a {
-            &:hover,
-            &:focus,
             &:active,
-            &.active {
-                text-decoration: underline;
+            &.active,
+            &:visited {
+                border-bottom: 1px solid @link-underline;
+                color: @link-text;
+            }
+            &:hover,
+            &:focus {
+                border-bottom: 1px solid @link-underline-active;
+                color: @link-text-active;
             }
         }
     }

--- a/docs/assets/css/main-content.less
+++ b/docs/assets/css/main-content.less
@@ -2,21 +2,6 @@
    Main content
    ========================================================================== */
 
-.content_main,
-.content_intro {
-   dd,
-   dt,
-   h3,
-   h4,
-   h5,
-   h6,
-   li,
-   p,
-   label {
-       max-width: inherit;
-   }
-}
-
 .section-image {
     width: 65%;
     margin: 0 auto;

--- a/docs/assets/css/secondary-nav.less
+++ b/docs/assets/css/secondary-nav.less
@@ -54,6 +54,18 @@
         });
     }
 
+    .m-list_link {
+        border: none;
+
+        &:visited {
+            color: @link-text;
+        }
+
+        &:hover {
+            border-bottom: 1px solid @link-underline-active;
+            color: @link-text-active;
+        }
+    }
 }
 
 


### PR DESCRIPTION
Limits line lengths to our standard `41.875rem` and sets the main and side nav links to be pacific except on hover when they're navy.

## Changes

- Color of side and main nav links.

## Removals

- `max-width: inherit;` that was overriding cf-layout's [max-width](https://github.com/cfpb/capital-framework/blob/0b15295c00ba1972676b6f4c86f3b40dcf45289d/packages/cf-layout/src/cf-layout.less#L252).

## Testing

1. Compare a [production page](https://cfpb.github.io/design-system/components/checkboxes) to a [PR preview page](https://deploy-preview-444--cfpb-design-system.netlify.com/design-system/components/checkboxes).

## Notes

- By default, Netlify CMS wraps images in `p` tags, meaning their max width is also constrained. When we start experimenting with new image layouts we'll need to ensure they don't get wrapped in `p`s.
- The main nav links have an `.active` class when it's the current page. The side nav has no such functionality.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [x] Safari on iOS
- [x] Chrome on Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing
