### PR TITLE
Add spacing when long lists of jump links wrap

### DIFF
--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -40,7 +40,7 @@
     {% endfor %}
 
     {%- if jump_links %}
-    <ul class="m-list m-list__horizontal u-mb15">
+    <ul class="m-list m-list__horizontal m-list__horizontal-spaced">
         {% for jump_link in jump_links %}
         <li class="m-list_item">
             <a class="m-list_link" href="#{{ jump_link | slugify }}">

--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -40,7 +40,7 @@
     {% endfor %}
 
     {%- if jump_links %}
-    <ul class="m-list m-list__horizontal u-mb30">
+    <ul class="m-list m-list__horizontal u-mb15">
         {% for jump_link in jump_links %}
         <li class="m-list_item">
             <a class="m-list_link" href="#{{ jump_link | slugify }}">

--- a/docs/assets/css/variation.less
+++ b/docs/assets/css/variation.less
@@ -69,6 +69,7 @@
     color: @red;
 }
 
-.m-list__horizontal > .m-list_item {
+.m-list__horizontal-spaced,
+.m-list__horizontal-spaced > .m-list_item {
     margin-bottom: unit( 15 / @base-font-size-px, em );
 }

--- a/docs/assets/css/variation.less
+++ b/docs/assets/css/variation.less
@@ -69,7 +69,11 @@
     color: @red;
 }
 
-.m-list__horizontal-spaced,
+// Wrapping long horizontal lists.
+.m-list__horizontal-spaced {
+    margin-bottom: unit( 30px / @base-font-size-px, em );
+}
+
 .m-list__horizontal-spaced > .m-list_item {
-    margin-bottom: unit( 15 / @base-font-size-px, em );
+    margin-bottom: unit( 15px / @base-font-size-px, em );
 }

--- a/docs/assets/css/variation.less
+++ b/docs/assets/css/variation.less
@@ -68,3 +68,7 @@
 .component-restrictions_heading-donot svg {
     color: @red;
 }
+
+.m-list__horizontal > .m-list_item {
+    margin-bottom: unit( 15 / @base-font-size-px, em );
+}


### PR DESCRIPTION
Thanks to @Scotchester for the suggestion.

To test, visit a page like https://cfpb.github.io/design-system/components/buttons in a narrow browser, and observe how the buttons wrap.

|Current|With this change|
|-|-|
|![image](https://user-images.githubusercontent.com/654645/86249940-ed9cbe00-bb7d-11ea-92c2-09a6368cdc01.png)|![image](https://user-images.githubusercontent.com/654645/86249963-f5f4f900-bb7d-11ea-9ba0-ee06ef8bf0a7.png)|