### PR TITLE
Make homepage editable via the CMS

### DIFF
--- a/docs/_includes/generic-content.html
+++ b/docs/_includes/generic-content.html
@@ -1,0 +1,9 @@
+<section class="content_main">
+
+    {% if page.body %}
+    <section>
+        {{ page.body | markdownify }}
+    </section>
+    {% endif %}
+
+</section><!-- .content_main -->

--- a/docs/_includes/generic-content.html
+++ b/docs/_includes/generic-content.html
@@ -1,9 +1,9 @@
 <section class="content_main">
 
     {% if page.body %}
-    <section>
+    <div>
         {{ page.body | markdownify }}
-    </section>
+    </div>
     {% endif %}
 
 </section><!-- .content_main -->

--- a/docs/_layouts/homepage.html
+++ b/docs/_layouts/homepage.html
@@ -3,10 +3,12 @@ layout: default
 ---
 <main class="content" id="main" role="main">
     <div class="content_wrapper">
-        <section class="content_main">
-            <h2>{{ page.title }}</h2>
-
-            {{ content }}
-        </section>
+        {% include generic-content.html %}
+    </div>
+    <div class="o-editor_link" id="edit-page">
+        <a class="a-btn" href="{{ site.baseurl }}/admin/#/collections/generic-pages/entries/home" title="Edit this page in Netlify CMS">
+            <span class="a-btn_text">Edit this page</span>
+            <span class="a-btn_icon">{% include icons/edit.svg %}</span>
+        </a>
     </div>
 </main>

--- a/docs/admin/config.yml
+++ b/docs/admin/config.yml
@@ -15,6 +15,17 @@ public_folder: /design-system/images/uploads
 pull_request_url: https://github.com/cfpb/design-system/pulls
 
 collections:
+  - label: "Generic pages"
+    name: "generic-pages"
+    files:
+      - label: "Home"
+        name: "home"
+        file: "home.md"
+        fields:
+          - name: 'body'
+            label: 'Markdown and/or HTML for the homepage'
+            widget: 'text'
+            required: true
   - name: 'getting-started'
     preview_path: "getting-started/{{slug}}"
     label: 'Getting started pages'

--- a/docs/admin/src/netlify-cms.js
+++ b/docs/admin/src/netlify-cms.js
@@ -1,5 +1,6 @@
 import CMS from 'netlify-cms';
 import { default as componentsPreviewTemplate } from './widgets/componentsPreviewTemplate';
+import { default as genericPreviewTemplate } from './widgets/genericPreviewTemplate';
 import { Preview as navPreview } from './widgets/navigationPreviewTemplate';
 
 CMS.registerPreviewTemplate( 'getting-started', componentsPreviewTemplate );
@@ -7,6 +8,6 @@ CMS.registerPreviewTemplate( 'foundation', componentsPreviewTemplate );
 CMS.registerPreviewTemplate( 'components', componentsPreviewTemplate );
 CMS.registerPreviewTemplate( 'templates', componentsPreviewTemplate );
 CMS.registerPreviewTemplate( 'navigation', navPreview );
-
+CMS.registerPreviewTemplate( 'home', genericPreviewTemplate );
 
 CMS.registerPreviewStyle( '/design-system/dist/css/main.css' );

--- a/docs/admin/src/widgets/genericPreviewTemplate.js
+++ b/docs/admin/src/widgets/genericPreviewTemplate.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react';
+import { ReactLiquid, liquidEngine } from 'react-liquid';
+import marked from 'marked';
+import template from '../../../_includes/generic-content.html';
+
+export default class Preview extends Component {
+
+  componentDidMount() {
+    liquidEngine.registerFilter( 'markdownify', initial => marked( initial || '' ) );
+  }
+
+  render() {
+    const data = {
+      page: this.props.entry.toJS().data
+    };
+    return (
+      <div>
+        <ReactLiquid template={ template } data={ data } html />
+      </div>
+    );
+  }
+
+}

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,29 +1,37 @@
 ---
-title: Welcome to the CFPB Design System
+title: Homepage
 layout: homepage
