### PR TITLE
Upgrade to Jekyll 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,5 +84,6 @@ docs/dist/
 docs/assets/icons/
 _site
 .sass-cache
+.jekyll-cache/
 .jekyll-metadata
 Gemfile.lock

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gem "nokogiri", "~> 1.10"
-gem "jekyll", "~> 3.8"
+gem "jekyll", "~> 4.0"
 gem "jekyll-last-modified-at", "~> 1.1.0"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,8 +4,7 @@ plugins:
 
 # Base configuration
 permalink: /:title
-exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md", "src", "node_modules"]
-markdown: kramdown
+exclude: [package.json, webpack.config.js, yarn.lock]
 highlighter: rouge
 
 # Organization

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -25,7 +25,7 @@
             {% for p in site.pages %}
                 {% if p.section == page.section and p.secondary_section == secondary_section %}
                 <li class="m-list_item">
-                    <a class="m-list_link" href="{{ site.baseurl }}/{{ p.section }}/{{ p.title | slugify }}">{{ p.title }}</a>
+                    <a class="m-list_link" href="{{ p.url | relative_url }}">{{ p.title }}</a>
                 </li>
                 {% endif %}
             {% endfor %}
@@ -38,7 +38,7 @@
     {% for p in site.pages %}
         {% if p.section == page.section %}
         <li class="m-list_item">
-            <a class="m-list_link" href="{{ site.baseurl }}/{{ p.section }}/{{ p.title | slugify }}">{{ p.title }}</a>
+            <a class="m-list_link" href="{{ p.url | relative_url }}">{{ p.title }}</a>
         </li>
         {% endif %}
     {% endfor %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -11,7 +11,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="{{ site.baseurl }}/dist/css/main.css">
+  <link rel="stylesheet" href="{{ "/dist/css/main.css" | relative_url }}">
   <script>
       // Confirm availability of JS and remove no-js class from html
       var docElement = document.documentElement;
@@ -32,6 +32,6 @@
     {{ content }}
     {% include footer.html %}
   </div>
-  <script src="{{ site.baseurl }}/dist/js/main.js" charset="utf-8"></script>
+  <script src="{{ "/dist/js/main.js" | relative_url }}" charset="utf-8"></script>
 </body>
 </html>

--- a/docs/_layouts/homepage.html
+++ b/docs/_layouts/homepage.html
@@ -6,7 +6,9 @@ layout: default
         {% include generic-content.html %}
     </div>
     <div class="o-editor_link" id="edit-page">
-        <a class="a-btn" href="{{ "/admin/#/collections/generic-pages/entries/home" | relative_url }} title="Edit this page in Netlify CMS">
+        <a class="a-btn" href="
+            {{- '/admin/#/collections/generic-pages/entries/home' | relative_url
+            -}}" title="Edit this page in Netlify CMS">
             <span class="a-btn_text">Edit this page</span>
             <span class="a-btn_icon">{% include icons/edit.svg %}</span>
         </a>

--- a/docs/_layouts/homepage.html
+++ b/docs/_layouts/homepage.html
@@ -6,7 +6,7 @@ layout: default
         {% include generic-content.html %}
     </div>
     <div class="o-editor_link" id="edit-page">
-        <a class="a-btn" href="{{ site.baseurl }}/admin/#/collections/generic-pages/entries/home" title="Edit this page in Netlify CMS">
+        <a class="a-btn" href="{{ "/admin/#/collections/generic-pages/entries/home" | relative_url }} title="Edit this page in Netlify CMS">
             <span class="a-btn_text">Edit this page</span>
             <span class="a-btn_icon">{% include icons/edit.svg %}</span>
         </a>

--- a/docs/_layouts/variation.html
+++ b/docs/_layouts/variation.html
@@ -32,13 +32,15 @@ layout: default
     </aside>
         {% include variation-content.html %}
         <div class="o-editor_link" id="edit-page">
-            <a class="a-btn" href="{{ site.baseurl }}/admin/#/collections/{{ page.section }}/entries/{{ page.path | split: '/' | last | replace: '.md', '' }}" title="Edit this page in Netlify CMS">
+            <a class="a-btn" href="{{ "/admin/#/collections/" | append: page.section | append: "/entries/" | append: page.path | split: '/' | last | replace: '.md' | relative_url }}" title="Edit this page in Netlify CMS">
                 <span class="a-btn_text">Edit this page</span>
                 <span class="a-btn_icon">{% include icons/edit.svg %}</span>
             </a>
         </div>
         <div class="o-editor_link" id="add-page">
-            <a class="a-btn" href="{{ site.baseurl }}/admin/#/collections/{{ page.section }}/new" title="Add a new Design System page in Netlify CMS">
+            <a class="a-btn"
+                href="{{ "/admin/#/collections/" | append: page.section | append: "/new" | relative_url }}"
+                title="Add a new Design System page in Netlify CMS">
                 <span class="a-btn_text">Add new page</span>
                 <span class="a-btn_icon">{% include icons/plus.svg %}</span>
             </a>

--- a/docs/_layouts/variation.html
+++ b/docs/_layouts/variation.html
@@ -32,7 +32,10 @@ layout: default
     </aside>
         {% include variation-content.html %}
         <div class="o-editor_link" id="edit-page">
-            <a class="a-btn" href="{{ "/admin/#/collections/" | append: page.section | append: "/entries/" | append: page.path | split: '/' | last | replace: '.md' | relative_url }}" title="Edit this page in Netlify CMS">
+            <a class="a-btn" href="
+                {{-"/admin/#/collections/" | append: page.section | append: '/entries/' | relative_url }}
+                {{- page.path | split: '/' | last | replace: '.md' -}}
+            " title="Edit this page in Netlify CMS">
                 <span class="a-btn_text">Edit this page</span>
                 <span class="a-btn_icon">{% include icons/edit.svg %}</span>
             </a>

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://cfpb.github.io/design-system/",
   "license": "MIT",
   "scripts": {
-    "start": "concurrently --kill-others \"yarn start-netlify\" \"bundle exec jekyll serve --watch --host=localhost\" \"yarn run watch\" \"yarn run watch-css\"",
+    "start": "concurrently --kill-others \"yarn start-netlify\" \"bundle exec jekyll serve --watch --profile --host=localhost\" \"yarn run watch\" \"yarn run watch-css\"",
     "start-netlify": "cd ../ && netlify-cms-proxy-server",
     "compile-js": "NODE_ENV=production webpack",
     "compile-css": "lessc --include-path=../packages/:../node_modules/normalize-css/normalize-css/ assets/css/main.less dist/css/main.css",


### PR DESCRIPTION
This commit updates Jekyll to version 4. Closes #465.

See these pages for documentation on the upgrade:

https://jekyllrb.com/news/2019/08/20/jekyll-4-0-0-released/
https://jekyllrb.com/docs/upgrading/3-to-4/

Minor changes include:

- Tried to use the built-in `relative_url` filter instead of having numerous references to site.baseurl.
- Added --profile to `yarn watch` to make it easier to keep track of build times.

To test, run `bundle update`, then `yarn`, and `yarn start`.

You might seem some errors like "Empty `slug` generated for ''" -- these are because we have some empty variation names and, as of Jekyll 4, the use of `| slugify` on these generates a warning. These should be fixed but that is independent of this upgrade -- note for example the empty variation names on https://cfpb.github.io/design-system/foundation/typography.