### PR TITLE
Expand expandables when printing

### DIFF
--- a/docs/assets/css/netlify.less
+++ b/docs/assets/css/netlify.less
@@ -32,9 +32,9 @@
 	}
 
 	// Hide the admin buttons when printing
-	.respond-to-print({
+	.respond-to-print( {
 		display: none;
-	});
+	} );
 }
 
 // Don't show the toggle code button in the Netlify CMS preview pane

--- a/docs/assets/css/netlify.less
+++ b/docs/assets/css/netlify.less
@@ -30,6 +30,11 @@
 			margin-left: 0.4375em;
 		}
 	}
+
+	// Hide the admin buttons when printing
+	.respond-to-print({
+		display: none;
+	});
 }
 
 // Don't show the toggle code button in the Netlify CMS preview pane

--- a/packages/cfpb-expandables/src/cfpb-expandables.less
+++ b/packages/cfpb-expandables/src/cfpb-expandables.less
@@ -62,14 +62,12 @@
             display: none;
         }
 
-        &__expanded .o-expandable_cue-close,
+        &__expanded .o-expandable_cue-close {
+            display: block;
+        }
+
         &__collapsed .o-expandable_cue-open {
             display: block;
-
-            // Hide the interactive expandable cues when printing
-            .respond-to-print({
-                display: none;
-            });
         }
     }
 
@@ -86,14 +84,6 @@
 
         &__collapsed {
             max-height: 0;
-
-            // Ensure all expandables are expanded when printing.
-            // To accommodate print stylesheets that display the raw URL after links,
-            // set an enormous max height to accommodate expandables that have a lot of links.
-            .respond-to-print({
-                display: block;
-                max-height: 99999px !important;
-            });
         }
 
         &__expanded {
@@ -207,4 +197,20 @@
             }
         }
     }
+
+    .respond-to-print( {
+        // Hide the interactive expandable cues when printing
+        &_target__expanded &_cue-close,
+        &_target__collapsed &_cue-open {
+            display: none;
+        }
+
+        // Ensure all expandables are expanded when printing.
+        // To accommodate print stylesheets that display the raw URL after links,
+        // set an enormous max height to accommodate expandables that have a lot of links.
+        &_content__collapsed {
+            display: block;
+            max-height: 99999px !important;
+        }
+    } );
 }

--- a/packages/cfpb-expandables/src/cfpb-expandables.less
+++ b/packages/cfpb-expandables/src/cfpb-expandables.less
@@ -62,12 +62,14 @@
             display: none;
         }
 
-        &__expanded .o-expandable_cue-close {
-            display: block;
-        }
-
+        &__expanded .o-expandable_cue-close,
         &__collapsed .o-expandable_cue-open {
             display: block;
+
+            // Hide the interactive expandable cues when printing
+            .respond-to-print({
+                display: none;
+            });
         }
     }
 
@@ -84,6 +86,14 @@
 
         &__collapsed {
             max-height: 0;
+
+            // Ensure all expandables are expanded when printing.
+            // To accommodate print stylesheets that display the raw URL after links,
+            // set an enormous max height to accommodate expandables that have a lot of links.
+            .respond-to-print({
+                display: block;
+                max-height: 99999px !important;
+            });
         }
 
         &__expanded {


### PR DESCRIPTION
Expand expandables when printing so that users get the entire page's content.

See https://github.local/CFPB/el-camino/issues/299

## Changes

- Hide the netlify CMS floating buttons when printing because why not. They block the page text.
- Hide the `Show`/`Hide` buttons when printing because they're irrelevant (and if we left them, it'd incorrectly say `Show` above expandables that are now open when printed)
- Sets a large max-height when printing because we display the raw URLs next to links which causes the expandable's content height to be greater than the non-print height, causing this bug:

<img width="827" alt="3a0a0300-e6c2-11ea-8345-8a0365b5283a" src="https://user-images.githubusercontent.com/1060248/91471510-37471380-e864-11ea-9b7e-fabb3026c8fc.png">

## Testing

1. Visit the PR preview link below and view a print preview of the expandables page. They should all be expanded.

## Screenshots

<img width="602" alt="Screen Shot 2020-08-27 at 12 55 45 PM" src="https://user-images.githubusercontent.com/1060248/91471913-ade41100-e864-11ea-808d-ded7454750ee.png">

## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
