### PR TITLE
Check for empty variation fields

### DIFF
--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -40,13 +40,17 @@
         {% for variation in variation_group.variations %}
         <div class="m-variation">
 
+            {% if variation.variation_name %}
             <div class="m-variation_name">
                 <h3>{{ variation.variation_name }}</h3>
             </div>
+            {% endif %}
 
+            {% if variation.variation_description %}
             <div class="m-variation_description">
                 {{ variation.variation_description | markdownify }}
             </div>
+            {% endif %}
 
             <!-- Live code example -->
             {% if variation.variation_code_snippet %}


### PR DESCRIPTION
## Changes

- Check for empty variation fields (which are optional)

## Testing

1. Edit a page in the preview PR and see that if you have an empty variation name or variation description those empty sections don't show up in the markup.
