### PR TITLE
Add link to CMS instructions page for new users

### DIFF
--- a/docs/admin/config.yml
+++ b/docs/admin/config.yml
@@ -112,7 +112,7 @@ collections:
     fields:
       - name: 'title'
         label: 'Page title'
-        widget: 'string-trimmed'
+        widget: 'string-with-instructions'
       - name: 'collection_name'
         value: 'pages'
         default: 'pages'
@@ -257,7 +257,7 @@ collections:
     fields:
       - name: 'title'
         label: 'Page title'
-        widget: 'string-trimmed'
+        widget: 'string-with-instructions'
       - name: 'collection_name'
         value: 'special-pages'
         default: 'special-pages'

--- a/docs/admin/src/netlify-cms.js
+++ b/docs/admin/src/netlify-cms.js
@@ -2,11 +2,13 @@ import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import CMS from 'netlify-cms';
 import StringTrimmedControl from './widgets/StringTrimmed';
+import StringWithInstructionsControl from './widgets/StringWithInstructions';
 import genericPreviewTemplate from './widgets/genericPreviewTemplate';
 import navigationPreviewTemplate from './widgets/navigationPreviewTemplate';
 import pagePreviewTemplate from './widgets/pagePreviewTemplate';
 
 CMS.registerWidget( 'string-trimmed', StringTrimmedControl, 'string' );
+CMS.registerWidget( 'string-with-instructions', StringWithInstructionsControl, 'string' );
 
 CMS.registerPreviewTemplate( 'special-pages', genericPreviewTemplate );
 CMS.registerPreviewTemplate( 'pages', pagePreviewTemplate );

--- a/docs/admin/src/widgets/StringWithInstructions.js
+++ b/docs/admin/src/widgets/StringWithInstructions.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const instructionsContainerStyle = {
+  'color': '#444a57',
+  'padding': '20px 0 10px'
+};
+
+const instructionsLinkStyle = {
+  'color': '#444a57',
+  'font-size': '16px',
+  'font-weight': 'normal',
+  'text-decoration': 'underline'
+};
+
+export default class StringTrimmedControl extends React.Component {
+
+  static propTypes = {
+    onChange: PropTypes.func.isRequired,
+    forID: PropTypes.string,
+    value: PropTypes.node,
+    classNameWrapper: PropTypes.string.isRequired,
+    setActiveStyle: PropTypes.func.isRequired,
+    setInactiveStyle: PropTypes.func.isRequired,
+  };
+
+  state = {
+    value: this.props.value || ''
+  };
+
+  handleChange(event) {
+    this.props.onChange( event.target.value.trim() );
+    this.setState( { value: event.target.value } );
+  };
+
+  render() {
+    const {
+      forID,
+      classNameWrapper,
+      setActiveStyle,
+      setInactiveStyle,
+    } = this.props;
+
+    return (
+      <div>
+        <input
+          type='text'
+          id={forID}
+          className={classNameWrapper}
+          value={this.state.value}
+          onChange={event => this.handleChange( event )}
+          onFocus={setActiveStyle}
+          onBlur={setInactiveStyle}
+        />
+        <div style={instructionsContainerStyle}>
+          Need help? Check out our guide on&nbsp;
+          <a href='/design-system/updating-this-website/' target='_blank' style={instructionsLinkStyle}>
+            how to use this CMS
+          </a>.
+        </div>
+      </div>
+    );
+  }
+}

--- a/docs/admin/src/widgets/StringWithInstructions.js
+++ b/docs/admin/src/widgets/StringWithInstructions.js
@@ -54,7 +54,7 @@ export default class StringTrimmedControl extends React.Component {
         />
         <div style={instructionsContainerStyle}>
           Need help? Check out our guide on&nbsp;
-          <a href='/design-system/updating-this-website/' target='_blank' style={instructionsLinkStyle}>
+          <a href='/design-system/updating-this-website/' target='_blank' rel='noopener noreferrer' style={instructionsLinkStyle}>
             how to use this CMS
           </a>.
         </div>


### PR DESCRIPTION
Puts a sentence under pages' title field in the CMS directing users to our how-to page. It's done by creating a new widget that's identical to our string widget with the addition of a hyperlink.

This approach adds some redundant code but adding/editing widgets is the sustainable method of modifying the CMS's left-hand editing pane. The alternative would be forking netlify-cms and tweaking its source code which is a maintenance headache.

## Additions

- `StringWithInstructions` widget

## Testing

1. Cloud browser tests should pass below.
1. Everything should function as normal.
1. Try editing a page via the PR preview link below and you should see the new sentence under the title field.

## Screenshots

<img width="700" alt="Screen Shot 2020-07-13 at 12 36 03 PM" src="https://user-images.githubusercontent.com/1060248/87329991-e70b3080-c505-11ea-9c70-0e8643d8c2dc.png">

## Notes

I wanted to put the help text at the very top of the page, above all the fields BUT netlify doesn't let you touch the area above a field's label. It ended up looking like this which isn't great:

<img width="699" alt="Screen Shot 2020-07-08 at 1 21 53 PM" src="https://user-images.githubusercontent.com/1060248/87330091-0a35e000-c506-11ea-8fef-8d6c29b0e9b4.png">

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
