### PR TITLE
Update site footer and remove from homepage

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -2,16 +2,16 @@
 
     <hr>
 
-    {% if page.url != 'search/index' %}
     <div class="block block__sub">
         <p>
             <small>
-                Help improve this website by
-                <a href="https://github.com/{{ site.repository }}/issues/new?assignees=&labels=content%2C+help+wanted&template=component-needs-content-edits.md&title=Suggestions+for%3A+%22{{ page.title }}%22">filing an issue</a>
-                on GitHub,
-                <a href="{{ '/updating-this-website/#editing-pages' | relative_url }}">editing a page</a>
-                or
-                <a href="{{ '/updating-this-website/#creating-new-pages' | relative_url }}">creating a new page</a>.
+                We need your help keeping the Design System accurate and up-to-date!
+                If you see something wrong or missing,
+                <a href="{{ '/updating-this-website/#editing-pages' | relative_url }}">edit the page</a>.
+                If you can’t make those changes yourself,
+                <a href="https://github.com/{{ site.repository }}/issues/new?assignees=&labels=content%2C+help+wanted&template=component-needs-content-edits.md&title=Suggestions+for%3A+%22{{ page.title }}%22">file an issue</a>.
+                If you have a substantial change to an existing page, or a new standard you want to add to the Design System,
+                <a href="{{ '/updating-this-website/#creating-new-pages' | relative_url }}">follow these guidelines</a>.
             </small>
         </p>
 
@@ -32,6 +32,5 @@
             </small>
         </p>
     </div>
-    {% endif %}
 
 </footer>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -32,7 +32,9 @@
 
   {{ content }}
 
+  {% if page.url != 'search/index' and page.url != '/index' %}
   {% include footer.html %}
+  {% endif %}
   <script src="{{ "/dist/js/main.js" | relative_url }}" charset="utf-8"></script>
 
   {% if page.is_interstitial %}


### PR DESCRIPTION
## Changes

- Update site footer text.
- Remove footer on homepage.

## Testing

1. Visit branch preview PR and see that there is no footer on the homepage and other pages have updated footer text.

## Screenshot

<img width="1226" alt="Screen Shot 2020-07-17 at 8 48 36 AM" src="https://user-images.githubusercontent.com/704760/87787853-533dab00-c80a-11ea-8ce5-1c81fb430aaf.png">
