### PR TITLE
Search: Set max line width on results

### DIFF
--- a/docs/assets/css/search.less
+++ b/docs/assets/css/search.less
@@ -5,7 +5,7 @@
 #search-form,
 #search-results {
     margin: 15px;
-    margin-left: 8px;
+    margin-left: 0;
 }
 
 #search-results {

--- a/docs/search-results.html
+++ b/docs/search-results.html
@@ -4,7 +4,7 @@ title: Search
 section: search
 ---
 
-<main class="content">
+<main class="content content_main">
   <div class="content_wrapper">
     <ul id="search-results"></ul>
   </div>


### PR DESCRIPTION
## Changes

- Sets the max line width by enclosing the search results in `content_main` class.

## Testing

1. See preview and perform a search and see that results aren't as wide as before.

## Screenshots

Before:
<img width="1384" alt="Screen Shot 2020-05-01 at 5 04 59 PM" src="https://user-images.githubusercontent.com/704760/80841883-55f70f80-8bce-11ea-89f7-1f79574d2248.png">

After:
<img width="1385" alt="Screen Shot 2020-05-01 at 5 06 25 PM" src="https://user-images.githubusercontent.com/704760/80841887-57283c80-8bce-11ea-82ca-1fcf8192c2b3.png">
