### PR TITLE
Change data-bound to data-js-hook value

### DIFF
--- a/docs/pages/tables.md
+++ b/docs/pages/tables.md
@@ -568,7 +568,7 @@ variation_groups:
         variation_code_snippet: >-
           <!--Code from Design Manual
 
-          <table class="o-table o-table__stack-on-small" data-bound="true">
+          <table class="o-table o-table__stack-on-small">
               <thead>
                   <tr>
                       <th class="u-w20pct">
@@ -663,7 +663,7 @@ variation_groups:
 
           Fixed-width columns at the 600 px breakpoint and less lose their custom widths and expand to full width. This is the same responsive pattern used for default tables at small screens.
         variation_code_snippet: |-
-          <table class="o-table o-table__stack-on-small" data-bound="true">
+          <table class="o-table o-table__stack-on-small">
               <thead>
                   <tr>
                       <th class="u-w20pct">

--- a/packages/cfpb-atomic-component/src/components/AtomicComponent.js
+++ b/packages/cfpb-atomic-component/src/components/AtomicComponent.js
@@ -91,7 +91,7 @@ assign( AtomicComponent.prototype, new EventObserver(), {
     } else {
       this.setElement( this.element );
     }
-    this.element.setAttribute( 'data-bound', true );
+    this.element.setAttribute( 'data-js-hook', 'state_atomic_init' );
   },
 
   /**
@@ -236,7 +236,7 @@ assign( AtomicComponent.prototype, new EventObserver(), {
     if ( this._delegate ) {
       this._delegate.destroy();
     }
-    this.element.removeAttribute( 'data-bound' );
+    this.element.removeAttribute( 'data-js-hook' );
 
     return this;
   },
@@ -304,7 +304,7 @@ AtomicComponent.init = function( scope ) {
   let element;
   for ( let i = 0, len = elements.length; i < len; i++ ) {
     element = elements[i];
-    if ( element.hasAttribute( 'data-bound' ) === false ) {
+    if ( element.hasAttribute( 'data-js-hook' ) === false ) {
       components.push( new this( element ) );
     }
   }

--- a/test/unit-test/src/cfpb-atomic-component/src/components/AtomicComponent-spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/components/AtomicComponent-spec.js
@@ -60,7 +60,7 @@ describe( 'AtomicComponent', () => {
   it( 'should add the bound attribute to passed elements', () => {
     const element = document.getElementById( 'test-block-a' );
     const atomicComponent = new AtomicComponent( element );
-    expect( atomicComponent.element.hasAttribute( 'data-bound' ) ).toBe( true );
+    expect( atomicComponent.element.hasAttribute( 'data-js-hook' ) ).toBe( true );
   } );
 
   it( 'should initialize all instances in the DOM', () => {

--- a/test/unit-test/src/cfpb-expandables/src/Expandable-spec.js
+++ b/test/unit-test/src/cfpb-expandables/src/Expandable-spec.js
@@ -84,9 +84,9 @@ describe( 'standard Expandable', () => {
   } );
 
   describe( 'initialized state', () => {
-    it( 'should be data-bound', () => {
-      expect( expandableDom1.getAttribute( 'data-bound' ) ).toBe( 'true' );
-      expect( expandableDom2.getAttribute( 'data-bound' ) ).toBe( 'true' );
+    it( 'should be initialized', () => {
+      expect( expandableDom1.getAttribute( 'data-js-hook' ) ).toBe( 'state_atomic_init' );
+      expect( expandableDom2.getAttribute( 'data-js-hook' ) ).toBe( 'state_atomic_init' );
     } );
 
     it( 'should be collapsed when the OPEN_DEFAULT class is not present',
@@ -161,9 +161,9 @@ describe( 'accordion Expandables', () => {
   } );
 
   describe( 'initialized state', () => {
-    it( 'should be data-bound', () => {
-      expect( expandableDom1.getAttribute( 'data-bound' ) ).toBe( 'true' );
-      expect( expandableDom2.getAttribute( 'data-bound' ) ).toBe( 'true' );
+    it( 'should be initialized', () => {
+      expect( expandableDom1.getAttribute( 'data-js-hook' ) ).toBe( 'state_atomic_init' );
+      expect( expandableDom2.getAttribute( 'data-js-hook' ) ).toBe( 'state_atomic_init' );
     } );
 
     it( 'should be collapsed when the OPEN_DEFAULT class is not present',


### PR DESCRIPTION
We have two syntaxes for specifying that a component is initialized. `data-bound` and `data-js-hook`. This PR changes the value to `data-js-hook` used elsewhere.

## Changes

- Change data-bound to data-js-hook value

## Testing

1. PR checks should pass.
