### PR TITLE
Add GitHub Action for running Lighthouse CI

### DIFF
--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -1,0 +1,85 @@
+name: Run Lighthouse against the docs
+
+on:
+  # Run every night at midnight UTC.
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  lighthouseci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Install Node and configure its cache.
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      # https://github.com/actions/cache/blob/master/examples.md#node---yarn
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      # Install Ruby and configure the Bundler cache.
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      # https://github.com/actions/cache/blob/master/examples.md#ruby---bundler
+      - name: Set up Bundler cache
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      # Build the docs and list of URLs to test.
+      - name: Build the documentation site
+        run: |
+          bundle config path vendor/bundle
+          yarn
+          yarn build
+
+      - name: Generate list of URLs to test
+        run: >
+          find docs/_site -type f -name "*.html" |
+          sed 's|^docs/_site||' |
+          sed '/^\/admin/d' |
+          sed 's/index.html$//' |
+          sed 's/.html$//' |
+          sort > urls.txt
+
+      - name: Try to set variable
+        run: echo "::set-env name=URLS::$(cat urls.txt | sed 's/^/--collect.url=http:\/\/localhost:4000\/design-system/' | tr '\n' ' ')"
+
+      # Install and run Lighthouse CI
+      - name: Install Lighthouse CI
+        run: npm install -g @lhci/cli@0.4.x
+
+      - name: Run Lighthouse CI
+        run: >
+          lhci autorun
+          --collect.settings.emulatedFormFactor=desktop
+          --collect.settings.onlyCategories=accessibility
+          --collect.numberOfRuns=1
+          --collect.startServerCommand="bundle exec jekyll serve --host=localhost --port=4000"
+          --collect.startServerReadyPattern="  Server running... press ctrl-c to stop."
+          ${{ env.URLS }}
+          --upload.target=temporary-public-storage
+
+      - name: Attach results as artifact to GitHub Actions run
+        uses: actions/upload-artifact@v1
+        with:
+          name: lighthouse-results
+          path: .lighthouseci

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ test/unit-test-coverage/
 docs/dist/
 docs/assets/icons/
 docs/_site
+.lighthouseci
 .sass-cache
 **/.jekyll-cache/
 .jekyll-metadata


### PR DESCRIPTION
This PR adds a new GitHub Action for running [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci) against the Design System documentation site. The full site is tested with Lighthouse every night at midnight UTC, using an emulated desktop browser. Results are both uploaded to Google's temporary public storage as well as attached to the Github Actions run as an artifact.

## Testing

See an example run on my fork [here](https://github.com/chosak/design-system/runs/870959613?check_suite_focus=true). From testing it takes between 15 and 20 minutes to run against the full site.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: