### PR TITLE
Fix GH Actions script when no changes exist

### DIFF
--- a/scripts/update-gh-pages.sh
+++ b/scripts/update-gh-pages.sh
@@ -26,18 +26,18 @@ yarn --cwd docs/ run build
 # Remove the built Jekyll website from .gitignore
 sed -i '/_site/d' ./.gitignore
 
-# Configure git
-git config user.name "CFPBot"
-git config user.email "CFPBot@users.noreply.github.com"
-
-# Commit the built website
+# Check to see if there are any changes to commit.
 cd "$target_dir"
-git add .
-git commit -m "Update GitHub Pages"
-if [ "$?" != "0" ]; then
-	echo "nothing to commit"
+
+if [ -z "$(git status --porcelain)" ]; then
+	echo "no local changes to commit"
 	exit 0
 fi
+
+# Commit all changed files.
+git config user.name "CFPBot"
+git config user.email "CFPBot@users.noreply.github.com"
+git commit -am "Update GitHub Pages"
 
 # Push to remote gh-pages branch
 git remote set-url "$remote_name" "$repo_uri"


### PR DESCRIPTION
Currently we run the gh-pages GitHub Action even if there are no changes in the documentation website.

There's a line that tries to exit early if there are no changes to commit, but it doesn't work properly. Because we use `set -e` at the top of the script, when 'git commit' returns 1 (if there are no changes to commit), it causes the script to fail with an error.

For example, that happened on this Actions run:

https://github.com/chosak/design-system/runs/637557200

Note the message right before failure with "nothing to commit, working tree clean". This also returns a non-zero status code, which causes the script to fail.

This commit instead first checks to see if there are any changes to commit, and gracefully exits if not.

An example run where there was a graceful exit:

https://github.com/chosak/design-system/runs/643781788

Note the message "no local changes to commit".

And an example run with a change that was properly committed:

https://github.com/chosak/design-system/runs/643801916