### PR TITLE
cfpb-layout: Support hr in content_line

### DIFF
--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -159,12 +159,12 @@
     {% if page.restrictions != empty and page.restrictions or page.usage and page.usage != '' %}
         <section class="sticky-header u-mb45">
             <h2 id="usage">Usage</h2>
-            <div class="content_line__wide content_line content_line u-mb20"></div>
-                {% if page.usage and page.usage != '' %}
-                    <p>
-                    {{ page.usage | markdownify }}
-                    </p>
-                {% endif %}
+            <hr class="content_line content_line__wide u-mb20">
+            {% if page.usage and page.usage != '' %}
+                <p>
+                {{ page.usage | markdownify }}
+                </p>
+            {% endif %}
             {% if page.restrictions and page.restrictions != empty %}
                 <div class="content-l component-restrictions">
                     <div class="content-l_col content-l_col-1">
@@ -208,7 +208,7 @@
     {% if page.accessibility and page.accessibility != '' %}
         <section class="sticky-header u-mb45">
             <h2 id="accessibility">Accessibility</h2>
-            <div class="content_line__wide content_line content_line u-mb20"></div>
+            <hr class="content_line  content_line__wide u-mb20">
             <p>
                 {{ page.accessibility | markdownify }}
             </p>
@@ -218,7 +218,7 @@
     {% if page.research and page.research != '' %}
         <section class="sticky-header u-mb45">
             <h2 id="research">Research</h2>
-            <div class="content_line__wide content_line content_line u-mb20"></div>
+            <hr class="content_line content_line__wide u-mb20">
             <p>
                 {{ page.research | markdownify }}
             </p>
@@ -231,7 +231,7 @@
             <div>
                 <section>
                     <h2 id="related-items">Related Items</h2>
-                    <div class="content_line__wide content_line content_line u-mb20"></div>
+                    <hr class="content_line content_line__wide u-mb20">
                     {{ page.related_items | markdownify }}
                 </section>
             </div>

--- a/docs/components/column-dividers.md
+++ b/docs/components/column-dividers.md
@@ -19,7 +19,7 @@ description: >+
 
 variation_groups:
   - variations:
-      - variation_code_snippet: <div class="content_line"></div>
+      - variation_code_snippet: <hr class="content_line">
         variation_description: A 1 pixel edge to edge bar that can divide content.
         variation_name: Content line
       - variation_code_snippet: |-
@@ -105,4 +105,3 @@ accessibility: ''
 research: ''
 last_updated: 2019-09-13T19:34:43.025Z
 ---
-

--- a/docs/components/left-hand-navigation.md
+++ b/docs/components/left-hand-navigation.md
@@ -13,7 +13,7 @@ variation_groups:
   - variations:
       - variation_code_snippet: |-
           <main class="content content__1-3" role="main">
-              <div class="content_line"></div>
+              <hr class="content_line">
               <div class="content_wrapper">
                   <aside class="content_sidebar">
                       Section navigation

--- a/docs/components/sidebars-prefooters.md
+++ b/docs/components/sidebars-prefooters.md
@@ -54,7 +54,7 @@ variation_groups:
         variation_name: Main content and sidebar
       - variation_code_snippet: |-
           <main class="content content__2-1" role="main">
-              <div class="content_line"></div>
+              <hr class="content_line">
               <div class="content_wrapper">
                   <section class="content_main">
                       <h2>Main content area</h2>
@@ -95,7 +95,7 @@ variation_groups:
               <section class="content_hero" style="background: #E3E4E5">
                   Content hero
               </section>
-              <div class="content_line"></div>
+              <hr class="content_line">
               <div class="content_wrapper">
                   <section class="content_main">
                       Main content area
@@ -115,7 +115,7 @@ variation_groups:
         variation_name: Bleedbar sidebar styling
       - variation_code_snippet: |-
           <main class="content content__2-1" role="main">
-              <div class="content_line"></div>
+              <hr class="content_line">
               <div class="content_wrapper">
                   <section class="content_main content_main__narrow">
                       <h2>Main content area</h2>

--- a/packages/cfpb-layout/src/cfpb-layout.less
+++ b/packages/cfpb-layout/src/cfpb-layout.less
@@ -228,6 +228,8 @@
 .content_line {
     height: 1px;
     background: @content_line;
+    border: none;
+    margin: 0;
 }
 
 //

--- a/packages/cfpb-layout/usage.md
+++ b/packages/cfpb-layout/usage.md
@@ -113,10 +113,10 @@ Color variables referenced in comments are from [@cfpb/cfpb-core's brand-colors.
 
 A 1 pixel edge to edge bar that can divide content.
 
-<div class="content_line"></div>
+<hr class="content_line">
 
 ```
-<div class="content_line"></div>
+<hr class="content_line">
 ```
 
 
@@ -174,7 +174,7 @@ left, sidebar on the right, in a ratio of 2:1).
 It is assumed that the content is wider than the sidebar.
 
 <main class="content content__1-3" role="main">
-    <div class="content_line"></div>
+    <hr class="content_line">
     <div class="content_wrapper">
         <aside class="content_sidebar">
             Section navigation
@@ -198,7 +198,7 @@ It is assumed that the content is wider than the sidebar.
 
 ```
 <main class="content content__1-3" role="main">
-    <div class="content_line"></div>
+    <hr class="content_line">
     <div class="content_wrapper">
         <aside class="content_sidebar">
             Section navigation
@@ -236,7 +236,7 @@ _Inline styling is for demonstration purposes only; do not include it in your
 markup._
 
 <main class="content content__2-1" role="main">
-    <div class="content_line"></div>
+    <hr class="content_line">
     <div class="content_wrapper">
         <section class="content_main">
             <h2>Main content area</h2>
@@ -260,7 +260,7 @@ markup._
 
 ```
 <main class="content content__2-1" role="main">
-    <div class="content_line"></div>
+    <hr class="content_line">
     <div class="content_wrapper">
         <section class="content_main">
             <h2>Main content area</h2>
@@ -296,7 +296,7 @@ it in your markup._
     <section class="content_hero" style="background: #E3E4E5">
         Content hero
     </section>
-    <div class="content_line"></div>
+    <hr class="content_line">
     <div class="content_wrapper">
         <section class="content_main">
             Main content area
@@ -312,7 +312,7 @@ it in your markup._
     <section class="content_hero" style="background: #E3E4E5">
         Content hero
     </section>
-    <div class="content_line"></div>
+    <hr class="content_line">
     <div class="content_wrapper">
         <section class="content_main">
             Main content area
@@ -334,7 +334,7 @@ _Inline styling is for demonstration purposes only; do not include it in your
 markup._
 
 <main class="content content__2-1" role="main">
-    <div class="content_line"></div>
+    <hr class="content_line">
     <div class="content_wrapper">
         <section class="content_main content_main__narrow">
             <h2>Main content area</h2>


### PR DESCRIPTION
The content line usually appears as `<div class="content_line"></div>`, yet semantically this sure seems like it should be a horizontal rule (`<hr>`) element? When you make it a horizontal rule it is too thick as the border needs to be removed.

## Removals

- Removes redundant `content_line` class from design system buttons docs page.

## Changes

- Converts `content_line` to `hr`.
- Adds no border and margin to support `content_line` on an `hr` element.

## Testing

1. Check buttons and layout page in this PR preview and inspect the source to see where the `content_line` is. It should be the same as the appearance on production.
