### PR TITLE
Fix plugin path to remove hardcoding

### DIFF
--- a/packages/cfpb-icons/src/icons-svg-inline.js
+++ b/packages/cfpb-icons/src/icons-svg-inline.js
@@ -20,12 +20,17 @@ module.exports = {
      */
     functions.add( 'icons-svg-inline', ( svgName, svgFillColor ) => {
       // Retrieve this plugin script's path so we can fake __dirname.
-      // When less is updated, the installedPlugins[x] index value may need to
-      // be updated. If you receive an error when building that's like
-      // "The "path" argument must be of type string. Received undefined"
-      // Add console.log( pluginManager.installedPlugins ) and look for the
-      // index value that has a filename property that points to this file.
-      const thisScriptPath = pluginManager.installedPlugins[2].filename;
+      let filenamePathPieces;
+      let thisScriptPath;
+      for ( let i = 0, len =  pluginManager.installedPlugins.length; i < len; i++ ) {
+        if ( typeof pluginManager.installedPlugins[i].filename !== 'undefined' ) {
+          thisScriptPath = pluginManager.installedPlugins[i].filename;
+          filenamePathPieces = thisScriptPath.split('/');
+          if ( filenamePathPieces[filenamePathPieces.length-1] === 'icons-svg-inline.js' ) {
+            break;
+          }
+        }
+      }
 
       // __dirname is not accessible in this script, so this fakes it.
       const __dirname = path.dirname( thisScriptPath );


### PR DESCRIPTION
Plugin positon in the less plugins index will vary by the environment this file is built in, so we need to scan the plugins instead of having a hardcoded position.

## Changes

- Make plugin index position dynamic.

## Testing

1. `yarn build` should pass.
