### PR TITLE
Add datepicker markup

### DIFF
--- a/docs/pages/text-inputs.md
+++ b/docs/pages/text-inputs.md
@@ -120,6 +120,17 @@ variation_groups:
               <textarea class="a-text-input a-text-input__full"
                         id="full-textarea-example">Placeholder text</textarea>
           </div>
+      - variation_name: Datepicker inputs
+        variation_code_snippet: >-
+          <div class="m-form-field">
+              <label class="a-label a-label__heading" for="datepicker-example">
+                  Label
+              </label>
+              <input class="a-text-input"
+                    type="date"
+                    id="datepicker-example"
+                    placeholder="mm/dd/yyyy">
+          </div>
       - variation_name: Text input with a button
         variation_description: These are used for simple forms where a full filter isn’t necessary.
         variation_code_snippet: |-


### PR DESCRIPTION
## Additions

- Adds date picker inputs to the DS.

## Testing

1. See the text inputs page on the PR preview.

## Screenshots

<img width="257" alt="Screen Shot 2020-11-16 at 11 31 36 AM" src="https://user-images.githubusercontent.com/704760/99280438-54ee9e00-27ff-11eb-9ae1-548f2e7eab37.png">

## Notes

This has the bug where the input increases in width when first mousing over it. Let me know if you see a reason that is happening. It appears to be DS specific, since it doesn't happen in the blog filter in cf.gov.