### PR TITLE
Add beige family colors for seal

### DIFF
--- a/docs/assets/css/color-swatches.less
+++ b/docs/assets/css/color-swatches.less
@@ -74,7 +74,10 @@
 
 }
 
-@colors: 'green-dark',
+@colors: 'beige',
+         'beige-30',
+         'beige-60',
+         'green-dark',
          'green-mid-dark',
          'green',
          'green-90',

--- a/packages/cfpb-core/src/brand-colors.less
+++ b/packages/cfpb-core/src/brand-colors.less
@@ -4,31 +4,36 @@
    ========================================================================== */
 
 // Official CFPB color palette.
-// Current as of August 26, 2020.
+// Current as of November 20, 2020.
 // To view the colors in the Design System, visit:
 // https://cfpb.github.io/design-system/foundation/color
 //
-//           | Green  | Teal   | Pacific | Navy   | Purple | Red    | Gold   | Neutral | Gray   |
-//           | ------ | ------ | ------- | ------ | ------ | ------ | ------ | ------- | ------ |
-// darker    |        |        |         |        |        |        |        |         | 293037 |
-// dark      | 1e9642 | 005e5d | 0050b4  | 002d72 | a01b68 | b63014 | dc731c | 745745  | 43484e |
-// mid-dark  | 1fa040 | 126b69 | 0061c1  | 123c7c | aa2071 | c3381c | ed881b | 7d604b  | 4f5257 |
-// base      | 20aa3f | 257675 | 0072ce  | 254b87 | b4267a | d14124 | ff9e1b | 8a6c57  | 5a5d61 |
-//   90      | 48b753 | 3e8685 | 2284d5  | 3e5f95 | be438b | d75a40 | ffab39 | 957865  | 676a6f |
-//   80      | 66c368 | 579695 | 4497dc  | 5674a3 | c55998 | dd735d | ffb858 | a18573  | 75787b |
-//   70      | 93cf7c | 70a6a5 | 61a7e2  | 6f88b2 | cd70a5 | e28875 | ffc372 | ad9484  | 838588 |
-//   60      | addc91 | 89b6b5 | 7eb7e8  | 889cc0 | d486b2 | e79e8e | ffce8d | baa496  | 919395 |
-//   50      | bae0a2 | 9ec4c3 | 96c4ed  | 9daecc | dc9cbf | ebb0a3 | ffd8a3 | c6b4a9  | a2a3a4 |
-//   40      | c7e5b3 | b4d2d1 | afd2f2  | b3c0d9 | e3b2cc | f0c3b8 | ffe1b9 | d3c5bc  | b4b5b6 |
-//   30      | d4eac6 | c4dddc | c3ddf6  | c3cde2 | ebc9d9 | f3d1c8 | ffe8cb | ddd1c9  | c3c4c4 |
-//   20      | e2efd8 | d4e7e6 | d6e8fa  | d3daeb | f0d8e2 | f7e0d9 | fff0dd | e7ddd7  | d2d3d5 |
-//   15      |        |        |         |        |        |        |        |         | dcdddf |
-//   10      | f0f8eb | f0f7f6 | eff8fd  | f4f6fa | fdf3f8 | fbefec | fff6ec | f8f5f2  | e7e8e9 |
-//    5      |        |        |         |        |        |        |        |         | f7f8f9 |
+//           | Beige  | Green  | Teal   | Pacific | Navy   | Purple | Red    | Gold   | Neutral | Gray   |
+//           | ------ | ------ | ------ | ------- | ------ | ------ | ------ | ------ | ------- | ------ |
+// darker    |        |        |        |         |        |        |        |        |         | 293037 |
+// dark      |        | 1e9642 | 005e5d | 0050b4  | 002d72 | a01b68 | b63014 | dc731c | 745745  | 43484e |
+// mid-dark  |        | 1fa040 | 126b69 | 0061c1  | 123c7c | aa2071 | c3381c | ed881b | 7d604b  | 4f5257 |
+// base      | bea96f | 20aa3f | 257675 | 0072ce  | 254b87 | b4267a | d14124 | ff9e1b | 8a6c57  | 5a5d61 |
+//   90      |        | 48b753 | 3e8685 | 2284d5  | 3e5f95 | be438b | d75a40 | ffab39 | 957865  | 676a6f |
+//   80      |        | 66c368 | 579695 | 4497dc  | 5674a3 | c55998 | dd735d | ffb858 | a18573  | 75787b |
+//   70      |        | 93cf7c | 70a6a5 | 61a7e2  | 6f88b2 | cd70a5 | e28875 | ffc372 | ad9484  | 838588 |
+//   60      | d8c8a0 | addc91 | 89b6b5 | 7eb7e8  | 889cc0 | d486b2 | e79e8e | ffce8d | baa496  | 919395 |
+//   50      |        | bae0a2 | 9ec4c3 | 96c4ed  | 9daecc | dc9cbf | ebb0a3 | ffd8a3 | c6b4a9  | a2a3a4 |
+//   40      |        | c7e5b3 | b4d2d1 | afd2f2  | b3c0d9 | e3b2cc | f0c3b8 | ffe1b9 | d3c5bc  | b4b5b6 |
+//   30      | f0e8d8 | d4eac6 | c4dddc | c3ddf6  | c3cde2 | ebc9d9 | f3d1c8 | ffe8cb | ddd1c9  | c3c4c4 |
+//   20      |        | e2efd8 | d4e7e6 | d6e8fa  | d3daeb | f0d8e2 | f7e0d9 | fff0dd | e7ddd7  | d2d3d5 |
+//   15      |        |        |        |         |        |        |        |        |         | dcdddf |
+//   10      |        | f0f8eb | f0f7f6 | eff8fd  | f4f6fa | fdf3f8 | fbefec | fff6ec | f8f5f2  | e7e8e9 |
+//    5      |        |        |        |         |        |        |        |        |         | f7f8f9 |
 //
 // CFPB Black: 101820
 // CFPB White: ffffff
 
+
+// Beige family
+@beige:            #bea96f;
+@beige-30:         #f0e8d8;
+@beige-60:         #d8c8a0;
 
 // Green family
 @green-dark:       #1e9642;


### PR DESCRIPTION
## Additions

- Add beige family colors for seal

## Testing

1. See specs on seal on https://cfpb.github.io/design-system/foundation/seal
2. Compare to same page on this PR's preview and see that beige colors are present.

## Screenshots

<img width="870" alt="Screen Shot 2020-11-20 at 5 55 38 PM" src="https://user-images.githubusercontent.com/704760/99857784-04a67180-2b5a-11eb-96b8-f5021cdd5967.png">