+body: >-
+  ## Welcome to the CFPB Design System
+
+  Our design system is an open-source resource for CFPB teams to produce effective and visually-consistent products that are easy for consumers to access, use, and understand. 
+
+  ## Getting started
+
+  Learn how to integrate our design system into your project, contribute to the code base, and update the documentation. [Get started](https://cfpb.github.io/design-system/getting-started/)
+
+  ## Foundation
+
+  Browse our design principles, best practices, and visual identity standards. Together, they serve as the foundation for our website and our external-facing materials. [View our foundation](https://cfpb.github.io/design-system/foundation/)
+
+  ## Components
+
+  Discover the different components that our design system provides. You'll find design specs, code snippets, as well as usage, accessibility, and implementation guidance. [Browse our components](https://cfpb.github.io/design-system/components/)
+
+  ## Templates
+
+  Find out more about the common page types that we use within our content management system, which are documented for easy reference. [Review our templates](https://cfpb.github.io/design-system/templates/)
+
+  ## About the CFPB Design System
+
+  Our design system has been created to work with a wide range of devices and browsers. Following a modern, mobile first responsive approach, sites built with our Design System easily adapt to a wide range of screen sizes, all while carefully following accessibility best practices. 
+
+  As a work of the United States government, all code is open source and in the public domain. We encourage you to use this framework in your own projects and to contribute back.
+
+  ## Help us make improvements
+
+  Since the start of the CFPB, our design system has evolved, and will continue to evolve, as we learn what works best for the CFPB and the people we serve. Our design system is open for the public, which allows you to help us make improvements by [filing an issue](https://github.com/cfpb/design-system/issues?milestone=&page=1&state=open) or [submitting a pull request](https://github.com/cfpb/design-system/pulls) on GitHub. Not on GitHub? Email us your suggestions at [tech@consumerfinance.gov](tech@consumerfinance.gov).
+
+  All content has been released as open source under the CC0 1.0 Universal Public Domain Dedication, and we’d love for other agencies, developers, or groups to adapt it for their own use.
 ---
-Our design system is an open-source resource for CFPB teams to produce effective and visually-consistent products that are easy for consumers to access, use, and understand. 
-
-## Getting started
-Learn how to integrate our design system into your project, contribute to the code base, and update the documentation. [Get started](https://cfpb.github.io/design-system/getting-started/)
-
-## Foundation
-Browse our design principles, best practices, and visual identity standards. Together, they serve as the foundation for our website and our external-facing materials. [View our foundation](https://cfpb.github.io/design-system/foundation/)
-
-## Components
-Discover the different components that our design system provides. You'll find design specs, code snippets, as well as usage, accessibility, and implementation guidance. [Browse our components](https://cfpb.github.io/design-system/components/)
-
-## Templates
-Find out more about the common page types that we use within our content management system, which are documented for easy reference. [Review our templates](https://cfpb.github.io/design-system/templates/)
-
-## About the CFPB Design System 
-Our design system has been created to work with a wide range of devices and browsers. Following a modern, mobile first responsive approach, sites built with our Design System easily adapt to a wide range of screen sizes, all while carefully following accessibility best practices. 
-
-As a work of the United States government, all code is open source and in the public domain. We encourage you to use this framework in your own projects and to contribute back.
-
-## Help us make improvements
-Since the start of the CFPB, our design system has evolved, and will continue to evolve, as we learn what works best for the CFPB and the people we serve. Our design system is open for the public, which allows you to help us make improvements by [filing an issue](https://github.com/cfpb/design-system/issues?milestone=&page=1&state=open) or [submitting a pull request](https://github.com/cfpb/design-system/pulls) on GitHub. Not on GitHub? Email us your suggestions at [tech@consumerfinance.gov](tech@consumerfinance.gov).
-
-All content has been released as open source under the CC0 1.0 Universal Public Domain Dedication, and we’d love for other agencies, developers, or groups to adapt it for their own use.
-
 


### PR DESCRIPTION
Adds netlify [file collection](https://www.netlifycms.org/docs/collection-types/#file-collections)  called 'Generic pages' that is used for one-off pages with unique layouts. Currently, the homepage is the only item in this collection. A jinja template and netlify preview template was created to unintelligently render whatever HTML and markdown is added to a generic page's "body" field.

## Additions

- Netlify CMS file collection w/ homepage file.
- Template for rendering and previewing "generic content", i.e. a freeform text field containing HTML and/or markdown.
- Edit button on homepage.

## Testing

1. Compare the [production homepage](https://cfpb.github.io/design-system/) to this [PR preview homepage](https://deploy-preview-456--cfpb-design-system.netlify.app/design-system). They should be the same.
1. Click the edit button in the bottom right and type random HTML and markdown into the text field. It should render in the preview pain. (Don't click save or it'll open a PR). Note: the text field will be blank when the page loads because Netlify CMS pulls its content from the master branch of this repo and the [home.md](https://github.com/cfpb/design-system/blob/master/docs/home.md) file doesn't have a `body` field until this PR is merged.

## Screenshots

<img width="1658" alt="Screen Shot 2020-04-23 at 5 56 39 PM" src="https://user-images.githubusercontent.com/1060248/80153594-d6dd5800-858b-11ea-9127-5126acef80b4.png">
