### PR TITLE
cfpb-core: Indent numbered lists

### DIFF
--- a/docs/pages/lists.md
+++ b/docs/pages/lists.md
@@ -55,6 +55,17 @@ variation_groups:
           presented in the order of importance, or a finite list of a counted
           number of items.
         variation_code_snippet: |-
+          <p>Less than 10 items is not indented.</p>
+          <ol>
+              <li>List item 1</li>
+              <li>List item 2</li>
+              <li>List item 3</li>
+          </ol>
+
+          <p>
+            More than 9 items is indented to align double digits.
+            Inner lists are not indented, regardless of number of items.
+          </p>
           <ol>
               <li>List item 1</li>
               <li>
@@ -70,9 +81,16 @@ variation_groups:
                         <li>Nested item 2-8</li>
                         <li>Nested item 2-9</li>
                         <li>Nested item 2-10</li>
+
                   </ol>
               </li>
-              <li>List item 3</li>
+              <li>List item 3
+                  <ol>
+                        <li>Nested item 3-1</li>
+                        <li>Nested item 3-2</li>
+                        <li>Nested item 3-3</li>
+                  </ol>
+              </li>
               <li>List item 4</li>
               <li>List item 5</li>
               <li>List item 6</li>

--- a/docs/pages/lists.md
+++ b/docs/pages/lists.md
@@ -63,9 +63,23 @@ variation_groups:
                         <li>Nested item 2-1</li>
                         <li>Nested item 2-2</li>
                         <li>Nested item 2-3</li>
+                        <li>Nested item 2-4</li>
+                        <li>Nested item 2-5</li>
+                        <li>Nested item 2-6</li>
+                        <li>Nested item 2-7</li>
+                        <li>Nested item 2-8</li>
+                        <li>Nested item 2-9</li>
+                        <li>Nested item 2-10</li>
                   </ol>
               </li>
               <li>List item 3</li>
+              <li>List item 4</li>
+              <li>List item 5</li>
+              <li>List item 6</li>
+              <li>List item 7</li>
+              <li>List item 8</li>
+              <li>List item 9</li>
+              <li>List item 10</li>
           </ol>
         variation_specs: >-
           #### Default

--- a/docs/pages/lists.md
+++ b/docs/pages/lists.md
@@ -64,7 +64,7 @@ variation_groups:
 
           <p>
             More than 9 items is indented to align double digits.
-            Inner lists are not indented, regardless of number of items.
+            Inner lists are not indented, regardless of the number of items.
           </p>
           <ol>
               <li>List item 1</li>

--- a/packages/cfpb-core/src/base.less
+++ b/packages/cfpb-core/src/base.less
@@ -371,6 +371,11 @@ li {
     }
 }
 
+ol li {
+    // 0.3rem.
+    margin-left: unit( 4.8px / @base-font-size-px, rem );
+}
+
 ol ol {
     list-style-type: lower-alpha;
 }

--- a/packages/cfpb-core/src/base.less
+++ b/packages/cfpb-core/src/base.less
@@ -459,8 +459,8 @@ ol {
 
     li:nth-last-child(n+10),
     li:nth-last-child(n+10) ~ li {
-        // 0.5rem.
-        margin-left: unit( 8px / @base-font-size-px, rem );
+        // 0.5625rem
+        margin-left: unit( 9px / @base-font-size-px, rem );
     }
 }
 

--- a/packages/cfpb-core/src/base.less
+++ b/packages/cfpb-core/src/base.less
@@ -371,11 +371,6 @@ li {
     }
 }
 
-ol li {
-    // 0.3rem.
-    margin-left: unit( 4.8px / @base-font-size-px, rem );
-}
-
 ol ol {
     list-style-type: lower-alpha;
 }
@@ -461,6 +456,19 @@ ol {
     // Slightly larger than necessary, but this is the minimum value
     // for numbers to not be partially in the margin in Internet Explorer.
     padding-left: unit( 21px / @base-font-size-px, em );
+
+    li:nth-last-child(n+10),
+    li:nth-last-child(n+10) ~ li {
+        // 0.5rem.
+        margin-left: unit( 8px / @base-font-size-px, rem );
+    }
+}
+
+ol ol {
+    // Negate margin added to lists longer than 9 items.
+    li {
+        margin-left: 0 !important;
+    }
 }
 
 //


### PR DESCRIPTION
## Changes

- Indents numbered lists 0.3rem to avoid clipping that can happen when lists are double digits. 

## Testing

1. Check lists page in the design system on this PR preview link.

## Screenshots

<img width="790" alt="Screen Shot 2020-10-06 at 12 06 23 PM" src="https://user-images.githubusercontent.com/704760/95227672-612d1780-07cc-11eb-8c3b-fecd424e33a8.png">

Before:

<img width="764" alt="Screen Shot 2020-10-06 at 12 03 56 PM" src="https://user-images.githubusercontent.com/704760/95227432-1d3a1280-07cc-11eb-8922-3b5ceebfd24b.png">

After:

<img width="783" alt="Screen Shot 2020-10-06 at 12 04 19 PM" src="https://user-images.githubusercontent.com/704760/95227460-232ff380-07cc-11eb-9932-3e4ea14f5a8b.png">
