### PR TITLE
Update normalize paths

### DIFF
--- a/packages/cfpb-core/src/cfpb-core.less
+++ b/packages/cfpb-core/src/cfpb-core.less
@@ -3,8 +3,8 @@
    Core Less file
    ========================================================================== */
 
-@import (less) '../../../normalize-css/normalize.css';
-@import (less) '../../../normalize-legacy-addon/normalize-legacy-addon.css';
+@import (less) 'normalize-css/normalize.css';
+@import (less) 'normalize-legacy-addon/normalize-legacy-addon.css';
 @import (less) 'brand-colors.less';
 @import (less) 'vars-breakpoints.less';
 @import (less) 'vars.less';

--- a/packages/cfpb-grid/src/cfpb-grid.less
+++ b/packages/cfpb-grid/src/cfpb-grid.less
@@ -5,8 +5,8 @@
 
 // Import external dependencies
 
-@import (less) '../../../normalize-css/normalize.css';
-@import (less) '../../../normalize-legacy-addon/normalize-legacy-addon.css';
+@import (less) 'normalize-css/normalize.css';
+@import (less) 'normalize-legacy-addon/normalize-legacy-addon.css';
 
 //
 // Less variables


### PR DESCRIPTION
The current paths to the normalize CSS works in the cf.gov repo, but breaks here. I think if we remove the path it'll just look into the `node_modules` where ever it's used.

## Changes

- Update normalize paths

## Testing

1. `gulp build` should pass.