### PR TITLE
Properly check if related items section is empty

### DIFF
--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -313,7 +313,7 @@
     {% endif %}
 
     <div class="content-l u-mb45">
-        {% if page.related_items %}
+        {% if page.related_items and page.related_items != '' %}
         <div class="content-l_col content-l_col-1-2">
             <div>
                 <section>


### PR DESCRIPTION
This will hopefully prevent [empty related items sections](https://cfpb.github.io/design-system/foundation/iconography#related-items) from rendering.

## Changes

- Related items logic

## Testing

1. PR preview link below should not have an empty related items section on the iconography page.

