### PR TITLE
Fix restrictions layout

### DIFF
--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -184,14 +184,16 @@
             {% endif %}
 
             {% if page.restrictions and page.restrictions != empty %}
+                <h2 id="restrictions">Restrictions</h2>
+                <div class="content_line content_line__wide u-mb20"></div>
                 <div class="content-l component-restrictions">
-                    <div class="content-l_col content-l_col-1">
-                        <h3>Restrictions</h3>
-                    </div>
                     {% for restriction in page.restrictions %}
                         {% if restriction.restrictions_do and restriction.restrictions_do != '' %}
                             <div class="content-l_col content-l_col-1-2">
-                                <div>
+                                <div class="block
+                                            block__flush-top
+                                            block__flush-bottom
+                                            block__padded-bottom">
                                     <header class="component-restrictions_heading-do">
                                         <h4>
                                             {% include icons/check-round.svg %}
@@ -206,7 +208,10 @@
                         {% endif %}
                         {% if restriction.restrictions_do_not and restriction.restrictions_do_not != '' %}
                             <div class="content-l_col content-l_col-1-2">
-                                <div>
+                                <div class="block
+                                            block__flush-top
+                                            block__flush-bottom
+                                            block__padded-bottom">
                                     <header class="component-restrictions_heading-donot">
                                         <h4>
                                             {% include icons/close-round.svg %}


### PR DESCRIPTION
## Changes

- Adjust heading size and padding on restrictions to address layout issues.

## Testing

1. Check PR preview page with restrictions, such as the buttons page.

## Screenshots

<img width="846" alt="Screen Shot 2020-05-14 at 8 36 35 AM" src="https://user-images.githubusercontent.com/704760/81935167-30023f80-95be-11ea-8f9b-e3e7b7686308.png">

<img width="950" alt="Screen Shot 2020-05-14 at 8 36 09 AM" src="https://user-images.githubusercontent.com/704760/81935171-32fd3000-95be-11ea-9f69-ef7dc6d06fff.png">
