### PR TITLE
Add last modified date

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 gem "nokogiri", "~> 1.10"
 gem "jekyll", "~> 3.8"
 gem "jekyll-redirect-from", "~> 0.15.0"
+gem "jekyll-last-modified-at", "~> 1.1.0"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,7 @@
 # Redirects
 plugins:
   - jekyll-redirect-from
+  - jekyll-last-modified-at
 
 # Base configuration
 permalink: /:title

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,5 +1,16 @@
 <footer class="footer" role="contentinfo">
     <div class="wrapper">
-        
+
+        <hr>
+
+        <div class="block block__sub">
+            <small>
+                <strong>Page last edited:</strong>
+                <time datetime="{{ page.last_modified_at }}">
+                    {{ page.last_modified_at | date: "%l:%M:%S %p %b %d, %Y" }}
+                </time>
+            </small>
+        </div>
+
     </div>
 </footer>

--- a/docs/admin/config.yml
+++ b/docs/admin/config.yml
@@ -111,10 +111,6 @@ collections:
         label: 'Help us make improvements'
         widget: 'markdown'
         required: false
-      - name: 'last_updated'
-        label: 'Page last updated'
-        widget: 'datetime'
-        required: false
   - name: 'foundation'
     preview_path: "foundation/{{slug}}"
     label: 'Foundation pages'
@@ -214,10 +210,6 @@ collections:
       - name: 'help_us'
         label: 'Help us make improvements'
         widget: 'markdown'
-        required: false
-      - name: 'last_updated'
-        label: 'Page last updated'
-        widget: 'datetime'
         required: false
   - name: 'components'
     preview_path: "components/{{slug}}"
@@ -329,10 +321,6 @@ collections:
         label: 'Help us make improvements'
         widget: 'markdown'
         required: false
-      - name: 'last_updated'
-        label: 'Page last updated'
-        widget: 'datetime'
-        required: false
   - name: 'templates'
     label: 'Templates pages'
     preview_path: "templates/{{slug}}"
@@ -430,8 +418,4 @@ collections:
       - name: 'help_us'
         label: 'Help us make improvements'
         widget: 'markdown'
-        required: false
-      - name: 'last_updated'
-        label: 'Page last updated'
-        widget: 'datetime'
         required: false


### PR DESCRIPTION
## Changes

- Adds `jekyll-last-modified-at` for providing a last modified date stamp in the footer.

## Testing

1. Check the PR preview link below and see that last modified date in the footer of pages.

## Screenshots

<img width="337" alt="Screen Shot 2020-04-17 at 12 24 15 PM" src="https://user-images.githubusercontent.com/704760/79591353-62e01300-80a6-11ea-96bb-a3707bb804e8.png">
