### PR TITLE
Inject SVG icons before rendering preview in Netlify CMS

### DIFF
--- a/docs/admin/src/widgets/variationPreviewTemplate.js
+++ b/docs/admin/src/widgets/variationPreviewTemplate.js
@@ -5,6 +5,10 @@ import { Tabs } from 'govuk-frontend';
 import marked from 'marked';
 import template from '../../../_includes/variation-content.html';
 
+// react-liquid (https://github.com/aquibm/react-liquid/) isn't able to `include` other files so we
+// strip out any instances of {% include icons/XXXXX.svg %}
+const cleanTemplate = template.replace( /{%\s+include\s+\/?icons\/([\w-]+)\.svg\s+%}/g, '' );
+
 export default class Preview extends Component {
 
   componentDidMount() {
@@ -30,7 +34,7 @@ export default class Preview extends Component {
     };
     return (
       <div>
-        <ReactLiquid template={template} data={data} html />
+        <ReactLiquid template={cleanTemplate} data={data} html />
       </div>
     );
   }

--- a/docs/admin/src/widgets/variationPreviewTemplate.js
+++ b/docs/admin/src/widgets/variationPreviewTemplate.js
@@ -6,8 +6,11 @@ import marked from 'marked';
 import template from '../../../_includes/variation-content.html';
 
 // react-liquid (https://github.com/aquibm/react-liquid/) isn't able to `include` other files so we
-// strip out any instances of {% include icons/XXXXX.svg %}
-const cleanTemplate = template.replace( /{%\s+include\s+\/?icons\/([\w-]+)\.svg\s+%}/g, '' );
+// replace instances of {% include icons/XXXXX.svg %} with the inlined SVG
+const templateWithIcons = template.replace(
+  /{%\s+include\s+\/?icons\/([\w-]+)\.svg\s+%}/g,
+  ( match, icon ) => require( `../../../_includes/icons/${ icon }.svg` )
+);
 
 export default class Preview extends Component {
 
@@ -34,7 +37,7 @@ export default class Preview extends Component {
     };
     return (
       <div>
-        <ReactLiquid template={cleanTemplate} data={data} html />
+        <ReactLiquid template={templateWithIcons} data={data} html />
       </div>
     );
   }

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,6 +28,7 @@
     "html-loader": "1.1.0",
     "less-watch-compiler": "^1.14.1",
     "netlify-cms-proxy-server": "^1.2.6",
+    "svg-inline-loader": "0.8.2",
     "webpack": "4.43.0",
     "webpack-cli": "3.3.11"
   },

--- a/docs/webpack.config.js
+++ b/docs/webpack.config.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require( 'path' );
 
 module.exports = {
   mode: process.env.NODE_ENV || 'development',
@@ -8,7 +8,7 @@ module.exports = {
     'search': './assets/js/search.js'
   },
   output: {
-    path: path.resolve(__dirname, 'dist', 'js'),
+    path: path.resolve( __dirname, 'dist', 'js' ),
     filename: '[name].js'
   },
   devtool: 'source-map',
@@ -27,7 +27,11 @@ module.exports = {
         use: {
           loader: 'html-loader'
         }
+      },
+      {
+        test: /\.svg$/,
+        loader: 'svg-inline-loader'
       }
     ]
   }
-}
+};

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -4926,7 +4926,7 @@ object-assign@^3.0.0:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
   integrity sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=
 
-object-assign@^4, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -6351,6 +6351,11 @@ simple-git@^1.129.0:
   dependencies:
     debug "^4.0.1"
 
+simple-html-tokenizer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz#05c2eec579ffffe145a030ac26cfea61b980fabe"
+  integrity sha1-BcLuxXn//+FFoDCsJs/qYbmA+r4=
+
 slate-base64-serializer@^0.2.107, slate-base64-serializer@^0.2.112:
   version "0.2.115"
   resolved "https://registry.yarnpkg.com/slate-base64-serializer/-/slate-base64-serializer-0.2.115.tgz#438e051959bde013b50507f3144257e74039ff7f"
