### PR TITLE
Fix footer timestamp links to GitHub histories

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -19,9 +19,11 @@
             <small>
                 <strong>Page last edited:</strong>
                 {% assign file_url_path = page.path | split: '/' | last %}
-                {% if page.section %}
-                    {% assign file_url_path = page.section | append: '/' | append: file_url_path %}
+                {% assign page_collection_name = 'pages' %}
+                {% if page.collection_name %}
+                    {% assign page_collection_name = page.collection_name %}
                 {% endif %}
+                {% assign file_url_path = page_collection_name | append: '/' | append: file_url_path %}
                 <a href="https://github.com/{{ site.repository }}/commits/master/docs/{{ file_url_path }}">
                     <time datetime="{{ page.last_modified_at }}">
                         {{ page.last_modified_at | date: "%l:%M:%S %p %b %d, %Y" }}


### PR DESCRIPTION
The recent IA change moved every page of the website into the `/docs/pages/`
directory with the exception of one-off special pages like the homepage
and the how-to page. Those live in `/docs/special-pages/` and have a
`collection_name` property created by netlify-cms indicating their specialness.

## Changes

- URL to GitHub history pages in footer

## Testing

1. Go to any page of the PR preview link below and click on the timestamp in the footer. They should all take you to a GitHub history page and not 404.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
