### PR TITLE
Fix "show details" functionality in CMS

### DIFF
--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -62,8 +62,8 @@
             {% if code_snippet or jinja_snippet or implementation or specs %}
 
             <div class="a-toggle_code">
-                <button href="#{{ variation.variation_name | slugify }}-code-{{ forloop.index }}" class="a-btn a-btn__link" data-toggle-code="show">Show details</button>
-                <button href="#{{ variation.variation_name | slugify }}-code-{{ forloop.index }}" class="a-btn a-btn__link u-hidden" data-toggle-code="hide">Hide details</button>
+                <button href="#{{ variation.variation_name | slugify }}-code-{{ forloop.index }}" class="a-btn a-btn__link" data-toggle-details="show">Show details</button>
+                <button href="#{{ variation.variation_name | slugify }}-code-{{ forloop.index }}" class="a-btn a-btn__link u-hidden" data-toggle-details="hide">Hide details</button>
             </div>
 
             <div class="govuk-tabs u-hidden" data-module="tabs" id="{{ variation.variation_name | slugify }}-code-{{ forloop.index }}">

--- a/docs/admin/src/widgets/variationPreviewTemplate.js
+++ b/docs/admin/src/widgets/variationPreviewTemplate.js
@@ -1,7 +1,7 @@
 const { AllHtmlEntities } = require( 'html-entities' );
 import React, { Component } from 'react';
 import { ReactLiquid, liquidEngine } from 'react-liquid';
-import { changeTab, initTabs } from '../../../assets/js/tabs.js';
+import { changeTab, init as initTabs } from '../../../assets/js/tabs.js';
 import ReactDOM from 'react-dom';
 import marked from 'marked';
 import slugify from 'slugify';
@@ -14,11 +14,6 @@ const templateWithIcons = template.replace(
   /{%\s+include\s+\/?icons\/([\w-]+)\.svg\s+%}/g,
   ( match, icon ) => require( `../../../_includes/icons/${ icon }.svg` )
 );
