### PR TITLE
Set sitewide timezone via Jekyll config

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,6 +6,7 @@ plugins:
 permalink: /:title
 exclude: [package.json, webpack.config.js, yarn.lock]
 highlighter: rouge
+timezone: America/New_York
 
 # Organization
 org: CFPB


### PR DESCRIPTION
Override server settings to ensure our "page last edited" timestamps show DC time.

## Changes

- Jekyll timezone no longer defaults to the local machine's timezone.

## Testing

1. The PR preview for the homepage should show [1:51 PM](https://deploy-preview-490--cfpb-design-system.netlify.app/design-system/) in the footer and not [5:51 PM](https://cfpb.github.io/design-system/).