### PR TITLE
Add local storage for remembering the toggle state

### DIFF
--- a/docs/_layouts/homepage.html
+++ b/docs/_layouts/homepage.html
@@ -9,7 +9,7 @@ layout: default
         <a class="a-btn" href="
             {{- '/admin/#/collections/special-pages/entries/home' | relative_url
             -}}" title="Edit this page in Netlify CMS">
-            <span class="a-btn_text">Edit this page</span>
+            <span class="a-btn_text">Edit page</span>
             <span class="a-btn_icon">{% include icons/edit.svg %}</span>
         </a>
     </div>

--- a/docs/_layouts/variation.html
+++ b/docs/_layouts/variation.html
@@ -26,7 +26,7 @@ layout: default
             <a class="a-btn"
                href="/design-system/updating-this-website?page={{ page.title | url_encode }}"
                title="Edit this page in Netlify CMS">
-                <span class="a-btn_text">Edit this page</span>
+                <span class="a-btn_text">Edit page</span>
                 <span class="a-btn_icon">{% include icons/edit.svg %}</span>
             </a>
         </div>

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -42,7 +42,13 @@ if ( tabs && tabs.length > 0 ) {
 const toggleAllBtn = document.querySelector( '#toggle-details' );
 const toggleBtns = document.querySelectorAll( '.a-toggle_code button' );
 
-toggleAllBtn.addEventListener( 'click', handleToggleAllClick, false );
+if ( toggleAllBtn ) {
+  toggleAllBtn.addEventListener( 'click', handleToggleAllClick, false );
+
+  if ( window.localStorage.getItem( 'toggleState' ) === 'hide' ) {
+    toggleAllDetails( toggleAllBtn );
+  }
+}
 
 for ( let i = 0, len = toggleBtns.length; i < len; i++ ) {
   toggleBtns[i].addEventListener( 'click', handleToggleClick, false );

--- a/docs/assets/js/toggle-details.js
+++ b/docs/assets/js/toggle-details.js
@@ -46,9 +46,11 @@ function toggleAllDetails( toggleBtn ) {
   if ( isShowingAllDetails ) {
     toggleBtn.querySelector( '.a-btn_text' ).innerHTML = 'Show all details';
     toggleBtn.setAttribute( 'title', 'Show all details' );
+    window.localStorage.setItem( 'toggleState', 'show' );
   } else {
     toggleBtn.querySelector( '.a-btn_text' ).innerHTML = 'Hide all details';
     toggleBtn.setAttribute( 'title', 'Hide all details' );
+    window.localStorage.setItem( 'toggleState', 'hide' );
   }
 
   const codeEls = document.querySelectorAll( '.a-toggle_code' );


### PR DESCRIPTION
## Changes

- Add local storage for remembering the toggle state across pages on the DS.
- Change "Edit this page" to "Edit page"

## Testing

1. View the PR preview branch and click the Show all details button on a component page and then visit another component page and see that the toggle is in the same state. Close the session and open the PR preview branch again and see that the toggle button is in the same state as when you last visited.
