### PR TITLE
Search refinements

### DIFF
--- a/docs/_includes/search-scripts.html
+++ b/docs/_includes/search-scripts.html
@@ -4,6 +4,10 @@
     // jekyll's liquid variables, such as site.pages.
     window.searchStore = {
         {% for page in site.pages %}
+
+        {% comment %} Exclude search page itself from results. {% endcomment %}
+        {% if page.url == 'search/index' %} {% continue %} {% endif %}
+
         '{{ page.url | slugify }}': {
 
             // Cycle through the variation fields of this page.

--- a/docs/assets/css/search.less
+++ b/docs/assets/css/search.less
@@ -1,8 +1,11 @@
 #search-form {
-    float: right;
+    margin: 15px;
+    margin-left: 15px;
+    .respond-to-min( @bp-xs-max, {
+        float: right;
+    } );
 }
 
-#search-form,
 #search-results {
     margin: 15px;
     margin-left: 0;

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -63,7 +63,7 @@ function displaySearchResults( elm, results, store ) {
  * @param {string} term - the search term
  */
 function displayNoSearchResults( elm, term ) {
-  elm.innerHTML = `<li>No results found for '${ term }'.</li>`;
+  elm.innerHTML = `<li>No search results found for '${ term }'.</li>`;
 }
 
 /**

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -1,23 +1,11 @@
 const lunr = require( 'lunr' );
 
-// This is set outside of displaySearchResults in case we dynamically call
-// displaySearchResults in the future, although right now it's only called
-// once per page load.
-const searchResultsElm = document.getElementById( 'search-results' );
-
 /**
  * Update page markup with search results.
  * @param {Array} results - A list of search result hits as objects.
  * @param {Object} store - search index/meta data store in the window object.
- * @returns {boolean} True if there are search results, false otherwise.
  */
-function displaySearchResults( results, store ) {
-  // Are there any results?
-  if ( results.length === 0 ) {
-    displayNoSearchResults( searchResultsElm, results.searchTerm );
-    return false;
-  }
-
+function displaySearchResults( elm, results, store ) {
   // Search results content will be placed in here.
   let resultsString = `
     <p>
@@ -66,9 +54,16 @@ function displaySearchResults( results, store ) {
     }
   }
 
-  searchResultsElm.innerHTML = resultsString;
+  elm.innerHTML = resultsString;
+}
 
-  return true;
+/**
+ * Display no search results in markup.
+ * @param {HTMLNode} elm - the HTML element to write to.
+ * @param {string} term - the search term
+ */
+function displayNoSearchResults( elm, term ) {
+  elm.innerHTML = `<li>No results found for '${ term }'.</li>`;
 }
 
 /**
@@ -118,17 +113,12 @@ function initializeSearchIndex( store ) {
   } );
 }
 
-/**
- * Display no search results in markup.
- * @param {HTMLNode} elm - the HTML element to write to.
- * @param {string} term - the search term
- */
-function displayNoSearchResults( elm, term ) {
-  elm.innerHTML = `<li>No results found for '${ term }'.</li>`;
-}
+// Create search-related references.
+const searchTerm = getURLParam( 'searchQuery' );
+const searchResultsElm = document.getElementById( 'search-results' );
+let results = [];
 
 // Check if the URL has a search term set.
-const searchTerm = getURLParam( 'searchQuery' );
 if ( searchTerm ) {
   document.getElementById( 'search-box' ).setAttribute( 'value', searchTerm );
 
@@ -139,11 +129,14 @@ if ( searchTerm ) {
   const idx = initializeSearchIndex( searchStore );
 
   // Perform a search on lunr index.
-  const results = idx.search( searchTerm );
+  results = idx.search( searchTerm );
   results.searchTerm = searchTerm;
+}
 
-  // Display the results of the search.
-  displaySearchResults( results, searchStore );
-} else {
+// Are there any results?
+if ( results.length === 0 ) {
   displayNoSearchResults( searchResultsElm, searchTerm );
+} else {
+  // Display the results of the search.
+  displaySearchResults( searchResultsElm, results, searchStore );
 }

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -29,7 +29,14 @@ function displaySearchResults( results, store ) {
   // Iterate over the results.
   for ( let i = 0; i < results.length; i++ ) {
     const item = store[results[i].ref];
-    resultsString += '<li><a href="../' + item.url + '"><h3>' + item.title + '</h3></a>';
+    resultsString += `
+      <li>
+        <a href="../${ item.url }">
+          <h3>
+            ${ item.title }
+          </h3>
+        </a>
+    `;
 
     // Show some preview text under each search results item.
     let previewText = '';
@@ -52,7 +59,10 @@ function displaySearchResults( results, store ) {
 
     // Add the preview text.
     if ( previewText !== '' ) {
-      resultsString += '<p>' + previewText.substring( 0, 150 ) + '…</p></li>';
+      resultsString += `
+          <p>${ previewText.substring( 0, 150 ) }…</p>
+        </li>
+      `;
     }
   }
 


### PR DESCRIPTION
## Changes

- Exclude search page itself from search results.
- Omit preview text if there aren't any fields to pull from (e.g. search for "homepage").
- Provide a result count and term at the top of search results.
- Provide search term in no results display.
- Don't float the search input box on mobile.

## Testing

1. Check preview and search for "homepage", "search", "block__flush", etc. and resize to mobile.

## Screenshots
<img width="461" alt="Screen Shot 2020-05-04 at 5 49 20 PM" src="https://user-images.githubusercontent.com/704760/81017592-cc934780-8e30-11ea-84df-69ee0d2659d0.png">
