### PR TITLE
Hide multiselect horizontal scroll, wrap checkbox label text

### DIFF
--- a/docs/pages/dropdowns.md
+++ b/docs/pages/dropdowns.md
@@ -132,7 +132,7 @@ variation_groups:
                   <option value="option5">Option 5</option>
                   <option value="option6">Option 6</option>
                   <option value="option7">Option 7</option>
-                  <option value="option8">Option 8</option>
+                  <option value="option8">Multiselect options can also contain long words that will be wrapped like supercalifragilisticexpialidocious</option>
               </select>
           </div>
     variation_group_description: "Custom JavaScript may be required to make the

--- a/packages/cfpb-forms/src/molecules/form-fields.less
+++ b/packages/cfpb-forms/src/molecules/form-fields.less
@@ -26,6 +26,8 @@
             grid-template-columns: unit( 30px / @base-font-size-px, em ) auto;
             vertical-align: top;
             cursor: pointer;
+            // Wrap long words in narrow form fields to prevent clipping
+            overflow-wrap: anywhere;
 
             &:before {
                 display: inline-block;

--- a/packages/cfpb-forms/src/organisms/multiselect.less
+++ b/packages/cfpb-forms/src/organisms/multiselect.less
@@ -28,6 +28,7 @@ select.o-multiselect {
 
         // Styles
         box-sizing: border-box;
+        overflow-x: hidden;
         overflow-y: scroll;
         position: absolute;
         z-index: 10;
@@ -53,6 +54,8 @@ select.o-multiselect {
     &_options {
         background-color: @white;
         padding: unit( 10px / @base-font-size-px, em );
+        // Double padding on the right to accommodate the fieldset's forced y scrollbar above
+        padding-right: unit( 20px / @base-font-size-px, em );
 
         li:last-child {
             margin-bottom: 0;


### PR DESCRIPTION
Remove multiselects' horizontal scrollbar by hiding overflow-x and ensure content is never clipped by breaking long words to new lines with overflow-wrap.

See https://github.local/CFGOV/platform/issues/3290 and https://github.local/CFPB/el-camino/issues/346

The word wrapping is necessary because we sometimes use multiselects in very narrow columns and words like "Servicemembers" are longer than the width of the column:

<img width="366" alt="blog" src="https://user-images.githubusercontent.com/1060248/99590808-dab74880-29bb-11eb-8141-0c25e3ca6750.png">

## Testing

1. Compare the [DS multiselect](https://cfpb.github.io/design-system/components/dropdowns-and-multiselects) with localhost or the PR preview at a variety of screen widths.

## Screenshots

| before | after |
|--------|-------|
| <img width="339" alt="before" src="https://user-images.githubusercontent.com/1060248/99590247-1bfb2880-29bb-11eb-9cc6-1a8d3907e0a2.png">   | <img width="339" alt="after" src="https://user-images.githubusercontent.com/1060248/99590265-1f8eaf80-29bb-11eb-8285-7c4439f18b2c.png">  |

## Notes

- The overflow-wrap change also affects checkboxes and radio buttons to accommodate the rare scenario that a checkbox has a massive word on a tiny screen:

<img width="261" alt="checkboxes" src="https://user-images.githubusercontent.com/1060248/99590424-52d13e80-29bb-11eb-81e8-9befe609f856.png">


## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
