### PR TITLE
Fix variations search | add search fields | highlight search term

### DIFF
--- a/docs/_includes/search-scripts.html
+++ b/docs/_includes/search-scripts.html
@@ -16,7 +16,7 @@
                 {% for variation in variation_group.variations %}
                     'variation_name{{ forloop.index }}': '{{ variation.variation_name | xml_escape }}',
                     'variation_description{{ forloop.index }}': {{ variation.variation_description | markdownify | strip_html | strip_newlines | jsonify }},
-                    'variation_code_snippet{{ forloop.index }}': {{ variation.variation_code_snippet | markdownify | strip_html | strip_newlines | jsonify }},
+                    'variation_code_snippet{{ forloop.index }}': `{{ variation.variation_code_snippet | xml_escape }}`,
                 {% endfor %}
             {% endfor %}
 

--- a/docs/_includes/search-scripts.html
+++ b/docs/_includes/search-scripts.html
@@ -5,25 +5,29 @@
     window.searchStore = {
         {% for page in site.pages %}
         '{{ page.url | slugify }}': {
+
+            // Cycle through the variation fields of this page.
+            {% for variation_group in page.variation_groups %}
+                // Determine the maximum number of variations present overall.
+                {% if variation_group.variations.size > variations_count %}
+                    {% assign variations_count = variation_group.variations | size  %}
+                {% endif %}
+
+                {% for variation in variation_group.variations %}
+                    'variation_name{{ forloop.index }}': '{{ variation.variation_name | xml_escape }}',
+                    'variation_description{{ forloop.index }}': {{ variation.variation_description | markdownify | strip_html | strip_newlines | jsonify }},
+                    'variation_code_snippet{{ forloop.index }}': {{ variation.variation_code_snippet | markdownify | strip_html | strip_newlines | jsonify }},
+                {% endfor %}
+            {% endfor %}
+
+
             'title': '{{ page.title | xml_escape }}',
             'description': {{ page.description | markdownify | strip_html | strip_newlines | jsonify }},
             'usage': {{ page.usage | markdownify | strip_html | strip_newlines | jsonify }},
-            'accessibility': {{ page.usage | markdownify | strip_html | strip_newlines | jsonify }},
-            'url': '{{ page.url | xml_escape }}',
-
-            // Determine the maximum number of variations present overall.
-            {% if page.variations.size > variations_count %}
-                {% assign variations_count = page.variations | size  %}
-            {% endif %}
-
-            // Cycle through the variation fields of this page.
-            {% for variation in page.variations %}
-                'variation_name{{ forloop.index }}': '{{ variation.variation_name | xml_escape }}',
-                'variation_description{{ forloop.index }}': {{ variation.variation_description | markdownify | strip_html | strip_newlines | jsonify }},
-                'variation_code_snippet{{ forloop.index }}': {{ variation.variation_code_snippet | markdownify | strip_html | strip_newlines | jsonify }}
-                {% unless forloop.last %},{% endunless %}
-            {% endfor %}
-
+            'accessibility': {{ page.accessibility | markdownify | strip_html | strip_newlines | jsonify }},
+            'research': {{ page.research | markdownify | strip_html | strip_newlines | jsonify }},
+            'related_items': {{ page.related_items | markdownify | strip_html | strip_newlines | jsonify }},
+            'url': '{{ page.url | xml_escape }}'
         }
         {% unless forloop.last %},{% endunless %}
         {% endfor %}
@@ -35,6 +39,8 @@
         'description',
         'usage',
         'accessibility',
+        'research',
+        'related_items',
         'url',
         // Populate the variation fields up to the possible maximum.
         {% for i in (1..variations_count) %}

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -7,7 +7,13 @@ const anchors = new AnchorJS();
 // Add anchors to all headings (except page title headings)
 anchors.add( 'h2:not(.title_heading), h3, h4, h5' );
 // Ensure there are no anchors in the live code examples
-anchors.remove( '.live-code-example h2, .live-code-example h3, .live-code-example h4, .live-code-example h5' );
+anchors.remove( `
+  .live-code-example h2,
+  .live-code-example h3,
+  .live-code-example h4,
+  .live-code-example h5,
+  #search-results h3
+` );
 
 Expandable.init();
 Table.init();

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -11,7 +11,6 @@ const searchResultsElm = document.getElementById( 'search-results' );
  * @param {Object} store - search index/meta data store in the window object.
  */
 function displaySearchResults( results, store ) {
-
   // Are there any results?
   if ( results.length ) {
     let appendString = '';
@@ -23,24 +22,19 @@ function displaySearchResults( results, store ) {
 
       // Show some preview text under each search results item.
       let previewText = '';
-      let itemFieldValue;
-      let field;
+      const searchMatchWordFragment = Object.keys( results[i].matchData.metadata )[0];
+      const searchMatchFields = results[i].matchData.metadata[ searchMatchWordFragment ];
 
-      // Search for the first preview field that is populated.
-      const searchFields = store.fields;
-      for ( const fieldId in searchFields ) {
-        field = searchFields[fieldId];
-        // Exclude certain fields from being considered for the result preview.
-        if ( field === 'title' || field === 'url' ) {
-          continue;
-        }
+      // Remove fields that should never appear as the preview.
+      delete searchMatchFields.id;
+      delete searchMatchFields.title;
 
-        itemFieldValue = item[field];
-        if ( typeof itemFieldValue !== 'undefined' && itemFieldValue !== '' ) {
-          previewText = itemFieldValue;
-          break;
-        }
-      }
+      previewText = item[ Object.keys( searchMatchFields )[0] ];
+
+      const regex = new RegExp( results.searchTerm, 'gi');
+      previewText = previewText.replace( regex, function replace( match ) {
+        return '<mark>' + match + '</mark>';
+      } );
 
       // Add the preview text.
       if ( previewText !== '' ) {
@@ -114,6 +108,7 @@ if ( searchTerm ) {
 
   // Perform a search on lunr index.
   const results = idx.search( searchTerm );
+  results.searchTerm = searchTerm;
 
   // Display the results of the search.
   displaySearchResults( results, searchStore );

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -23,15 +23,15 @@ function displaySearchResults( results, store ) {
       // Show some preview text under each search results item.
       let previewText = '';
       const searchMatchWordFragment = Object.keys( results[i].matchData.metadata )[0];
-      const searchMatchFields = results[i].matchData.metadata[ searchMatchWordFragment ];
+      const searchMatchFields = results[i].matchData.metadata[searchMatchWordFragment];
 
       // Remove fields that should never appear as the preview.
       delete searchMatchFields.id;
       delete searchMatchFields.title;
 
-      previewText = item[ Object.keys( searchMatchFields )[0] ];
+      previewText = item[Object.keys( searchMatchFields )[0]];
 
-      const regex = new RegExp( results.searchTerm, 'gi');
+      const regex = new RegExp( results.searchTerm, 'gi' );
       previewText = previewText.replace( regex, function replace( match ) {
         return '<mark>' + match + '</mark>';
       } );


### PR DESCRIPTION
## Changes

- Fix missing variations field search by including new variations_group parent.
- Add `research` and `related_items` fields to search.
- Highlight search term in results with `<mark>` element.

## Testing

1. Perform a search on PR preview.

## Screenshots

<img width="1044" alt="Screen Shot 2020-05-01 at 6 12 35 PM" src="https://user-images.githubusercontent.com/704760/80845655-e423c380-8bd7-11ea-96ab-ffa6ec016f09.png">
