### PR TITLE
Add link to pages' GitHub history in footer

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -7,9 +7,14 @@
         <div class="block block__sub">
             <small>
                 <strong>Page last edited:</strong>
-                <time datetime="{{ page.last_modified_at }}">
-                    {{ page.last_modified_at | date: "%l:%M:%S %p %b %d, %Y" }}
-                </time>
+                {% if page.section %}
+                    {% assign file_url_section = page.section | append: '/' %}
+                {% endif %}
+                <a href="https://github.com/{{ site.repository }}/commits/master/docs/{{ file_url_section }}{{ page.path | split: '/' | last }}">
+                    <time datetime="{{ page.last_modified_at }}">
+                        {{ page.last_modified_at | date: "%l:%M:%S %p %b %d, %Y" }}
+                    </time>
+                </a>
             </small>
         </div>
         {% endif %}

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -7,10 +7,11 @@
         <div class="block block__sub">
             <small>
                 <strong>Page last edited:</strong>
+                {% assign file_url_path = page.path | split: '/' | last %}
                 {% if page.section %}
-                    {% assign file_url_section = page.section | append: '/' %}
+                    {% assign file_url_path = page.section | append: '/' | append: file_url_path %}
                 {% endif %}
-                <a href="https://github.com/{{ site.repository }}/commits/master/docs/{{ file_url_section }}{{ page.path | split: '/' | last }}">
+                <a href="https://github.com/{{ site.repository }}/commits/master/docs/{{ file_url_path }}">
                     <time datetime="{{ page.last_modified_at }}">
                         {{ page.last_modified_at | date: "%l:%M:%S %p %b %d, %Y" }}
                     </time>

--- a/docs/assets/css/footer.less
+++ b/docs/assets/css/footer.less
@@ -2,12 +2,8 @@
    Footer
    ========================================================================== */
 
-.site-footer {
-    display: table-row; /* for sticky footer */
-    height: 1px; /* for sticky footer */
-    background: @gray-10;
-}
-
-.site-footer_wrapper {
-    padding: 2em 0;
+footer {
+    a {
+        border-bottom-width: 1px;
+    }
 }


### PR DESCRIPTION
## Removes

- All the CSS rules in `footer.less` that aren't used anywhere. 

## Changes

- Links pages' "Last edited" timestamp to their GitHub history pages.

## Testing

1. Check out the PR preview link below.

## Screenshots

<img width="516" alt="Screen Shot 2020-04-30 at 6 20 54 PM" src="https://user-images.githubusercontent.com/1060248/80765261-9f812500-8b10-11ea-9e4b-eb3772e23ac3.png">
