### PR TITLE
Remove object shorthand to aid IE11

### DIFF
--- a/docs/assets/js/redirect-banner.js
+++ b/docs/assets/js/redirect-banner.js
@@ -59,4 +59,6 @@ function init() {
   }
 }
 
-export default { init };
+export default {
+  init: init
+};

--- a/docs/assets/js/sidebar.js
+++ b/docs/assets/js/sidebar.js
@@ -39,4 +39,6 @@ function init() {
   } );
 }
 
-export default { init };
+export default {
+  init: init
+};

--- a/packages/cfpb-atomic-component/src/utilities/type-checkers/index.js
+++ b/packages/cfpb-atomic-component/src/utilities/type-checkers/index.js
@@ -164,13 +164,13 @@ function isEmpty( value ) {
 
 // Expose public methods.
 export default {
-  isUndefined,
-  isDefined,
-  isObject,
-  isString,
-  isNumber,
-  isDate,
-  isArray,
-  isFunction,
-  isEmpty
+  isUndefined: isUndefined,
+  isDefined: isDefined,
+  isObject: isObject,
+  isString: isString,
+  isNumber: isNumber,
+  isDate: isDate,
+  isArray: isArray,
+  isFunction: isFunction,
+  isEmpty: isEmpty
 };

--- a/webpack.config.docs.js
+++ b/webpack.config.docs.js
@@ -70,7 +70,16 @@ module.exports = ( env, argv ) => {
             path.resolve( __dirname, 'packages' )
           ],
           use: {
-            loader: 'babel-loader'
+            loader: 'babel-loader',
+            options: {
+              presets: [ [ '@babel/preset-env', {
+
+                /* Use useBuiltIns: 'usage' and set `debug: true` to see what
+                   scripts require polyfilling. */
+                useBuiltIns: false,
+                debug: false
+              } ] ]
+            }
           }
         },
         {


### PR DESCRIPTION
IE11 does not like ES6 object shorthand. Instead of polyfilling all the places this is used, this PR just removes the shorthand.

## Changes

- Remove ES6 object shorthand to support IE11 limitations.

## Testing

1. PR tests should pass.
