### PR TITLE
Add missing invisibility utility class

### DIFF
--- a/packages/cfpb-core/src/utilities.less
+++ b/packages/cfpb-core/src/utilities.less
@@ -76,6 +76,14 @@
     display: none;
 }
 
+//
+// Hide an element while retaining its layout.
+//
+
+.u-invisible {
+    visibility: hidden;
+}
+
 // TODO: Deprecated. Remove in CFv5.
 //
 // Inline block


### PR DESCRIPTION
The multiselect [uses it](https://github.com/cfpb/design-system/blob/4c7f6970c0d44cd130703ef96259268b3b15d1e3/packages/cfpb-forms/src/organisms/Multiselect.js#L108) but it wasn't migrated from cf.gov. We haven't noticed its absence because the fieldset element has its height adjusted when it open/closes but it might be related to the latest Chrome bug we've discovered.

## Additions

- `u-invisible` class

## Testing

1. Nothing should look different.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
