### PR TITLE
Add toggle all details button

### DIFF
--- a/docs/_layouts/variation.html
+++ b/docs/_layouts/variation.html
@@ -14,8 +14,8 @@ layout: default
         <div class="o-editor_link" id="toggle-details">
             <a class="a-btn"
                 href="#"
-                title="Toggle details">
-                <span class="a-btn_text">Toggle details</span>
+                title="Show all details">
+                <span class="a-btn_text">Show all details</span>
                 <span class="a-btn_icon">{% include icons/lightbulb.svg %}</span>
             </a>
         </div>

--- a/docs/_layouts/variation.html
+++ b/docs/_layouts/variation.html
@@ -7,6 +7,21 @@ layout: default
 
     <div class="ds-content">
         {% include variation-content.html %}
+
+
+        {% if page.variation_groups.size > 0 %}
+
+        <div class="o-editor_link" id="toggle-details">
+            <a class="a-btn"
+                href="#"
+                title="Toggle details">
+                <span class="a-btn_text">Toggle details</span>
+                <span class="a-btn_icon">{% include icons/lightbulb.svg %}</span>
+            </a>
+        </div>
+
+        {% endif %}
+
         <div class="o-editor_link" id="edit-page">
             <a class="a-btn"
                href="/design-system/updating-this-website?page={{ page.title | url_encode }}"
@@ -15,5 +30,6 @@ layout: default
                 <span class="a-btn_icon">{% include icons/edit.svg %}</span>
             </a>
         </div>
+
     </div>
 </main>

--- a/docs/assets/css/netlify.less
+++ b/docs/assets/css/netlify.less
@@ -2,7 +2,11 @@
 	position: fixed;
 	bottom: 30px;
 	right: 30px;
-    z-index: 1;
+	z-index: 1;
+
+	&#toggle-details {
+    	bottom: 75px;
+    }
 
 	.a-btn {
 		border-radius: 8px;
@@ -13,7 +17,7 @@
 		display: none;
 	}
 
