### PR TITLE
Replace Travis CI deployment step with GitHub Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,21 @@
+name: GitHub Pages
+
+on:
+    push:
+        branches:
+        - master
+    
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/setup-node@v1
+          with:
+            node-version: 12
+        - uses: actions/setup-ruby@v1
+          with:
+            ruby-version: '2.6'
+        - uses: actions/checkout@v1
+        - run: ./scripts/update-gh-pages.sh
+          env:
+            GITHUB_TOKEN: ${{ secrets.github_token }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,3 @@ install:
 - yarn --cwd docs/
 script:
 - yarn test
-before_deploy:
-- yarn --cwd docs/ run build
-- sed -i '/_site/d' ./.gitignore
-deploy:
-  provider: pages
-  skip_cleanup: true
-  local_dir: docs/_site/
-  verbose: true
-  github_token: $GITHUB_TOKEN
-  on:
-    branch: master
-env:
-  matrix:
-    # $GITHUB_TOKEN for cfpb/design-system (using the CFPBot GH account)
-    # See https://docs.travis-ci.com/user/deployment/pages/
-    secure: zlRBn1Ga42/3sfPIqq3Dmb++aGgWexi9yQsgzwBml1m3biF2x79ggBemPpuTYGnzRQvB3wIP7sZm/VfSXZaU2QufWgiX8KXd69ztErVDu/tUCMY4n4NbQz6H2P/WulKD2B9gdmGuxdMj2K3elUo7OLnnbTXNHX8wrh5+pWqNgJBBhsJHRMBNE8F9RvzrhcAZtKbfDFUgALhJD0oYriEddggpjD8turMSV37PTI24MENBYsJY2oR9hT3RTfe0WFxnDj57tisZ+IXe94JurQmAADAjuBixdDEpGrlT3ilRmiH+OinGX5+8R4dftiHEFF3SaM8feK4ml7JuzObcD1GQvs6H54g/AMYhvPy+6IUlru4EGXYO9CrYZCXiR5ODHC6UCcnvjWakhl6YSAsc79k1fQCPOoeH8j/e4wuPOX9Vu3aGi/frnXG0F+CkFTZ3vhsA2M3AKiED1xmwxsPgV7pKMlEzu5EI1cNxsGM/vKY/Ej2W8Y4Nl33j14vAhuK5rL6B5PAxHG6/iwevGNSacBvb2a+pgxutOCp0S969JgyKfyhJOtEtJ4wxsn4ZLs8ANy32uSyDBgNghT9HbiJstR7WhmH0+As5YCRI2C2dFHv409AUl+JnfX6cDzjM7xGwgGwjMBd2dDbVUo6W3dJhhN8xSQ7ne3UZnmlcjsn3nMhAujA=

--- a/scripts/update-gh-pages.sh
+++ b/scripts/update-gh-pages.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# See full list of GitHub-provided env variables at
+# https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
+repo_uri="https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+remote_name="origin"
+main_branch="master"
+target_branch="gh-pages"
+target_dir="docs/_site/"
+
+cd "$GITHUB_WORKSPACE"
+
+# Mount the github pages branch as a subdirectory
+# See http://sangsoonam.github.io/2019/02/08/using-git-worktree-to-deploy-github-pages.html
+git worktree add "$target_dir" "$target_branch"
+
+# Install dependencies
+yarn
+yarn --cwd docs/
+
+# Build the design system website
+yarn --cwd docs/ run build
+
+# Remove the built Jekyll website from .gitignore
+sed -i '/_site/d' ./.gitignore
+
+# Configure git
+git config user.name "CFPBot"
+git config user.email "CFPBot@users.noreply.github.com"
+
+# Commit the built website
+cd "$target_dir"
+git add .
+git commit -m "Update GitHub Pages"
+if [ "$?" != "0" ]; then
+	echo "nothing to commit"
+	exit 0
+fi
+
+# Push to remote gh-pages branch
+git remote set-url "$remote_name" "$repo_uri"
+git push "$remote_name" "$target_branch"


### PR DESCRIPTION
Travis has proven unreliable so we should migrate our CI to GitHub Actions. This PR migrates the gh-pages deployment step. In a future PR we can migrate our PR tests.

## Additions

- `deploy` GitHub Actions job.
- Shell script that builds the website and pushes it to gh-pages.


## Removals

- Travis CI deployment step.

## Testing

1. Hmmmmmm. Merge this PR and see if the action completes?

## Todos

- Migrate PR tests to GitHub Actions.
- [Configure caching](https://github.com/actions/cache/blob/master/examples.md#node---yarn) to greatly speed up the website build time.