### PR TITLE
Add doc JS to linter

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -5,9 +5,9 @@ import Table from '@cfpb/cfpb-tables/src/Table';
 
 const anchors = new AnchorJS();
 // Add anchors to all headings (except page title headings)
-anchors.add('h2:not(.title_heading), h3, h4, h5');
+anchors.add( 'h2:not(.title_heading), h3, h4, h5' );
 // Ensure there are no anchors in the live code examples
-anchors.remove('.live-code-example h2, .live-code-example h3, .live-code-example h4, .live-code-example h5');
+anchors.remove( '.live-code-example h2, .live-code-example h3, .live-code-example h4, .live-code-example h5' );
 
 Expandable.init();
 Table.init();

--- a/scripts/gulp/lint.js
+++ b/scripts/gulp/lint.js
@@ -57,7 +57,10 @@ function lintTests() {
  * @returns {Object} An output stream from gulp.
  */
 function lintScripts() {
-  return _genericLintJs( [ 'packages/*/src/**/*.js' ] );
+  return _genericLintJs( [
+    'packages/*/src/**/*.js',
+    'docs/assets/js/**/*.js'
+  ] );
 }
 
 /**


### PR DESCRIPTION
## Changes

- Add documentation site JS to the gulp linter script.

## Testing

1. `gulp lint` should include doc/assets/js/main.js
