### PR TITLE
Don't strip newlines from search index

### DIFF
--- a/docs/_includes/search-scripts.html
+++ b/docs/_includes/search-scripts.html
@@ -19,20 +19,20 @@
 
                 {% for variation in variation_group.variations %}
                     'variation_name{{ forloop.index }}': '{{ variation.variation_name | escape }}',
-                    'variation_description{{ forloop.index }}': {{ variation.variation_description | markdownify | strip_html | strip_newlines | jsonify }},
+                    'variation_description{{ forloop.index }}': {{ variation.variation_description | markdownify | strip_html | jsonify }},
                     'variation_code_snippet{{ forloop.index }}': `{{ variation.variation_code_snippet | escape }}`,
                 {% endfor %}
             {% endfor %}
 
 
             'title': '{{ page.title | escape }}',
-            'description': {{ page.description | markdownify | strip_html | strip_newlines | jsonify }},
-            'use_cases': {{ page.use_cases | markdownify | strip_html | strip_newlines | jsonify }},
-            'content_guidelines': {{ page.content_guidelines | markdownify | strip_html | strip_newlines | jsonify }},
-            'behavior': {{ page.behavior | markdownify | strip_html | strip_newlines | jsonify }},
-            'accessibility': {{ page.accessibility | markdownify | strip_html | strip_newlines | jsonify }},
-            'research': {{ page.research | markdownify | strip_html | strip_newlines | jsonify }},
-            'related_items': {{ page.related_items | markdownify | strip_html | strip_newlines | jsonify }},
+            'description': {{ page.description | markdownify | strip_html | jsonify }},
+            'use_cases': {{ page.use_cases | markdownify | strip_html | jsonify }},
+            'content_guidelines': {{ page.content_guidelines | markdownify | strip_html | jsonify }},
+            'behavior': {{ page.behavior | markdownify | strip_html | jsonify }},
+            'accessibility': {{ page.accessibility | markdownify | strip_html | jsonify }},
+            'research': {{ page.research | markdownify | strip_html | jsonify }},
+            'related_items': {{ page.related_items | markdownify | strip_html | jsonify }},
             'url': '{{ page.url | escape }}'
         }
         {% unless forloop.last %},{% endunless %}


### PR DESCRIPTION
Stripping newlines like this means that text in headings gets erroneously combined with subsequent lines. For example, try this search:

https://cfpb.github.io/design-system/search/?searchQuery=coherent

This returns no results, incorrectly. Now try this one:

https://cfpb.github.io/design-system/search/?searchQuery=reaching.coherent

This search shouldn't work.

This change removes the use of `strip_newlines`.

Fixes el-camino#264.