### PR TITLE
Remove unused redirects plugin

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
 gem "nokogiri", "~> 1.10"
 gem "jekyll", "~> 3.8"
-gem "jekyll-redirect-from", "~> 0.15.0"
 gem "jekyll-last-modified-at", "~> 1.1.0"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,5 @@
 # Redirects
 plugins:
-  - jekyll-redirect-from
   - jekyll-last-modified-at
 
 # Base configuration


### PR DESCRIPTION
We're not using this plugin right now, so removing it until such time as we want or need to support redirects this way.