### PR TITLE
Add banner when redirected from CF/DM

### DIFF
--- a/docs/_includes/redirect-banner.html
+++ b/docs/_includes/redirect-banner.html
@@ -9,7 +9,7 @@
         <div class="m-notification_content">
           <div class="h4 m-notification_message">
             You’ve been redirected to this website from
-            <span class="redirect-source-name"></span>.
+            <span data-redirect="source-name"></span>.
           </div>
           <p class="m-notification_explanation">
             The website you were trying to visit has been deprecated.
@@ -17,9 +17,9 @@
           </p>
           <p> 
             A permanent snapshot of
-            <span class="redirect-source-name"></span>
+            <span data-redirect="source-name"></span>
             is available at
-            <a class="redirect-archive-website"></a>.
+            <a data-redirect="archive-website"></a>.
           </p>
         </div>
       </div>

--- a/docs/_includes/redirect-banner.html
+++ b/docs/_includes/redirect-banner.html
@@ -1,0 +1,28 @@
+<div
+  id="redirect-banner"
+  class="block block__flush-top block__flush-bottom block__padded-top u-hidden"
+>
+  <div class="m-global-banner">
+    <div class="wrapper wrapper__match-content">
+      <div class="m-notification m-notification__warning m-notification__visible">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
+        <div class="m-notification_content">
+          <div class="h4 m-notification_message">
+            You’ve been redirected to this website from
+            <span class="redirect-source-name"></span>.
+          </div>
+          <p class="m-notification_explanation">
+            The website you were trying to visit has been deprecated.
+            Future updates will happen here.
+          </p>
+          <p> 
+            A permanent snapshot of
+            <span class="redirect-source-name"></span>
+            is available at
+            <a class="redirect-archive-website"></a>.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -27,7 +27,11 @@
     </a>
   </div>
   {% include header.html %}
+
+  {% include redirect-banner.html %}
+
   {{ content }}
+
   {% include footer.html %}
   <script src="{{ "/dist/js/main.js" | relative_url }}" charset="utf-8"></script>
 

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -42,3 +42,41 @@ function handleDocumentClick( event ) {
 }
 
 document.addEventListener( 'click', handleDocumentClick, false );
+
+// Show redirect banner if we're coming from the now-deprecated Capital
+// Framework or Design Manual websites.
+if ( window.location.search.match( /[?&]utm_medium=redirect([&#]|$)/ ) ) {
+    const match = window.location.search.match( /[?&]utm_source=([^&#]*)/ );
+
+    const redirectSources = {
+        capitalframework: {
+            name: 'Capital Framework',
+            url: 'https://cfpb.github.io/capital-framework-archive/'
+        },
+        designmanual: {
+            name: 'the CFPB Design Manual',
+            url: 'https://cfpb.github.io/design-manual-archive/'
+        }
+    };
+
+    if ( match ) {
+        const source = redirectSources[ match[ 1 ] ];
+
+        if ( source ) {
+            const banner = document.querySelector( '#redirect-banner' );
+
+            banner.querySelectorAll( 'span.redirect-source-name' ).forEach(
+                name => { name.textContent = source.name; }
+            );
+
+            banner.querySelectorAll( 'a.redirect-archive-website' ).forEach(
+                link => {
+                    link.textContent = source.url;
+                    link.href = source.url;
+                }
+            );
+
+            banner.classList.remove( 'u-hidden' );
+        }
+    }
+}

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -64,17 +64,17 @@ if ( window.location.search.match( /[?&]utm_medium=redirect([&#]|$)/ ) ) {
 
         if ( source ) {
             const banner = document.querySelector( '#redirect-banner' );
+            const sourceNames = banner.querySelectorAll( 'span.redirect-source-name' );
+            const links = banner.querySelectorAll( 'a.redirect-archive-website' );
 
-            banner.querySelectorAll( 'span.redirect-source-name' ).forEach(
-                name => { name.textContent = source.name; }
-            );
+            for ( let i = 0, len = sourceNames.length; i < len; i++ ) {
+                sourceNames[i].textContent = source.name;
+            }
 
-            banner.querySelectorAll( 'a.redirect-archive-website' ).forEach(
-                link => {
-                    link.textContent = source.url;
-                    link.href = source.url;
-                }
-            );
+            for ( let i = 0, len = links.length; i < len; i++ ) {
+                links[i].textContent = source.url;
+                links[i].href = source.url;
+            }
 
             banner.classList.remove( 'u-hidden' );
         }

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -48,18 +48,18 @@ document.addEventListener( 'click', handleDocumentClick, false );
 if ( window.location.search.match( /[?&]utm_medium=redirect([&#]|$)/ ) ) {
     const match = window.location.search.match( /[?&]utm_source=([^&#]*)/ );
 
-    const redirectSources = {
-        capitalframework: {
-            name: 'Capital Framework',
-            url: 'https://cfpb.github.io/capital-framework-archive/'
-        },
-        designmanual: {
-            name: 'the CFPB Design Manual',
-            url: 'https://cfpb.github.io/design-manual-archive/'
-        }
-    };
-
     if ( match ) {
+        const redirectSources = {
+            capitalframework: {
+                name: 'Capital Framework',
+                url: 'https://cfpb.github.io/capital-framework-archive/'
+            },
+            designmanual: {
+                name: 'the CFPB Design Manual',
+                url: 'https://cfpb.github.io/design-manual-archive/'
+            }
+        };
+
         const source = redirectSources[ match[ 1 ] ];
 
         if ( source ) {

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -64,8 +64,8 @@ if ( window.location.search.match( /[?&]utm_medium=redirect([&#]|$)/ ) ) {
 
         if ( source ) {
             const banner = document.querySelector( '#redirect-banner' );
-            const sourceNames = banner.querySelectorAll( 'span.redirect-source-name' );
-            const links = banner.querySelectorAll( 'a.redirect-archive-website' );
+            const sourceNames = banner.querySelectorAll( 'span[data-redirect=source-name]' );
+            const links = banner.querySelectorAll( 'a[data-redirect=archive-website]' );
 
             for ( let i = 0, len = sourceNames.length; i < len; i++ ) {
                 sourceNames[i].textContent = source.name;


### PR DESCRIPTION
When visitors are redirected from the soon-to-be-deprecated [Capital Framework](https://cfpb.github.io/capital-framework/) and [Design Manual](https://cfpb.github.io/design-manual/) websites, the landing URLs will have certain query string parameters:

?utm_medium=redirect&utm_source=capitalframework
?utm_medium=redirect&utm_source=designmanual

When this traffic comes in, we want to show a banner to users to let them know they've been redirected.

This change adds that banner using JavaScript.

## Screenshots

When visiting http://localhost:4000/design-system/?utm_source=capitalframework&utm_medium=redirect:

![image](https://user-images.githubusercontent.com/654645/86386006-26609400-bc5f-11ea-966e-5583a68abd46.png)

When visiting http://localhost:4000/design-system/?utm_source=designmanual&utm_medium=redirect:

![image](https://user-images.githubusercontent.com/654645/86386085-4abc7080-bc5f-11ea-8e37-47bfc5180e23.png)

## Notes

I'd very much welcome feedback on the JS implementation of this. I wasn't sure if there was some better way to do the templating. Also seeking feedback on the text content of the banners.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: