### PR TITLE
Copy over color swatch styles from design manual

### DIFF
--- a/docs/assets/css/color-swatches.less
+++ b/docs/assets/css/color-swatches.less
@@ -6,7 +6,7 @@
 }
 
 .swatches__primary {
-    .grid_column(9.40)
+    .grid_column( 9.40 )
 }
 
 
@@ -50,7 +50,7 @@
 /* Make swatch tables multi column at appropriate widths */
 
 /* Small tablet (600px) */
-@media only screen and (min-width: 37.5em) {
+@media only screen and ( min-width: 37.5em ) {
 
     th {
         width: unit( 70px / @base-font-size-px, em );
@@ -59,44 +59,44 @@
         .grid_nested-col-group();
     }
     .swatch {
-        .grid_column(6)
+        .grid_column( 6 )
     }
 }
 /* Landscape tablet/netbook/laptop (1024px) */
 @media only screen and (min-width: 64em) {
     .swatch__secondary {
-        .grid_column(3);
+        .grid_column( 3 );
     }
 
     .swatch__primary {
-        .grid_column(4);
+        .grid_column( 4 );
     }
 
 }
 
 @colors: 'dark-green', 'green', 'green-80', 'green-60', 'green-40', 'green-20', 'green-10',
-        'dark-teal', 'teal', 'teal-80', 'teal-60', 'teal-40', 'teal-20', 'teal-10',
-        'dark-pacific', 'pacific', 'pacific-80', 'pacific-60', 'pacific-40', 'pacific-20', 'pacific-10',
-        'dark-navy', 'navy', 'navy-80', 'navy-60', 'navy-40', 'navy-20', 'navy-10',
-        'dark-purple', 'purple', 'purple-80', 'purple-60', 'purple-40', 'purple-20', 'purple-10',
-        'dark-red', 'red', 'red-80', 'red-60', 'red-40', 'red-20', 'red-10',
-        'dark-gold', 'gold', 'gold-80', 'gold-60', 'gold-40', 'gold-20', 'gold-10',
-        'dark-neutral', 'neutral', 'neutral-80', 'neutral-60', 'neutral-40', 'neutral-20', 'neutral-10',
-        'dark-gray', 'gray', 'gray-80', 'gray-60', 'gray-40', 'gray-20', 'gray-10', 'gray-5',
-        'black', 'white';
+         'dark-teal', 'teal', 'teal-80', 'teal-60', 'teal-40', 'teal-20', 'teal-10',
+         'dark-pacific', 'pacific', 'pacific-80', 'pacific-60', 'pacific-40', 'pacific-20', 'pacific-10',
+         'dark-navy', 'navy', 'navy-80', 'navy-60', 'navy-40', 'navy-20', 'navy-10',
+         'dark-purple', 'purple', 'purple-80', 'purple-60', 'purple-40', 'purple-20', 'purple-10',
+         'dark-red', 'red', 'red-80', 'red-60', 'red-40', 'red-20', 'red-10',
+         'dark-gold', 'gold', 'gold-80', 'gold-60', 'gold-40', 'gold-20', 'gold-10',
+         'dark-neutral', 'neutral', 'neutral-80', 'neutral-60', 'neutral-40', 'neutral-20', 'neutral-10',
+         'dark-gray', 'gray', 'gray-80', 'gray-60', 'gray-40', 'gray-20', 'gray-10', 'gray-5',
+         'black', 'white';
 
 // Set up looping mixin
-.color-swatch-loop(@index) when (@index > 0) {
+.color-swatch-loop( @index ) when ( @index > 0 ) {
     // Retrieve the next variable name from the @colors array
-    @name: e(extract(@colors, @index));
+    @name: e( extract( @colors, @index ) );
     // Output the `.swatch_field__color` rule
     .swatch_field__@{name} { background: @@name; }
     // Call the next iteration of the loop
-    .color-swatch-loop((@index - 1));
+    .color-swatch-loop( @index - 1 );
 }
 
 // Initiate loop
-.color-swatch-loop( length(@colors) );
+.color-swatch-loop( length( @colors ) );
 
 .color-table {
     width: 100%;
@@ -107,7 +107,7 @@
         height: 2.5em;
     }
 
-    td:not(:first-of-type) {
+    td:not( :first-of-type ) {
         white-space: nowrap;
     }
 }

--- a/docs/assets/css/color-swatches.less
+++ b/docs/assets/css/color-swatches.less
@@ -1,0 +1,113 @@
+/* Color swatches for Identity/Color page
+   ========================================================================== */
+
+.swatches-container__primary{
+    .grid_nested-col-group()
+}
+
+.swatches__primary {
+    .grid_column(9.40)
+}
+
+
+.swatch {
+
+    margin-left: 0;
+
+    &_field {
+        height: 5em;
+    }
+
+    &__primary &_field {
+        height: 10em;
+    }
+
+    &_head {
+        margin: 0.25em 0;
+    }
+
+    &_table {
+        width: 100%;
+    }
+
+    td,
+    th {
+        padding: 0;
+        vertical-align: top;
+        background: transparent !important;
+    }
+    th {
+        padding-right: 0.25em;
+        font-weight: 600;
+        text-align: left;
+    }
+
+    &_field__green {
+        background: @green;
+    }
+}
+
+/* Make swatch tables multi column at appropriate widths */
+
+/* Small tablet (600px) */
+@media only screen and (min-width: 37.5em) {
+
+    th {
+        width: unit( 70px / @base-font-size-px, em );
+    }
+    .swatches {
+        .grid_nested-col-group();
+    }
+    .swatch {
+        .grid_column(6)
+    }
+}
+/* Landscape tablet/netbook/laptop (1024px) */
+@media only screen and (min-width: 64em) {
+    .swatch__secondary {
+        .grid_column(3);
+    }
+
+    .swatch__primary {
+        .grid_column(4);
+    }
+
+}
+
+@colors: 'dark-green', 'green', 'green-80', 'green-60', 'green-40', 'green-20', 'green-10',
+        'dark-teal', 'teal', 'teal-80', 'teal-60', 'teal-40', 'teal-20', 'teal-10',
+        'dark-pacific', 'pacific', 'pacific-80', 'pacific-60', 'pacific-40', 'pacific-20', 'pacific-10',
+        'dark-navy', 'navy', 'navy-80', 'navy-60', 'navy-40', 'navy-20', 'navy-10',
+        'dark-purple', 'purple', 'purple-80', 'purple-60', 'purple-40', 'purple-20', 'purple-10',
+        'dark-red', 'red', 'red-80', 'red-60', 'red-40', 'red-20', 'red-10',
+        'dark-gold', 'gold', 'gold-80', 'gold-60', 'gold-40', 'gold-20', 'gold-10',
+        'dark-neutral', 'neutral', 'neutral-80', 'neutral-60', 'neutral-40', 'neutral-20', 'neutral-10',
+        'dark-gray', 'gray', 'gray-80', 'gray-60', 'gray-40', 'gray-20', 'gray-10', 'gray-5',
+        'black', 'white';
+
+// Set up looping mixin
+.color-swatch-loop(@index) when (@index > 0) {
+    // Retrieve the next variable name from the @colors array
+    @name: e(extract(@colors, @index));
+    // Output the `.swatch_field__color` rule
+    .swatch_field__@{name} { background: @@name; }
+    // Call the next iteration of the loop
+    .color-swatch-loop((@index - 1));
+}
+
+// Initiate loop
+.color-swatch-loop( length(@colors) );
+
+.color-table {
+    width: 100%;
+    margin-bottom: unit( 45px / @base-font-size-px, em );
+
+    .swatch_field {
+        width: 30%;
+        height: 2.5em;
+    }
+
+    td:not(:first-of-type) {
+        white-space: nowrap;
+    }
+}

--- a/docs/assets/css/main.less
+++ b/docs/assets/css/main.less
@@ -67,3 +67,4 @@ nav ul {
 @import (less) "toggle-code-button.less";
 @import (less) "badges.less";
 @import (less) "variation.less";
+@import (less) "color-swatches.less";


### PR DESCRIPTION
Brings over the [color swatch CSS](https://github.com/cfpb/design-manual/blob/9e8d7a6718a2d68226ebd2e570d6c5e45afd2648/src/static/css/content.less#L218) from the design manual so that the color page no longer looks bonkers.

## Additions

- Color swatch stylesheet

## Testing

1. Compare [production](https://cfpb.github.io/design-system/foundation/color) to the [PR preview](https://deploy-preview-447--cfpb-design-system.netlify.app/design-system/foundation/color).
