### PR TITLE
Fix variation horizontal rules and bottom padding

### DIFF
--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -86,24 +86,24 @@
             {% assign variation_description = variation.variation_description | strip | markdownify %}
             {% assign variation_code_snippet = variation.variation_code_snippet %}
 
-            {% unless variation_name == '' %}
+            {% if variation_name and variation_name != '' %}
             <div class="m-variation_name">
                 <h3>{{ variation_name }}</h3>
             </div>
-            {% endunless %}
+            {% endif %}
 
-            {% unless variation_description == '' %}
+            {% if variation_description and variation_description != '' %}
             <div class="m-variation_description">
                 {{ variation_description }}
             </div>
-            {% endunless %}
+            {% endif %}
 
             <!-- Live code example -->
-            {% unless variation_code_snippet == '' %}
+            {% if variation_code_snippet and variation_code_snippet != '' %}
             <div class="a-live_code">
                 {{ variation_code_snippet }}
             </div>
-            {% endunless %}
+            {% endif %}
 
             {% assign code_snippet = variation.variation_code_snippet | strip %}
             {% assign jinja_snippet = variation.variation_jinja_code_snippet | strip %}

--- a/docs/assets/css/tabs.less
+++ b/docs/assets/css/tabs.less
@@ -7,6 +7,7 @@
 // 40.0625em; 641px
 // if we change them in this CSS we also have to fork and release our own JS with updated breakpoints
 
+
 @media (min-width: 40.0625em) {
     .govuk-tabs {
         margin: 0 -1rem;
@@ -14,6 +15,7 @@
 }
 
 .govuk-tabs__list {
+    border-top: 1px solid @gray;
     margin: 0;
     padding: 0;
     list-style: none;

--- a/docs/assets/css/toggle-code-button.less
+++ b/docs/assets/css/toggle-code-button.less
@@ -1,14 +1,18 @@
 // Button to show/hide code snippets and specs on component pages
 
 .a-toggle_code {
-    border-bottom: 1px solid @gray-40;
     text-align: right;
     margin: 0 -1rem;
     padding: 0 2rem 1rem;
+
     .a-btn {
         text-transform: uppercase;
         &.u-hidden {
             display: none;
         }
     }
+}
+
+.m-variation:last-child .a-toggle_code {
+        padding-bottom: 0;
 }

--- a/docs/assets/css/variation.less
+++ b/docs/assets/css/variation.less
@@ -41,12 +41,19 @@
 
 
 .m-variation {
+    border-bottom: 1px solid @gray-40;
+
     &_name {
         margin-top: 2rem;
     }
 
     &:first-child .m-variation_name {
         margin-top: 0;
+    }
+
+    &:last-child {
+        border-bottom: 0;
+        padding-bottom: 1rem;
     }
 }
 


### PR DESCRIPTION
Horizontal rules separating variations was tied to variations' 'toggle details'
element. Thus, variations without any details to toggle lacked the line.

There was also no padding at the end of variation groups when the final
variation lacked details.

See https://[GHE]/CFPB/el-camino/issues/274

## Changes

- Variation and toggle code Less.

## Testing

1. In the PR preview below, there should be lines between the [logo lockups](https://cfpb.github.io/design-system/foundation/logo#lockups-1).
1. In the PR preview below, there should be padding at the bottom of the [email signup variations section](https://cfpb.github.io/design-system/patterns/e-mail-signup-forms#when-other-options-are-better).

## Screenshots

| before | after |
|--------|-------|
| <img width="905" alt="Screen Shot 2020-07-15 at 1 04 12 PM" src="https://user-images.githubusercontent.com/1060248/87574156-fcb25e80-c69b-11ea-8c24-1fef79f7dd15.png">   | <img width="905" alt="Screen Shot 2020-07-15 at 1 04 38 PM" src="https://user-images.githubusercontent.com/1060248/87574161-fe7c2200-c69b-11ea-9ada-466b6e6db4db.png">  |


| before | after |
|--------|-------|
| <img width="891" alt="Screen Shot 2020-07-15 at 1 04 56 PM" src="https://user-images.githubusercontent.com/1060248/87574163-ff14b880-c69b-11ea-80a3-34c82ba3c137.png">   | <img width="891" alt="Screen Shot 2020-07-15 at 1 05 43 PM" src="https://user-images.githubusercontent.com/1060248/87574164-ffad4f00-c69b-11ea-84af-ea5300221d21.png">  |

## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
