### PR TITLE
Fix iOS navigation bug

### DIFF
--- a/docs/assets/js/sidebar.js
+++ b/docs/assets/js/sidebar.js
@@ -5,15 +5,26 @@
 function init() {
   const secondaryNavCat = document.querySelector( '.ds-nav-container' );
 
+  // First collapse the navigation if in mobile.
+  if ( innerWidth < 601 ) {
+    secondaryNavCat.removeAttribute( 'open' );
+  }
+
+  let windowWidth = window.innerWidth;
   /**
    * Test the viewport size and set whether the test passes on the instance.
    */
   function handleViewportChange() {
-    if ( window.innerWidth < 601 ) {
-      secondaryNavCat.removeAttribute( 'open' );
-
-    } else {
-      secondaryNavCat.setAttribute( 'open', 'open' );
+    // Collapse the navigation if we resize to mobile,
+    // but only if we haven't already.
+    // Otherwise, we're on desktop size, so open the navigation.
+    let innerWidth = window.innerWidth;
+    if ( innerWidth !== windowWidth ) {
+      if ( innerWidth < 601 ) {
+        secondaryNavCat.removeAttribute( 'open' );
+      } else {
+        secondaryNavCat.setAttribute( 'open', 'open' );
+      }
     }
   }
 

--- a/docs/assets/js/sidebar.js
+++ b/docs/assets/js/sidebar.js
@@ -6,11 +6,11 @@ function init() {
   const secondaryNavCat = document.querySelector( '.ds-nav-container' );
 
   // First collapse the navigation if in mobile.
-  if ( innerWidth < 601 ) {
+  let windowWidth = window.innerWidth;
+  if ( windowWidth < 601 ) {
     secondaryNavCat.removeAttribute( 'open' );
   }
 
-  let windowWidth = window.innerWidth;
   /**
    * Test the viewport size and set whether the test passes on the instance.
    */
@@ -19,12 +19,14 @@ function init() {
     // but only if we haven't already.
     // Otherwise, we're on desktop size, so open the navigation.
     let innerWidth = window.innerWidth;
-    if ( innerWidth !== windowWidth ) {
-      if ( innerWidth < 601 ) {
-        secondaryNavCat.removeAttribute( 'open' );
-      } else {
-        secondaryNavCat.setAttribute( 'open', 'open' );
-      }
+    if ( innerWidth === windowWidth ) {
+      return;
+    }
+
+    if ( innerWidth < 601 ) {
+      secondaryNavCat.removeAttribute( 'open' );
+    } else {
+      secondaryNavCat.setAttribute( 'open', 'open' );
     }
   }
 

--- a/docs/assets/js/sidebar.js
+++ b/docs/assets/js/sidebar.js
@@ -6,7 +6,7 @@ function init() {
   const secondaryNavCat = document.querySelector( '.ds-nav-container' );
 
   // First collapse the navigation if in mobile.
-  let windowWidth = window.innerWidth;
+  const windowWidth = window.innerWidth;
   if ( windowWidth < 601 ) {
     secondaryNavCat.removeAttribute( 'open' );
   }
@@ -18,7 +18,7 @@ function init() {
     // Collapse the navigation if we resize to mobile,
     // but only if we haven't already.
     // Otherwise, we're on desktop size, so open the navigation.
-    let innerWidth = window.innerWidth;
+    const innerWidth = window.innerWidth;
     if ( innerWidth === windowWidth ) {
       return;
     }


### PR DESCRIPTION
iOS triggers a resize event when scrolling that was causing the navigation menu to close unexpectedly. This PR first checks if the window size has actually changed before closing the menu.

## Changes

- Check that window size has changed before closing or opening the sidebar navigation menu.

## Testing

1. Pull branch and run locally. 
2. Open the iOS simulator (Applications > Xcode > [right-click Show Package Contents] > Contents > Developer > Applications > Simulator.app)
3. Open the localhost:4000/design-system in the Simulator.
4. Open the navigation menu.
5. Scroll down the page. The menu should not close on its own.
