### PR TITLE
Linter fixes

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -1,8 +1,11 @@
 import { TOGGLE_ATTRIBUTE, toggleDetails } from './toggle-details.js';
-import { Tabs } from 'govuk-frontend';
 import AnchorJS from 'anchor-js';
 import Expandable from '@cfpb/cfpb-expandables/src/Expandable';
 import Table from '@cfpb/cfpb-tables/src/Table';
+import { Tabs } from 'govuk-frontend';
+import redirectBanner from './redirect-banner.js';
+
+redirectBanner.init();
 
 const anchors = new AnchorJS();
 // Add anchors to all headings (except page title headings)
@@ -42,41 +45,3 @@ function handleDocumentClick( event ) {
 }
 
 document.addEventListener( 'click', handleDocumentClick, false );
-
-// Show redirect banner if we're coming from the now-deprecated Capital
-// Framework or Design Manual websites.
-if ( window.location.search.match( /[?&]utm_medium=redirect([&#]|$)/ ) ) {
-    const match = window.location.search.match( /[?&]utm_source=([^&#]*)/ );
-
-    if ( match ) {
-        const redirectSources = {
-            capitalframework: {
-                name: 'Capital Framework',
-                url: 'https://cfpb.github.io/capital-framework-archive/'
-            },
-            designmanual: {
-                name: 'the CFPB Design Manual',
-                url: 'https://cfpb.github.io/design-manual-archive/'
-            }
-        };
-
-        const source = redirectSources[ match[ 1 ] ];
-
-        if ( source ) {
-            const banner = document.querySelector( '#redirect-banner' );
-            const sourceNames = banner.querySelectorAll( 'span[data-redirect=source-name]' );
-            const links = banner.querySelectorAll( 'a[data-redirect=archive-website]' );
-
-            for ( let i = 0, len = sourceNames.length; i < len; i++ ) {
-                sourceNames[i].textContent = source.name;
-            }
-
-            for ( let i = 0, len = links.length; i < len; i++ ) {
-                links[i].textContent = source.url;
-                links[i].href = source.url;
-            }
-
-            banner.classList.remove( 'u-hidden' );
-        }
-    }
-}

--- a/docs/assets/js/redirect-banner.js
+++ b/docs/assets/js/redirect-banner.js
@@ -1,0 +1,62 @@
+/**
+ * Retrieve redirect source name and URL.
+ * @param {Array} match - Matched URL UTM source.
+ * @returns {Object} Hash of redirect source's name and URL.
+ */
+function getSource( match ) {
+  const redirectSources = {
+    capitalframework: {
+      name: 'Capital Framework',
+      url: 'https://cfpb.github.io/capital-framework-archive/'
+    },
+    designmanual: {
+      name: 'the CFPB Design Manual',
+      url: 'https://cfpb.github.io/design-manual-archive/'
+    }
+  };
+
+  return redirectSources[match[1]];
+}
+
+/**
+ * Populate the redirection banner contents and display the banner.
+ * @param {string} sourceName - The source's name.
+ * @param {string} sourceUrl - The source's URL
+ */
+function displayBanner( sourceName, sourceUrl ) {
+  const banner = document.querySelector( '#redirect-banner' );
+  const sourceNames = banner.querySelectorAll( 'span[data-redirect=source-name]' );
+  const links = banner.querySelectorAll( 'a[data-redirect=archive-website]' );
+
+  for ( let i = 0, len = sourceNames.length; i < len; i++ ) {
+    sourceNames[i].textContent = sourceName;
+  }
+
+  for ( let i = 0, len = links.length; i < len; i++ ) {
+    links[i].textContent = sourceUrl;
+    links[i].href = sourceUrl;
+  }
+
+  banner.classList.remove( 'u-hidden' );
+}
+
+/**
+ * Show redirect banner if we're coming from the now-deprecated
+ * Capital Framework or Design Manual websites.
+ */
+function init() {
+  const locationSearch = window.location.search;
+  if ( locationSearch.match( /[?&]utm_medium=redirect([&#]|$)/ ) ) {
+    const match = locationSearch.match( /[?&]utm_source=([^&#]*)/ );
+
+    if ( match ) {
+      const source = getSource( match );
+      if ( source ) {
+        displayBanner( source.name, source.url );
+      }
+    }
+
+  }
+}
+
+export default { init };

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -2,6 +2,7 @@ const lunr = require( 'lunr' );
 
 /**
  * Update page markup with search results.
+ * @param {HTMLNode} elm - The element to inject the search results into.
  * @param {Array} results - A list of search result hits as objects.
  * @param {Object} store - search index/meta data store in the window object.
  */
@@ -118,12 +119,12 @@ const searchTerm = getURLParam( 'searchQuery' );
 const searchResultsElm = document.getElementById( 'search-results' );
 let results = [];
 
+// Get the global search store.
+const searchStore = window.searchStore;
+
 // Check if the URL has a search term set.
 if ( searchTerm ) {
   document.getElementById( 'search-box' ).setAttribute( 'value', searchTerm );
-
-  // Get the global search store.
-  const searchStore = window.searchStore;
 
   // Get the lunr index.
   const idx = initializeSearchIndex( searchStore );

--- a/docs/assets/js/toggle-details.js
+++ b/docs/assets/js/toggle-details.js
@@ -8,8 +8,8 @@ export const TOGGLE_ATTRIBUTE = 'data-toggle-details';
 export function toggleDetails( button, document = window.document ) {
   const container = button.parentNode;
   const codeEl = document.querySelector( button.getAttribute( 'href' ) );
-  const hideCodeBtn = container.querySelector( `[${TOGGLE_ATTRIBUTE}="hide"]` );
-  const showCodeBtn = container.querySelector( `[${TOGGLE_ATTRIBUTE}="show"]` );
+  const hideCodeBtn = container.querySelector( `[${ TOGGLE_ATTRIBUTE }="hide"]` );
+  const showCodeBtn = container.querySelector( `[${ TOGGLE_ATTRIBUTE }="show"]` );
   if ( codeEl && codeEl.classList.contains( HIDDEN_CLASS ) ) {
     codeEl.classList.remove( HIDDEN_CLASS );
     hideCodeBtn.classList.remove( HIDDEN_CLASS );

--- a/test/browser/webdriver-sauce.conf.js
+++ b/test/browser/webdriver-sauce.conf.js
@@ -56,37 +56,37 @@ exports.config = {
       }
     },
     {
-      browserName: 'MicrosoftEdge',
-      browserVersion: 'latest',
-      platformName: 'Windows 10',
+      'browserName': 'MicrosoftEdge',
+      'browserVersion': 'latest',
+      'platformName': 'Windows 10',
       'sauce:options': {
         screenResolution: '1024x768'
       },
-      exclude: [
+      'exclude': [
         // Netlify CMS is only tested with Chrome
         'test/browser/docs/netlify-cms.js'
       ]
     },
     {
-      browserName: 'internet explorer',
-      browserVersion: '11.285',
-      platformName: 'Windows 10',
+      'browserName': 'internet explorer',
+      'browserVersion': '11.285',
+      'platformName': 'Windows 10',
       'sauce:options': {
         screenResolution: '1024x768'
       },
-      exclude: [
+      'exclude': [
         // Netlify CMS is only tested with Chrome
         'test/browser/docs/netlify-cms.js'
       ]
     },
     {
-      browserName: 'firefox',
-      browserVersion: 'latest',
-      platformName: 'Windows 10',
+      'browserName': 'firefox',
+      'browserVersion': 'latest',
+      'platformName': 'Windows 10',
       'sauce:options': {
         screenResolution: '1024x768'
       },
-      exclude: [
+      'exclude': [
         // Netlify CMS is only tested with Chrome
         'test/browser/docs/netlify-cms.js'
       ]
@@ -207,10 +207,11 @@ exports.config = {
        * @param {Array.<Object>} capabilities list of capabilities details
        * @param {Array.<String>} specs List of spec file paths that are to be run
        */
-  beforeSession: function (config, capabilities, specs) {
+  beforeSession: function( config, capabilities, specs ) {
     // Set a global variable indicating the tests are being run via Sauce Labs
     global.SAUCE_LABS = true;
   }
+
   /**
        * Gets executed before test execution begins. At this point you can access to all global
        * variables like `browser`. It is the perfect place to define custom commands.


### PR DESCRIPTION
Fixed some issues flagged by the linter.

## Changes

- Moves redirection banner to its own script file.
- Breaks redirection script into functions to reduce complexity warnings.
- Fixes missing jsdoc argument in search script.
- Fixes undefined variable warning in search script.
- Minor spacing and quotation autofixes from linter.

## Testing

1. Redirection and search should work as before.
