### PR TITLE
Don't run browser tests on forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,11 @@ jobs:
         sleep 5
 
     - name: Run browser tests
+      # Don't run these tests on forks. It would be nice to instead check
+      # to see if the Sauce Labs environment variables are defined, but that
+      # doesn't seem currently possible:
+      # https://github.com/actions/runner/issues/520
+      if: ${{ github.repository_owner == 'cfpb' }}
       env:
         # These credentials are from @contolini's CFPB Sauce Labs account
         # They're defined on the repo's settings page:


### PR DESCRIPTION
The browser tests require Sauce credentials to be defined in GitHub repo settings (SAUCE_USERNAME and SAUCE_ACCESS_KEY). If these credentials aren't defined, the tests will fail. Unfortunately this means that if you have a fork without a Sauce account, you can't pass the test.

This change modifies the browser tests Action so that it won't run when on a fork. It would be better to somehow disable the tests only if those credentials aren't defined, but I couldn't find an easy way to do so.