### PR TITLE
Convert restrictions do/do not to use icon

### DIFF
--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -174,8 +174,9 @@
                         {% if restriction.restrictions_do and restriction.restrictions_do != '' %}
                             <div class="content-l_col content-l_col-1-2">
                                 <div>
-                                    <header class="m-slug-header">
-                                        <h4 class="a-heading">
+                                    <header class="component-restrictions_heading-do">
+                                        <h4>
+                                            {% include icons/check-round.svg %}
                                             Do
                                         </h4>
                                     </header>
@@ -188,8 +189,9 @@
                         {% if restriction.restrictions_do_not and restriction.restrictions_do_not != '' %}
                             <div class="content-l_col content-l_col-1-2">
                                 <div>
-                                    <header class="m-slug-header m-slug-header__warning">
-                                        <h4 class="a-heading">
+                                    <header class="component-restrictions_heading-donot">
+                                        <h4>
+                                            {% include icons/close-round.svg %}
                                             Do not
                                         </h4>
                                     </header>

--- a/docs/assets/css/variation.less
+++ b/docs/assets/css/variation.less
@@ -53,3 +53,12 @@
         background-color: @white;
     }
 }
+
+//
+.component-restrictions_heading-do svg {
+    color: @green;
+}
+
+.component-restrictions_heading-donot svg {
+    color: @red;
+}

--- a/docs/assets/css/variation.less
+++ b/docs/assets/css/variation.less
@@ -54,7 +54,7 @@
     }
 }
 
-//
+// The icon colors on the restrictions do/do not sections.
 .component-restrictions_heading-do svg {
     color: @green;
 }


### PR DESCRIPTION
## Changes

- Convert restrictions do/do not section to use an icon instead of a bar.

## Testing

1. Check buttons page on the PR preview, or any other page that has a restrictions section.

## Screenshots

Before:
<img width="888" alt="Screen Shot 2020-05-11 at 12 32 26 PM" src="https://user-images.githubusercontent.com/704760/81586509-9cddc580-9383-11ea-8f80-5d01bbfcc939.png">

After:
<img width="672" alt="Screen Shot 2020-05-11 at 12 32 17 PM" src="https://user-images.githubusercontent.com/704760/81586508-9c452f00-9383-11ea-9c43-a6806970dd52.png">


## Notes

- The restrictions section should just be deleted, really
