### PR TITLE
Reduce scope of Netlify CMS permissions

### DIFF
--- a/docs/admin/config.yml
+++ b/docs/admin/config.yml
@@ -2,6 +2,7 @@ backend:
   name: github
   repo: cfpb/design-system
   branch: master
+  auth_scope: public_repo
   squash_merges: true
   commit_messages:
     create: Create "{{slug}}" page


### PR DESCRIPTION
Netlify used to require access to all public and private repos in order
to use their CMS. They have since added a config option to only require
access to users' public repos.

Fixes #420.

## Testing

1. Try editing a page at the PR preview link below and confirm that when authenticating with Netlify only access to public repos is requested.