-	&:hover {
+	& {
 		.a-btn {
 			display: inline-block;
 		}

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -1,6 +1,6 @@
 import {
-  toggleDetails,
-  toggleAllDetails
+  toggleAllDetails,
+  toggleDetails
 } from './toggle-details.js';
 import AnchorJS from 'anchor-js';
 import Expandable from '@cfpb/cfpb-expandables/src/Expandable';
@@ -39,6 +39,18 @@ if ( tabs && tabs.length > 0 ) {
   }
 }
 
+const toggleAllBtn = document.querySelector( '#toggle-details' );
+const toggleBtns = document.querySelectorAll( '.a-toggle_code button' );
+
+toggleAllBtn.addEventListener( 'click', handleToggleAllClick, false );
+
+for ( let i = 0, len = toggleBtns.length; i < len; i++ ) {
+  toggleBtns[i].addEventListener( 'click', handleToggleClick, false );
+}
+
+/**
+ * @param {MouseEvent} event - The mouse event object from the click.
+ */
 function handleToggleAllClick( event ) {
   event.preventDefault();
   toggleAllDetails( toggleAllBtn );
@@ -48,15 +60,6 @@ function handleToggleAllClick( event ) {
  * @param {MouseEvent} event - The mouse event object from the click.
  */
 function handleToggleClick( event ) {
-  let target = event.target;
+  const target = event.target;
   toggleDetails( target );
-}
-
-const toggleAllBtn = document.querySelector( '#toggle-details' );
-const toggleBtns = document.querySelectorAll( '.a-toggle_code button' );
-
-toggleAllBtn.addEventListener( 'click', handleToggleAllClick, false );
-
-for ( let i = 0, len = toggleBtns.length; i < len; i++ ) {
-  toggleBtns[i].addEventListener( 'click', handleToggleClick, false );
 }

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -41,7 +41,7 @@ if ( tabs && tabs.length > 0 ) {
 
 function handleToggleAllClick( event ) {
   event.preventDefault();
-  toggleAllDetails();
+  toggleAllDetails( toggleAllBtn );
 }
 
 /**

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -1,4 +1,7 @@
-import { TOGGLE_ATTRIBUTE, toggleDetails } from './toggle-details.js';
+import {
+  toggleDetails,
+  toggleAllDetails
+} from './toggle-details.js';
 import AnchorJS from 'anchor-js';
 import Expandable from '@cfpb/cfpb-expandables/src/Expandable';
 import Table from '@cfpb/cfpb-tables/src/Table';
@@ -36,14 +39,24 @@ if ( tabs && tabs.length > 0 ) {
   }
 }
 
+function handleToggleAllClick( event ) {
+  event.preventDefault();
+  toggleAllDetails();
+}
+
 /**
  * @param {MouseEvent} event - The mouse event object from the click.
  */
-function handleDocumentClick( event ) {
-  const target = event.target;
-  if ( target.matches( `[${ TOGGLE_ATTRIBUTE }]` ) ) {
-    toggleDetails( target );
-  }
+function handleToggleClick( event ) {
+  let target = event.target;
+  toggleDetails( target );
 }
 
-document.addEventListener( 'click', handleDocumentClick, false );
+const toggleAllBtn = document.querySelector( '#toggle-details' );
+const toggleBtns = document.querySelectorAll( '.a-toggle_code button' );
+
+toggleAllBtn.addEventListener( 'click', handleToggleAllClick, false );
+
+for ( let i = 0, len = toggleBtns.length; i < len; i++ ) {
+  toggleBtns[i].addEventListener( 'click', handleToggleClick, false );
+}

--- a/docs/assets/js/toggle-details.js
+++ b/docs/assets/js/toggle-details.js
@@ -1,11 +1,12 @@
 const HIDDEN_CLASS = 'u-hidden';
-export const TOGGLE_ATTRIBUTE = 'data-toggle-details';
+const TOGGLE_ATTRIBUTE = 'data-toggle-details';
 
 /**
+ * Toggle details for a single variation.
  * @param {DOMNode} button - Button element that controls the toggling
  * @param {DOMNode} document - Defaults to window.document but overridable for ReactDOM
  */
-export function toggleDetails( button, document = window.document ) {
+function toggleDetails( button, document = window.document ) {
   const container = button.parentNode;
   const codeEl = document.querySelector( button.getAttribute( 'href' ) );
   const hideCodeBtn = container.querySelector( `[${ TOGGLE_ATTRIBUTE }="hide"]` );
@@ -19,4 +20,22 @@ export function toggleDetails( button, document = window.document ) {
     hideCodeBtn.classList.add( HIDDEN_CLASS );
     showCodeBtn.classList.remove( HIDDEN_CLASS );
   }
+}
+
+/**
+ * Toggle all details for a page.
+ */
+function toggleAllDetails() {
+  const codeEls = document.querySelectorAll( '.a-toggle_code' );
+  let buttonElm;
+  for ( let i = 0, len = codeEls.length; i < len; i++ ) {
+    buttonElm = codeEls[i].querySelector( 'button:not(.u-hidden)' )
+    toggleDetails( buttonElm );
+  }
+}
+
+export {
+  TOGGLE_ATTRIBUTE,
+  toggleDetails,
+  toggleAllDetails
 }

--- a/docs/assets/js/toggle-details.js
+++ b/docs/assets/js/toggle-details.js
@@ -43,7 +43,7 @@ function toggleDetails( button, document = window.document, state ) {
  * @param {HTMLNode} toggleBtn - The button that called this method.
  */
 function toggleAllDetails( toggleBtn ) {
-  if ( isShowingAllDetails ) {
+  if ( isShowingAllDetails ) {
     toggleBtn.querySelector( '.a-btn_text' ).innerHTML = 'Show all details';
     toggleBtn.setAttribute( 'title', 'Show all details' );
   } else {
@@ -54,7 +54,7 @@ function toggleAllDetails( toggleBtn ) {
   const codeEls = document.querySelectorAll( '.a-toggle_code' );
   let buttonElm;
   for ( let i = 0, len = codeEls.length; i < len; i++ ) {
-    buttonElm = codeEls[i].querySelector( 'button:not(.u-hidden)' )
+    buttonElm = codeEls[i].querySelector( 'button:not(.u-hidden)' );
     toggleDetails(
       buttonElm,
       window.document,
@@ -69,4 +69,4 @@ export {
   TOGGLE_ATTRIBUTE,
   toggleDetails,
   toggleAllDetails
-}
+};

--- a/docs/assets/js/toggle-details.js
+++ b/docs/assets/js/toggle-details.js
@@ -3,7 +3,7 @@ const TOGGLE_ATTRIBUTE = 'data-toggle-details';
 const STATE_SHOW = 'show';
 const STATE_HIDE = 'hide';
 
-let isShowingAllDetails = true;
+let isShowingAllDetails = false;
 
 /**
  * Toggle details for a single variation.
@@ -40,7 +40,6 @@ function toggleDetails( button, document = window.document, state ) {
  * @param {HTMLNode} toggleBtn - The button that called this method.
  */
 function toggleAllDetails( toggleBtn ) {
-  isShowingAllDetails = !isShowingAllDetails;
   if ( isShowingAllDetails ) {
     toggleBtn.querySelector( '.a-btn_text' ).innerHTML = 'Show all details';
     toggleBtn.setAttribute( 'title', 'Show all details' );
@@ -48,6 +47,7 @@ function toggleAllDetails( toggleBtn ) {
     toggleBtn.querySelector( '.a-btn_text' ).innerHTML = 'Hide all details';
     toggleBtn.setAttribute( 'title', 'Hide all details' );
   }
+
   const codeEls = document.querySelectorAll( '.a-toggle_code' );
   let buttonElm;
   for ( let i = 0, len = codeEls.length; i < len; i++ ) {
@@ -58,6 +58,8 @@ function toggleAllDetails( toggleBtn ) {
       isShowingAllDetails ? STATE_HIDE : STATE_SHOW
     );
   }
+
+  isShowingAllDetails = !isShowingAllDetails;
 }
 
 export {

--- a/docs/assets/js/toggle-details.js
+++ b/docs/assets/js/toggle-details.js
@@ -9,6 +9,9 @@ let isShowingAllDetails = false;
  * Toggle details for a single variation.
  * @param {DOMNode} button - Button element that controls the toggling
  * @param {DOMNode} document - Defaults to window.document but overridable for ReactDOM
+ * @param {string} [state] -
+ *   Optional param to specify whether to force showing or hiding of the details
+ *   Value should be either 'show' or 'hide'.
  */
 function toggleDetails( button, document = window.document, state ) {
   const container = button.parentNode;

--- a/docs/assets/js/toggle-details.js
+++ b/docs/assets/js/toggle-details.js
@@ -1,17 +1,30 @@
 const HIDDEN_CLASS = 'u-hidden';
 const TOGGLE_ATTRIBUTE = 'data-toggle-details';
+const STATE_SHOW = 'show';
+const STATE_HIDE = 'hide';
+
+let isShowingAllDetails = true;
 
 /**
  * Toggle details for a single variation.
  * @param {DOMNode} button - Button element that controls the toggling
  * @param {DOMNode} document - Defaults to window.document but overridable for ReactDOM
  */
-function toggleDetails( button, document = window.document ) {
+function toggleDetails( button, document = window.document, state ) {
   const container = button.parentNode;
   const codeEl = document.querySelector( button.getAttribute( 'href' ) );
   const hideCodeBtn = container.querySelector( `[${ TOGGLE_ATTRIBUTE }="hide"]` );
   const showCodeBtn = container.querySelector( `[${ TOGGLE_ATTRIBUTE }="show"]` );
-  if ( codeEl && codeEl.classList.contains( HIDDEN_CLASS ) ) {
+
+  if ( typeof state === 'undefined' ) {
+    if ( codeEl && codeEl.classList.contains( HIDDEN_CLASS ) ) {
+      state = STATE_SHOW;
+    } else {
+      state = STATE_HIDE;
+    }
+  }
+
+  if ( state === STATE_SHOW ) {
     codeEl.classList.remove( HIDDEN_CLASS );
     hideCodeBtn.classList.remove( HIDDEN_CLASS );
     showCodeBtn.classList.add( HIDDEN_CLASS );
@@ -24,13 +37,26 @@ function toggleDetails( button, document = window.document ) {
 
 /**
  * Toggle all details for a page.
+ * @param {HTMLNode} toggleBtn - The button that called this method.
  */
-function toggleAllDetails() {
+function toggleAllDetails( toggleBtn ) {
+  isShowingAllDetails = !isShowingAllDetails;
+  if ( isShowingAllDetails ) {
+    toggleBtn.querySelector( '.a-btn_text' ).innerHTML = 'Show all details';
+    toggleBtn.setAttribute( 'title', 'Show all details' );
+  } else {
+    toggleBtn.querySelector( '.a-btn_text' ).innerHTML = 'Hide all details';
+    toggleBtn.setAttribute( 'title', 'Hide all details' );
+  }
   const codeEls = document.querySelectorAll( '.a-toggle_code' );
   let buttonElm;
   for ( let i = 0, len = codeEls.length; i < len; i++ ) {
     buttonElm = codeEls[i].querySelector( 'button:not(.u-hidden)' )
-    toggleDetails( buttonElm );
+    toggleDetails(
+      buttonElm,
+      window.document,
+      isShowingAllDetails ? STATE_HIDE : STATE_SHOW
+    );
   }
 }
 

--- a/test/browser/docs/show-details.js
+++ b/test/browser/docs/show-details.js
@@ -11,10 +11,10 @@ describe( 'The "show details" toggling feature', function() {
 
   before( function() {
     browser.url( '/design-system/components/' );
-    browser.setWindowSize( 1024, 768 );
+    browser.setWindowSize( 1600, 1200 );
     const sideNav = $( '.ds-nav' );
     sideNav.waitForDisplayed();
-    componentPages = $$( '.ds-nav .m-list_link' ).map( el => ( {
+    componentPages = $$( '.ds-nav-2 .m-list_link' ).map( el => ( {
       name: el.getText(),
       url: el.getAttribute( 'href' )
     } ) );
@@ -35,7 +35,6 @@ describe( 'The "show details" toggling feature', function() {
         before( function() {
           browser.url( componentPage.url );
           browser.refresh();
-          browser.setWindowSize( 1400, 800 );
           showDetailsButton = $( 'button=Show details' );
           hideDetailsButton = $( 'button=Hide details' );
           detailsTabs = [ ...$$( '.govuk-tabs' ) ];

--- a/test/browser/docs/show-details.js
+++ b/test/browser/docs/show-details.js
@@ -35,7 +35,7 @@ describe( 'The "show details" toggling feature', function() {
         before( function() {
           browser.url( componentPage.url );
           browser.refresh();
-          browser.setWindowSize( 1024, 768 );
+          browser.setWindowSize( 1400, 800 );
           showDetailsButton = $( 'button=Show details' );
           hideDetailsButton = $( 'button=Hide details' );
           detailsTabs = [ ...$$( '.govuk-tabs' ) ];

--- a/test/browser/webdriver-sauce.conf.js
+++ b/test/browser/webdriver-sauce.conf.js
@@ -52,7 +52,7 @@ exports.config = {
       'platformName': 'Windows 10',
       // Increase the VM's resolution for Netlify CMS tests that require a wider viewport.
       'sauce:options': {
-        screenResolution: '1440x900'
+        screenResolution: '1600x1200'
       }
     },
     {
@@ -60,7 +60,7 @@ exports.config = {
       'browserVersion': 'latest',
       'platformName': 'Windows 10',
       'sauce:options': {
-        screenResolution: '1024x768'
+        screenResolution: '1600x1200'
       },
       'exclude': [
         // Netlify CMS is only tested with Chrome
@@ -72,7 +72,7 @@ exports.config = {
       'browserVersion': '11.285',
       'platformName': 'Windows 10',
       'sauce:options': {
-        screenResolution: '1024x768'
+        screenResolution: '1600x1200'
       },
       'exclude': [
         // Netlify CMS is only tested with Chrome
@@ -84,7 +84,7 @@ exports.config = {
       'browserVersion': 'latest',
       'platformName': 'Windows 10',
       'sauce:options': {
-        screenResolution: '1024x768'
+        screenResolution: '1600x1200'
       },
       'exclude': [
         // Netlify CMS is only tested with Chrome


### PR DESCRIPTION
## Additions

- Adds a toggle details button that toggles the show/hide button for details.

## Changes

- Makes the edit page button (and the toggle all button) always show text.
 
## Testing

1. Visit the PR preview branch and find a page that has details, such as buttons, and click the toggle details button in the lower-right.

## Screenshots
![toggle-details](https://user-images.githubusercontent.com/704760/87165207-d35a9280-c297-11ea-88ff-3e57b767d165.gif)

## Todos

- Is the state of the toggled details retained across pages? If so we need to save a cookie or similar.
- If some details are showing and some others aren't, how should the toggle button work? 