### PR TITLE
Delete old branch workflow that is no longer used

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,9 +1,0 @@
-workflow "delete merged branch" {
-  on = "pull_request"
-  resolves = ["Delete merged branch"]
-}
-
-action "Delete merged branch" {
-  uses = "cfpb/delete-merged-branch@master"
-  secrets = ["GITHUB_TOKEN"]
-}


### PR DESCRIPTION
GitHub now natively supports the deleting of branches from a repo's
settings screen so this workflow is not needed.

## Removals

- Stale workflow

## Testing

1. When this PR is merged, the `delete-branch-workflow` should be automatically deleted.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