-
-/**
- * @param {MouseEvent} event - The mouse event object from the click.
- */
-
 
 export default class Preview extends Component {
 
@@ -33,31 +28,26 @@ export default class Preview extends Component {
     this.containerRef = React.createRef();
   }
 
+  /**
+   * @param {MouseEvent} event - The mouse event object from the click.
+   */
   handleClick( event ) {
     const target = event.target;
-    // Returns the preview component's native DOM element for
-    // use with our non-React vanilla JS toggling and tabs functionality.
-    // https://reactjs.org/docs/react-dom.html#finddomnode
-    const doc = ReactDOM.findDOMNode( this );
     if ( target.matches( '[data-toggle-code]' ) ) {
       event.preventDefault();
-      toggleDetails( target, doc );
+      toggleDetails( target, this.containerRef.current );
     }
     if ( target.matches( '.govuk-tabs__tab' ) ) {
       event.preventDefault();
-      changeTab( target, doc );
+      changeTab( target, this.containerRef.current );
     }
   }
 
   componentDidMount() {
-    const container = ReactDOM.findDOMNode( this.containerRef.current );
-    container.addEventListener( 'click', this.handleClick );
+    const container = this.containerRef.current;
     // The Gov UK tab styles require a parent element to have .js-enabled, see tabs.less
     container.classList.add( 'js-enabled' );
-    // Initialize the Gov UK tabs once everything has finished loading
-    window.addEventListener( 'load', () => {
-      initTabs( container );
-    } );
+    initTabs( container );
   }
 
   render() {
@@ -65,7 +55,7 @@ export default class Preview extends Component {
       page: this.props.entry.toJS().data
     };
     return (
-      <div ref={this.containerRef}>
+      <div ref={this.containerRef} onClick={event => this.handleClick( event )}>
         <ReactLiquid template={templateWithIcons} data={data} html />
       </div>
     );

--- a/docs/admin/src/widgets/variationPreviewTemplate.js
+++ b/docs/admin/src/widgets/variationPreviewTemplate.js
@@ -1,9 +1,12 @@
 const { AllHtmlEntities } = require( 'html-entities' );
 import React, { Component } from 'react';
 import { ReactLiquid, liquidEngine } from 'react-liquid';
-import { Tabs } from 'govuk-frontend';
+import { changeTab, initTabs } from '../../../assets/js/tabs.js';
+import ReactDOM from 'react-dom';
 import marked from 'marked';
+import slugify from 'slugify';
 import template from '../../../_includes/variation-content.html';
+import toggleDetails from '../../../assets/js/toggle-details.js';
 
 // react-liquid (https://github.com/aquibm/react-liquid/) isn't able to `include` other files so we
 // replace instances of {% include icons/XXXXX.svg %} with the inlined SVG
@@ -12,23 +15,49 @@ const templateWithIcons = template.replace(
   ( match, icon ) => require( `../../../_includes/icons/${ icon }.svg` )
 );
 
+/**
+ * @param {MouseEvent} event - The mouse event object from the click.
+ */
+
+
 export default class Preview extends Component {
 
-  componentDidMount() {
+  constructor( props ) {
+    super( props );
     const entities = new AllHtmlEntities();
-    const tabs = document.querySelector( 'iframe' ).contentWindow.document.querySelectorAll( '[data-module="tabs"]' );
 
+    liquidEngine.registerFilter( 'slugify', initial => slugify( initial, { lower: true } ) );
     liquidEngine.registerFilter( 'xml_escape', initial => entities.encode( initial ) );
     liquidEngine.registerFilter( 'markdownify', initial => marked( initial || '' ) );
 
-    if ( tabs && tabs.length > 0 ) {
-      document.querySelector( 'iframe' ).contentWindow.document.body.classList.add( 'js-enabled' );
-      for ( let i = 0; i < tabs.length; i++ ) {
-        const tab = tabs[i];
-        new Tabs( tab ).init( );
-      }
-    }
+    this.containerRef = React.createRef();
+  }
 
+  handleClick( event ) {
+    const target = event.target;
+    // Returns the preview component's native DOM element for
+    // use with our non-React vanilla JS toggling and tabs functionality.
+    // https://reactjs.org/docs/react-dom.html#finddomnode
+    const doc = ReactDOM.findDOMNode( this );
+    if ( target.matches( '[data-toggle-code]' ) ) {
+      event.preventDefault();
+      toggleDetails( target, doc );
+    }
+    if ( target.matches( '.govuk-tabs__tab' ) ) {
+      event.preventDefault();
+      changeTab( target, doc );
+    }
+  }
+
+  componentDidMount() {
+    const container = ReactDOM.findDOMNode( this.containerRef.current );
+    container.addEventListener( 'click', this.handleClick );
+    // The Gov UK tab styles require a parent element to have .js-enabled, see tabs.less
+    container.classList.add( 'js-enabled' );
+    // Initialize the Gov UK tabs once everything has finished loading
+    window.addEventListener( 'load', () => {
+      initTabs( container );
+    } );
   }
 
   render() {
@@ -36,7 +65,7 @@ export default class Preview extends Component {
       page: this.props.entry.toJS().data
     };
     return (
-      <div>
+      <div ref={this.containerRef}>
         <ReactLiquid template={templateWithIcons} data={data} html />
       </div>
     );

--- a/docs/admin/src/widgets/variationPreviewTemplate.js
+++ b/docs/admin/src/widgets/variationPreviewTemplate.js
@@ -26,7 +26,7 @@ export default class Preview extends Component {
     super( props );
     const entities = new AllHtmlEntities();
 
-    liquidEngine.registerFilter( 'slugify', initial => slugify( initial, { lower: true } ) );
+    liquidEngine.registerFilter( 'slugify', initial => slugify( initial || '', { lower: true } ) );
     liquidEngine.registerFilter( 'xml_escape', initial => entities.encode( initial ) );
     liquidEngine.registerFilter( 'markdownify', initial => marked( initial || '' ) );
 

--- a/docs/admin/src/widgets/variationPreviewTemplate.js
+++ b/docs/admin/src/widgets/variationPreviewTemplate.js
@@ -1,12 +1,13 @@
-const { AllHtmlEntities } = require( 'html-entities' );
 import React, { Component } from 'react';
 import { ReactLiquid, liquidEngine } from 'react-liquid';
+import { TOGGLE_ATTRIBUTE, toggleDetails } from '../../../assets/js/toggle-details.js';
 import { changeTab, init as initTabs } from '../../../assets/js/tabs.js';
+import { AllHtmlEntities } from 'html-entities';
 import ReactDOM from 'react-dom';
 import marked from 'marked';
 import slugify from 'slugify';
 import template from '../../../_includes/variation-content.html';
-import toggleDetails from '../../../assets/js/toggle-details.js';
+
 
 // react-liquid (https://github.com/aquibm/react-liquid/) isn't able to `include` other files so we
 // replace instances of {% include icons/XXXXX.svg %} with the inlined SVG
@@ -33,7 +34,7 @@ export default class Preview extends Component {
    */
   handleClick( event ) {
     const target = event.target;
-    if ( target.matches( '[data-toggle-code]' ) ) {
+    if ( target.matches( `[${ TOGGLE_ATTRIBUTE }]` ) ) {
       event.preventDefault();
       toggleDetails( target, this.containerRef.current );
     }

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -2,6 +2,7 @@ import { Tabs } from 'govuk-frontend';
 import AnchorJS from 'anchor-js';
 import Expandable from '@cfpb/cfpb-expandables/src/Expandable';
 import Table from '@cfpb/cfpb-tables/src/Table';
+import toggleDetails from './toggle-details.js';
 
 const anchors = new AnchorJS();
 // Add anchors to all headings (except page title headings)
@@ -29,29 +30,14 @@ if ( tabs && tabs.length > 0 ) {
   }
 }
 
-const HIDDEN_CLASS = 'u-hidden';
-
 /**
  * @param {MouseEvent} event - The mouse event object from the click.
  */
 function handleDocumentClick( event ) {
   const target = event.target;
-  if ( !target.matches( '[data-toggle-code]' ) ) {
-    return;
+  if ( target.matches( '[data-toggle-code]' ) ) {
+    toggleDetails( target );
   }
-  event.preventDefault();
-  const container = target.parentNode;
-  const codeEl = document.querySelector( target.getAttribute( 'href' ) );
-  if ( codeEl && codeEl.classList.contains( HIDDEN_CLASS ) ) {
-    codeEl.classList.remove( HIDDEN_CLASS );
-    container.querySelector( '[data-toggle-code="hide"]' ).classList.remove( HIDDEN_CLASS );
-    container.querySelector( '[data-toggle-code="show"]' ).classList.add( HIDDEN_CLASS );
-  } else {
-    codeEl.classList.add( HIDDEN_CLASS );
-    container.querySelector( '[data-toggle-code="hide"]' ).classList.add( HIDDEN_CLASS );
-    container.querySelector( '[data-toggle-code="show"]' ).classList.remove( HIDDEN_CLASS );
-  }
-
 }
 
 document.addEventListener( 'click', handleDocumentClick, false );

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -1,8 +1,8 @@
+import { TOGGLE_ATTRIBUTE, toggleDetails } from './toggle-details.js';
 import { Tabs } from 'govuk-frontend';
 import AnchorJS from 'anchor-js';
 import Expandable from '@cfpb/cfpb-expandables/src/Expandable';
 import Table from '@cfpb/cfpb-tables/src/Table';
-import toggleDetails from './toggle-details.js';
 
 const anchors = new AnchorJS();
 // Add anchors to all headings (except page title headings)
@@ -35,7 +35,7 @@ if ( tabs && tabs.length > 0 ) {
  */
 function handleDocumentClick( event ) {
   const target = event.target;
-  if ( target.matches( '[data-toggle-code]' ) ) {
+  if ( target.matches( `[${ TOGGLE_ATTRIBUTE }]` ) ) {
     toggleDetails( target );
   }
 }

--- a/docs/assets/js/tabs.js
+++ b/docs/assets/js/tabs.js
@@ -23,23 +23,23 @@ export function init( container ) {
  * @param {DOMNode} document - Defaults to window.document but overridable for ReactDOM
  */
 export function changeTab( tab, document = window.document ) {
-  const TABS_CONTAINER_CLASS = '.govuk-tabs';
-  const TAB_CLASS = '.govuk-tabs__list-item';
+  const TABS_CONTAINER_CLASS = 'govuk-tabs';
+  const TAB_CLASS = 'govuk-tabs__list-item';
   const TAB_CLASS_SELECTED = 'govuk-tabs__list-item--selected';
-  const TAB_CONTENT_CLASS = '.govuk-tabs__panel';
+  const TAB_CONTENT_CLASS = 'govuk-tabs__panel';
   const TAB_CONTENT_CLASS_HIDDEN = 'govuk-tabs__panel--hidden';
 
   const selectedTabContent = document.querySelector( tab.getAttribute( 'href' ) );
-  const selectedTabListItem = tab.closest( TAB_CLASS );
-  const tabsContainer = tab.closest( TABS_CONTAINER_CLASS );
+  const selectedTabListItem = tab.closest( `.${TAB_CLASS}` );
+  const tabsContainer = tab.closest( `.${TABS_CONTAINER_CLASS}` );
 
   // Un-highlight all tabs
-  tabsContainer.querySelectorAll( TAB_CLASS ).forEach( tabListItem => {
+  tabsContainer.querySelectorAll( `.${TAB_CLASS}` ).forEach( tabListItem => {
     tabListItem.classList.remove( TAB_CLASS_SELECTED );
   } );
 
   // Hide all tab content
-  tabsContainer.querySelectorAll( TAB_CONTENT_CLASS ).forEach( content => {
+  tabsContainer.querySelectorAll( `.${TAB_CONTENT_CLASS}` ).forEach( content => {
     content.classList.add( TAB_CONTENT_CLASS_HIDDEN );
   } );
 

--- a/docs/assets/js/tabs.js
+++ b/docs/assets/js/tabs.js
@@ -9,7 +9,7 @@ export function init( container ) {
   if ( tabs && tabs.length > 0 ) {
     for ( let i = 0; i < tabs.length; i++ ) {
       const tab = tabs[i];
-      new Tabs( tab ).init( );
+      new Tabs( tab ).init();
     }
   }
 }
@@ -30,16 +30,16 @@ export function changeTab( tab, document = window.document ) {
   const TAB_CONTENT_CLASS_HIDDEN = 'govuk-tabs__panel--hidden';
 
   const selectedTabContent = document.querySelector( tab.getAttribute( 'href' ) );
-  const selectedTabListItem = tab.closest( `.${TAB_CLASS}` );
-  const tabsContainer = tab.closest( `.${TABS_CONTAINER_CLASS}` );
+  const selectedTabListItem = tab.closest( `.${ TAB_CLASS }` );
+  const tabsContainer = tab.closest( `.${ TABS_CONTAINER_CLASS }` );
 
   // Un-highlight all tabs
-  tabsContainer.querySelectorAll( `.${TAB_CLASS}` ).forEach( tabListItem => {
+  tabsContainer.querySelectorAll( `.${ TAB_CLASS }` ).forEach( tabListItem => {
     tabListItem.classList.remove( TAB_CLASS_SELECTED );
   } );
 
   // Hide all tab content
-  tabsContainer.querySelectorAll( `.${TAB_CONTENT_CLASS}` ).forEach( content => {
+  tabsContainer.querySelectorAll( `.${ TAB_CONTENT_CLASS }` ).forEach( content => {
     content.classList.add( TAB_CONTENT_CLASS_HIDDEN );
   } );
 

--- a/docs/assets/js/tabs.js
+++ b/docs/assets/js/tabs.js
@@ -1,0 +1,51 @@
+import { Tabs } from 'govuk-frontend';
+
+/**
+ * @param {DOMNode} container - Parent element containing Gov UK tab HTML
+ */
+export function init( container ) {
+  const tabs = container.querySelectorAll( '[data-module="tabs"]' );
+
+  if ( tabs && tabs.length > 0 ) {
+    for ( let i = 0; i < tabs.length; i++ ) {
+      const tab = tabs[i];
+      new Tabs( tab ).init( );
+    }
+  }
+}
+
+/**
+ * This is a helper function that is only used within Netlify CMS.
+ * The original Gov UK tabs code modifies the URL's hash which breaks Netlify
+ * so we replace their functionality with some simple tab switching below.
+ *
+ * @param {DOMNode} tab - Tab element that was clicked
+ * @param {DOMNode} document - Defaults to window.document but overridable for ReactDOM
+ */
+export function changeTab( tab, document = window.document ) {
+  const TABS_CONTAINER_CLASS = '.govuk-tabs';
+  const TAB_CLASS = '.govuk-tabs__list-item';
+  const TAB_CLASS_SELECTED = 'govuk-tabs__list-item--selected';
+  const TAB_CONTENT_CLASS = '.govuk-tabs__panel';
+  const TAB_CONTENT_CLASS_HIDDEN = 'govuk-tabs__panel--hidden';
+
+  const selectedTabContent = document.querySelector( tab.getAttribute( 'href' ) );
+  const selectedTabListItem = tab.closest( TAB_CLASS );
+  const tabsContainer = tab.closest( TABS_CONTAINER_CLASS );
+
+  // Un-highlight all tabs
+  tabsContainer.querySelectorAll( TAB_CLASS ).forEach( tabListItem => {
+    tabListItem.classList.remove( TAB_CLASS_SELECTED );
+  } );
+
+  // Hide all tab content
+  tabsContainer.querySelectorAll( TAB_CONTENT_CLASS ).forEach( content => {
+    content.classList.add( TAB_CONTENT_CLASS_HIDDEN );
+  } );
+
+  // Highlight the selected tab
+  selectedTabListItem.classList.add( TAB_CLASS_SELECTED );
+
+  // Show the selected tab's content
+  selectedTabContent.classList.remove( TAB_CONTENT_CLASS_HIDDEN );
+}

--- a/docs/assets/js/toggle-details.js
+++ b/docs/assets/js/toggle-details.js
@@ -1,19 +1,22 @@
 const HIDDEN_CLASS = 'u-hidden';
+export const TOGGLE_ATTRIBUTE = 'data-toggle-details';
 
 /**
  * @param {DOMNode} button - Button element that controls the toggling
  * @param {DOMNode} document - Defaults to window.document but overridable for ReactDOM
  */
-export default function toggle( button, document = window.document ) {
+export function toggleDetails( button, document = window.document ) {
   const container = button.parentNode;
   const codeEl = document.querySelector( button.getAttribute( 'href' ) );
+  const hideCodeBtn = container.querySelector( `[${TOGGLE_ATTRIBUTE}="hide"]` );
+  const showCodeBtn = container.querySelector( `[${TOGGLE_ATTRIBUTE}="show"]` );
   if ( codeEl && codeEl.classList.contains( HIDDEN_CLASS ) ) {
     codeEl.classList.remove( HIDDEN_CLASS );
-    container.querySelector( '[data-toggle-code="hide"]' ).classList.remove( HIDDEN_CLASS );
-    container.querySelector( '[data-toggle-code="show"]' ).classList.add( HIDDEN_CLASS );
+    hideCodeBtn.classList.remove( HIDDEN_CLASS );
+    showCodeBtn.classList.add( HIDDEN_CLASS );
   } else {
     codeEl.classList.add( HIDDEN_CLASS );
-    container.querySelector( '[data-toggle-code="hide"]' ).classList.add( HIDDEN_CLASS );
-    container.querySelector( '[data-toggle-code="show"]' ).classList.remove( HIDDEN_CLASS );
+    hideCodeBtn.classList.add( HIDDEN_CLASS );
+    showCodeBtn.classList.remove( HIDDEN_CLASS );
   }
 }

--- a/docs/assets/js/toggle-details.js
+++ b/docs/assets/js/toggle-details.js
@@ -1,0 +1,19 @@
+const HIDDEN_CLASS = 'u-hidden';
+
+/**
+ * @param {DOMNode} button - Button element that controls the toggling
+ * @param {DOMNode} document - Defaults to window.document but overridable for ReactDOM
+ */
+export default function toggle( button, document = window.document ) {
+  const container = button.parentNode;
+  const codeEl = document.querySelector( button.getAttribute( 'href' ) );
+  if ( codeEl && codeEl.classList.contains( HIDDEN_CLASS ) ) {
+    codeEl.classList.remove( HIDDEN_CLASS );
+    container.querySelector( '[data-toggle-code="hide"]' ).classList.remove( HIDDEN_CLASS );
+    container.querySelector( '[data-toggle-code="show"]' ).classList.add( HIDDEN_CLASS );
+  } else {
+    codeEl.classList.add( HIDDEN_CLASS );
+    container.querySelector( '[data-toggle-code="hide"]' ).classList.add( HIDDEN_CLASS );
+    container.querySelector( '[data-toggle-code="show"]' ).classList.remove( HIDDEN_CLASS );
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -44,6 +44,7 @@
     "normalize-css": "^2.3.1",
     "normalize-legacy-addon": "^0.1.0",
     "react": "16.13.1",
-    "react-liquid": "1.3.0"
+    "react-liquid": "1.3.0",
+    "slugify": "1.4.0"
   }
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -6434,6 +6434,11 @@ slate@^0.47.0:
     tiny-warning "^0.0.3"
     type-of "^2.0.1"
 
+slugify@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.0.tgz#c9557c653c54b0c7f7a8e786ef3431add676d2cb"
+  integrity sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"

--- a/test/browser/docs/code-snippets.js
+++ b/test/browser/docs/code-snippets.js
@@ -9,8 +9,8 @@ describe( 'The code snippet toggling feature', () => {
   before( () => {
     browser.url( '/design-system/components/buttons' );
     browser.setWindowSize( 1024, 768 );
-    codeShowButton = $( '.a-toggle_code [data-toggle-code="show"]' );
-    codeHideButton = $( '.a-toggle_code [data-toggle-code="hide"]' );
+    codeShowButton = $( 'button=Show details' );
+    codeHideButton = $( 'button=Hide details' );
     codeSnippetTabs = [ ...$$( '.govuk-tabs' ) ];
     areCodeSnippetTabsVisible = () => codeSnippetTabs.some( snippet => snippet.isDisplayed() );
   } );

--- a/test/browser/docs/netlify-cms.js
+++ b/test/browser/docs/netlify-cms.js
@@ -49,6 +49,9 @@ describe( 'Netlify CMS', () => {
 
     beforeEach( () => {
       browser.url( '/design-system/admin/#/collections/components/entries/buttons' );
+      // Make the browser a little wider than normal to prevent the "show details" tabs
+      // from triggering their mobile media queries
+      browser.setWindowSize( 1400, 800 );
       loginButton = browser.react$( 'LoginButton' );
     } );
 
@@ -66,6 +69,23 @@ describe( 'Netlify CMS', () => {
       expect( previewPane ).toHaveTextContaining( 'component pages are the best' );
     } );
 
+    it( 'should support switching between the various "show details" tabs', () => {
+      loginButton.waitForDisplayed();
+      loginButton.click();
+      // Wait for the editor to load
+      const editorContainer = browser.react$( 'EditorContainer' );
+      editorContainer.waitForDisplayed();
+      // The preview pane is an iframe
+      browser.switchToFrame( $( 'iframe' ) );
+      const detailsButton = $( 'button=Show details' );
+      detailsButton.click();
+      const implementationButton = $( 'a=Implementation' );
+      expect( implementationButton ).toBeDisplayed();
+      implementationButton.click();
+      // Move one level up the DOM tree
+      const implementationButtonParent = implementationButton.$( '..' );
+      expect( implementationButtonParent ).toHaveClassContaining( 'selected' );
+    } );
   } );
 
 } );

--- a/test/browser/webdriver-sauce.conf.js
+++ b/test/browser/webdriver-sauce.conf.js
@@ -49,7 +49,11 @@ exports.config = {
     {
       browserName: 'chrome',
       browserVersion: 'latest',
-      platformName: 'Windows 10'
+      platformName: 'Windows 10',
+      // Increase the VM's resolution for Netlify CMS tests that require a wider viewport.
+      'sauce:options': {
+        screenResolution: '1440x900'
+      }
     },
     {
       browserName: 'safari',
@@ -113,7 +117,7 @@ exports.config = {
   baseUrl: 'http://localhost:4000',
   //
   // Default timeout for all waitFor* commands.
-  waitforTimeout: 120000,
+  waitforTimeout: 180000,
   //
   // Default timeout in milliseconds for request
   // if browser driver or grid doesn't send response
@@ -159,7 +163,7 @@ exports.config = {
   // See the full list at http://mochajs.org/
   mochaOpts: {
     ui: 'bdd',
-    timeout: 120000
+    timeout: 180000
   }
   //
   // =====


### PR DESCRIPTION
Fixes the "show details" link within Netlify CMS's live preview pane. The Gov UK tabs we use modifies the URL's hash which doesn't play well with Netlify CMS so a simpler version of the tab switching is provided for the CMS.

## Additions

- Simplified version of the Gov UK tab switching code for the CMS to use.
- Browser test that clicks some "show details" tabs in the CMS.
- Slugify liquid filter for the preview pane (before this PR, the `slugify` filter erroneously wasn't being recognized)

## Changes

- Moves the "show details" and tabs code into their own files so they can be imported as needed.

## Testing

1. Cloud browser tests should pass below.
1. `yarn test:browser` should pass locally
1. Editing a page with variation details (like buttons) via this PR's preview link should show functioning tabs while [production](https://cfpb.github.io/design-system/admin/#/collections/components/entries/buttons) does not.

## Screenshots

![cms-tabs](https://user-images.githubusercontent.com/1060248/82235848-47646400-9901-11ea-84b6-28ecfb2dbfd6.gif)

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
