### PR TITLE
Build docs into design-system subdirectory

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ exclude: [package.json, webpack.config.js, yarn.lock]
 highlighter: rouge
 timezone: America/New_York
 source: docs
-destination: docs/_site
+destination: docs/_site/design-system
 
 # Organization
 org: CFPB

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -2,7 +2,7 @@ const glob = require( 'glob' );
 const path = require( 'path' );
 
 const filenames = glob.sync( '**/*.html', {
-  cwd: path.join( __dirname, 'docs/_site' ),
+  cwd: path.join( __dirname, 'docs/_site/design-system' ),
   ignore: 'admin/**',
   nonull: false
 } );

--- a/scripts/build-netlify-pr-preview.sh
+++ b/scripts/build-netlify-pr-preview.sh
@@ -4,10 +4,3 @@ set -eu
 
 yarn
 yarn run build-netlify
-
-# The design system website lives at cfpb.github.io/design-system
-# To simulate this with the PR preview websites we put the compiled
-# Jekyll site into a design-system/ sub directory
-mv docs/_site/ docs/_site-tmp/
-mkdir -p docs/_site/design-system
-mv docs/_site-tmp/* docs/_site/design-system/

--- a/scripts/update-gh-pages.sh
+++ b/scripts/update-gh-pages.sh
@@ -8,7 +8,7 @@ repo_uri="https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
 remote_name="origin"
 main_branch="master"
 target_branch="gh-pages"
-target_dir="docs/_site/"
+target_dir="docs/_site/design-system/"
 
 cd "$GITHUB_WORKSPACE"
 


### PR DESCRIPTION
Currently we build the docs under `docs/_site`. Instead let's build them under `docs/_site/design-system`, which will simplify a couple of downstream consumers.

Hopefully the Netlify preview site builds properly here.