@@ -6739,6 +6744,15 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+svg-inline-loader@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/svg-inline-loader/-/svg-inline-loader-0.8.2.tgz#9872414f9e4141601e04eb80cda748c9a50dae71"
+  integrity sha512-kbrcEh5n5JkypaSC152eGfGcnT4lkR0eSfvefaUJkLqgGjRQJyKDvvEE/CCv5aTSdfXuc+N98w16iAojhShI3g==
+  dependencies:
+    loader-utils "^1.1.0"
+    object-assign "^4.0.1"
+    simple-html-tokenizer "^0.1.1"
 
 symbol-observable@^1.0.2, symbol-observable@^1.2.0:
   version "1.2.0"

--- a/test/browser/docs/code-snippets.js
+++ b/test/browser/docs/code-snippets.js
@@ -7,7 +7,7 @@ describe( 'The code snippet toggling feature', () => {
   let arecodeSnippetTabsVisible;
 
   before( () => {
-    browser.url( 'http://localhost:4000/design-system/components/buttons' );
+    browser.url( '/design-system/components/buttons' );
     browser.setWindowSize( 1024, 768 );
     codeShowButton = $( '.a-toggle_code [data-toggle-code="show"]' );
     codeHideButton = $( '.a-toggle_code [data-toggle-code="hide"]' );

--- a/test/browser/docs/netlify-cms.js
+++ b/test/browser/docs/netlify-cms.js
@@ -1,3 +1,4 @@
+/* eslint-disable handle-callback-err */
 /* eslint-disable no-undef */
 
 describe( 'Netlify CMS', () => {
@@ -5,43 +6,79 @@ describe( 'Netlify CMS', () => {
   let loginButton;
 
   beforeEach( () => {
-    browser.url( 'http://localhost:4000/design-system/admin/#/collections/generic-pages/entries/home' );
-    loginButton = browser.react$( 'LoginButton' );
+    browser.reloadSession();
   } );
 
-  afterEach( () => {
-    browser.execute( () => {
-      localStorage.clear();
-      sessionStorage.clear();
+  describe( 'Editing the homepage', () => {
+
+    beforeEach( () => {
+      browser.url( 'http://localhost:4000/design-system/admin/#/collections/generic-pages/entries/home' );
+      loginButton = browser.react$( 'LoginButton' );
     } );
-    browser.refresh();
+
+    it( 'should load the login page with a login button', () => {
+      loginButton.waitForDisplayed();
+      expect( loginButton ).toExist();
+    } );
+
+    it( 'should allow the user to log in', () => {
+      loginButton.waitForDisplayed();
+      loginButton.click();
+      const editorContainer = browser.react$( 'EditorContainer' );
+      editorContainer.waitForDisplayed();
+      expect( editorContainer ).toExist();
+    } );
+
+    it( 'should properly render a preview of a page', () => {
+      loginButton.waitForDisplayed();
+      loginButton.click();
+      // The homepage's body field
+      const pageBodyField = $( '#nc-root #body-field-1' );
+      pageBodyField.waitForDisplayed();
+      pageBodyField.clearValue();
+      pageBodyField.setValue( 'browser tests are fun' );
+      // The preview pane is an iframe
+      browser.switchToFrame( $( 'iframe' ) );
+      const previewPane = $( 'body' );
+      expect( previewPane ).toHaveTextContaining( 'browser tests are fun' );
+    } );
+
   } );
 
-  it( 'should load the login page with a login button', () => {
-    loginButton.waitForDisplayed();
-    expect( loginButton ).toExist();
-  } );
+  describe( 'Editing a component page', () => {
 
-  it( 'should allow the user to log in', () => {
-    loginButton.waitForDisplayed();
-    loginButton.click();
-    const editorContainer = browser.react$( 'EditorContainer' );
-    editorContainer.waitForDisplayed();
-    expect( editorContainer ).toExist();
-  } );
+    beforeEach( () => {
+      browser.url( 'http://localhost:4000/design-system/admin/#/collections/components/entries/buttons' );
+      loginButton = browser.react$( 'LoginButton' );
+    } );
 
-  it( 'should properly render a preview of a page', () => {
-    loginButton.waitForDisplayed();
-    loginButton.click();
-    // The homepage's body field
-    const pageTitleField = $( '#nc-root #body-field-1' );
-    pageTitleField.waitForDisplayed();
-    pageTitleField.clearValue();
-    pageTitleField.setValue( 'browser tests are fun' );
-    // The preview pane is an iframe
-    browser.switchToFrame( $( 'iframe' ) );
-    const previewPane = $( 'body' );
-    expect( previewPane ).toHaveTextContaining( 'browser tests are fun' );
+    it( 'should load the login page with a login button', () => {
+      loginButton.waitForDisplayed();
+      expect( loginButton ).toExist();
+    } );
+
+    it( 'should allow the user to log in', () => {
+      loginButton.waitForDisplayed();
+      loginButton.click();
+      const editorContainer = browser.react$( 'EditorContainer' );
+      editorContainer.waitForDisplayed();
+      expect( editorContainer ).toExist();
+    } );
+
+    it( 'should properly render a preview of a page', () => {
+      loginButton.waitForDisplayed();
+      loginButton.click();
+      // The button page's title field
+      const pageTitleField = $( '#nc-root #title-field-1' );
+      pageTitleField.waitForDisplayed();
+      pageTitleField.clearValue();
+      pageTitleField.setValue( 'component pages are the best' );
+      // The preview pane is an iframe
+      browser.switchToFrame( $( 'iframe' ) );
+      const previewPane = $( 'body' );
+      expect( previewPane ).toHaveTextContaining( 'component pages are the best' );
+    } );
+
   } );
 
 } );

--- a/test/browser/docs/netlify-cms.js
+++ b/test/browser/docs/netlify-cms.js
@@ -52,20 +52,7 @@ describe( 'Netlify CMS', () => {
       loginButton = browser.react$( 'LoginButton' );
     } );
 
-    it( 'should load the login page with a login button', () => {
-      loginButton.waitForDisplayed();
-      expect( loginButton ).toExist();
-    } );
-
-    it( 'should allow the user to log in', () => {
-      loginButton.waitForDisplayed();
-      loginButton.click();
-      const editorContainer = browser.react$( 'EditorContainer' );
-      editorContainer.waitForDisplayed();
-      expect( editorContainer ).toExist();
-    } );
-
-    it( 'should properly render a preview of a page', () => {
+    it( 'should properly render a preview of a component page', () => {
       loginButton.waitForDisplayed();
       loginButton.click();
       // The button page's title field

--- a/test/browser/docs/netlify-cms.js
+++ b/test/browser/docs/netlify-cms.js
@@ -12,7 +12,7 @@ describe( 'Netlify CMS', () => {
   describe( 'Editing the homepage', () => {
 
     beforeEach( () => {
-      browser.url( 'http://localhost:4000/design-system/admin/#/collections/generic-pages/entries/home' );
+      browser.url( '/design-system/admin/#/collections/generic-pages/entries/home' );
       loginButton = browser.react$( 'LoginButton' );
     } );
 
@@ -48,7 +48,7 @@ describe( 'Netlify CMS', () => {
   describe( 'Editing a component page', () => {
 
     beforeEach( () => {
-      browser.url( 'http://localhost:4000/design-system/admin/#/collections/components/entries/buttons' );
+      browser.url( '/design-system/admin/#/collections/components/entries/buttons' );
       loginButton = browser.react$( 'LoginButton' );
     } );
 

--- a/test/browser/packages/cfpb-expandables.js
+++ b/test/browser/packages/cfpb-expandables.js
@@ -7,7 +7,7 @@ describe( 'Basic CFPB expandable', () => {
   let isExpandableContentVisible;
 
   before( () => {
-    browser.url( 'http://localhost:4000/design-system/components/expandables' );
+    browser.url( '/design-system/components/expandables' );
     browser.setWindowSize( 1024, 768 );
     // Selects the first expandable live code sample, "Basic expandable"
     expandableHeader = $( '.a-live_code button.o-expandable_header' );


### PR DESCRIPTION
A little hacky but it works and I'm unsure of a better way. I added a browser test to catch future regressions.

## Changes

- The variation template strips out any icon include statements before rendering.

## Testing

1. Cloud browser tests should pass below.
1. `yarn test:browser` should pass locally.
1. Editing the buttons pages on the [PR preview](https://deploy-preview-493--cfpb-design-system.netlify.app/design-system/admin/#/collections/components/entries/buttons) should correctly show the preview pane while on [production](https://cfpb.github.io/design-system/admin/#/collections/components/entries/buttons) it throws an error and is blank.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
