### PR TITLE
Fix component template rendering logic

### DIFF
--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -186,7 +186,8 @@
     {% endif %}
 
     {% comment %} liquid templates' order of operations is from right to left, see https://help.shopify.com/en/themes/liquid/basics/operators for examples explaining the nonsense below {% endcomment %}
-    {% if page.restrictions != empty and page.restrictions or page.use_cases and page.use_cases != '' %}
+    {% if page.use_cases != '' or page.content_guidelines != '' or page.behavior != '' or page.restrictions and pag
+e.restrictions != empty %}
         <section class="sticky-header u-mb45">
 
             {% if page.use_cases and page.use_cases != '' %}

--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -186,8 +186,7 @@
     {% endif %}
 
     {% comment %} liquid templates' order of operations is from right to left, see https://help.shopify.com/en/themes/liquid/basics/operators for examples explaining the nonsense below {% endcomment %}
-    {% if page.use_cases != '' or page.content_guidelines != '' or page.behavior != '' or page.restrictions and pag
-e.restrictions != empty %}
+    {% if page.use_cases != '' or page.content_guidelines != '' or page.behavior != '' or page.restrictions and page.restrictions != empty %}
         <section class="sticky-header u-mb45">
 
             {% if page.use_cases and page.use_cases != '' %}

--- a/docs/components/heading-hierarchy.md
+++ b/docs/components/heading-hierarchy.md
@@ -164,7 +164,7 @@ variation_groups:
               </h2>
           </header>
     variation_group_description: The heading variations below have specific use cases.
-use_cases: .
+use_cases: ''
 content_guidelines: |-
   Headings should be sentence case. 
   * Do not include punctuation in headings. 

--- a/docs/components/helper-text.md
+++ b/docs/components/helper-text.md
@@ -75,7 +75,7 @@ variation_groups:
           #### Placeholder text
           Avenir Next Regular, 16 px, Gray (#5a5d61)
     variation_group_name: Standard helper text
-use_cases: .
+use_cases: ''
 content_guidelines: >-
   #### Required vs. optional fields
 

--- a/docs/components/notifications.md
+++ b/docs/components/notifications.md
@@ -217,7 +217,7 @@ variation_groups:
 
 
       For screen reader accessibility, include anchor links to the fields that need correction.
-use_cases: .
+use_cases: ''
 content_guidelines: ""
 behavior: >-
   #### Visibility

--- a/docs/components/text-inputs.md
+++ b/docs/components/text-inputs.md
@@ -171,7 +171,7 @@ variation_groups:
               <textarea class="a-text-input a-text-input__full"
                         id="full-textarea-example">Placeholder text</textarea>
           </div>
-use_cases: .nan
+use_cases: ''
 content_guidelines: >-
   Choose the appropriate width for text input fields so they match the kind of
   information requested. This makes it easier for users to quickly grasp what’s


### PR DESCRIPTION
We were erroneously checking for only component restrictions and use cases when rendering component pages, resulting in editors having to put dummy content in the use cases field to get anything to appear. We should check for all four sections: use cases, content guidelines, behavior and restrictions.

Fixes: GHE/CFPB/el-camino/issues/238

## Changes

- Check for the existence of `page.content_guidelines` and `page.behavior` along with restrictions and use cases.

## Testing

1. The [PR preview](https://deploy-preview-548--cfpb-design-system.netlify.app/design-system/components/headings#use-cases) headings page should not have a Use Cases section while  [production](https://cfpb.github.io/design-system/components/headings#use-cases) has a placeholder period in that section.
