### PR TITLE
Add data viz color swatch classes

### DIFF
--- a/docs/assets/css/color-swatches.less
+++ b/docs/assets/css/color-swatches.less
@@ -98,6 +98,12 @@
 // Initiate loop
 .color-swatch-loop( length( @colors ) );
 
+// Data viz swatches that have not yet been officially adopted as brand colors in brand-colors.less
+.swatch_field__mid-dark-green { background: #1fa040 }
+.swatch_field__navy-50 { background: #9daecc }
+.swatch_field__gold-70 { background: #ffc372 }
+.swatch_field__purple-50 { background: #dc9cbf }
+
 .color-table {
     width: 100%;
     margin-bottom: unit( 45px / @base-font-size-px, em );


### PR DESCRIPTION
We have some unique colors that are used in our data visualizations
but haven't made their way into our official brand-colors.less stylesheet.
To prevent empty color swatches from appearing in our data viz section of
the website, I have manually created their CSS classes.

## Additions

- Data viz color CSS classes.

## Testing

1. [These tables](https://cfpb.github.io/design-system/foundation/color#data-visualization-palettes) have empty color sections while the [same tables of the PR preview website](https://deploy-preview-930--cfpb-design-system.netlify.app/design-system/foundation/color#data-visualization-palettes) do not.

## Screenshots

| before | after |
|--------|-------|
| <img width="904" alt="Screen Shot 2020-07-17 at 1 19 49 PM" src="https://user-images.githubusercontent.com/1060248/87813672-5ea3cd00-c830-11ea-9ee1-076be7c17b4c.png">   | <img width="904" alt="Screen Shot 2020-07-17 at 1 19 53 PM" src="https://user-images.githubusercontent.com/1060248/87813682-62cfea80-c830-11ea-99db-1dcfd387892b.png">  |

## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
