### PR TITLE
Accommodate Chrome's improper handling of fieldset display properties

### DIFF
--- a/packages/cfpb-forms/src/organisms/multiselect.less
+++ b/packages/cfpb-forms/src/organisms/multiselect.less
@@ -38,6 +38,12 @@ select.o-multiselect {
         width: 100%;
 
         transition: max-height 0.25s ease-out;
+
+        // Chrome doesn't properly handle fieldset display properties
+        // See https://bugs.chromium.org/p/chromium/issues/detail?id=375693
+        // and https://codepen.io/contolini/pen/rNLXrvP
+        // and https://codepen.io/pembe180/pen/wCsIk
+        display: -webkit-box;
     }
 
     &.u-active {

--- a/test/browser/packages/cfpb-forms.js
+++ b/test/browser/packages/cfpb-forms.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-undef */
+
+describe( 'Multiselect', function() {
+
+  let multiselectInput;
+
+  before( function() {
+    browser.url( '/design-system/components/dropdowns-and-multiselects' );
+    browser.setWindowSize( 1024, 768 );
+    browser.pause( 1000 );
+    // Selects the first multiselect live code sample
+    multiselectInput = $( '.a-live_code .o-multiselect_search' );
+  } );
+
+  it( 'should show the first multiselect option when opened', function() {
+    multiselectInput.click();
+    multiselectInput.scrollIntoView();
+    // Ensure multiselect has fully expanded
+    browser.pause( 300 );
+    const firstMultiSelectOption = $( '.a-live_code .o-multiselect_options li:first-child' );
+    expect( firstMultiSelectOption.isDisplayedInViewport() ).toBeTruthy();
+  } );
+
+  it( 'should not show the last multiselect option until the user scrolls to it', function() {
+    multiselectInput.scrollIntoView();
+    multiselectInput.click();
+    const multiselectFieldset = $( '.a-live_code .o-multiselect_fieldset' );
+    const lastMultiSelectOption = $( '.a-live_code .o-multiselect_options li:last-child' );
+    lastMultiSelectOption.scrollIntoView();
+    const multiselectFieldsetScrollTop = multiselectFieldset.getProperty( 'scrollTop' );
+    // Ensure multiselect has fully expanded
+    browser.pause( 300 );
+    // If the scrollTop of the fieldset is zero, it means no scrolling was necessary to reach
+    // the last multiselect option which indicates the options aren't contained within the
+    // scrollable area and are spilling over due to a browser or CSS bug.
+    expect( multiselectFieldsetScrollTop ).toBeGreaterThan( 0 );
+  } );
+
+} );


### PR DESCRIPTION
There's a regression w/ Chrome 87 that causes fieldset elements to not honor its layout properties. It causes multiselect options to overflow their fielset container. If you're on v87 locally you can see the bug by opening the multiselect at https://cfpb.github.io/design-system/components/dropdowns-and-multiselects

https://bugs.chromium.org/p/chromium/issues/detail?id=375693
https://codepen.io/contolini/pen/rNLXrvP
https://codepen.io/pembe180/pen/wCsIk

## Changes

- Set the fieldset's display to `-webkit-box` for Chrome.

## Testing

1. Compare the multiselect page in the PR preview against production in Chrome 87.

## Screenshots

| before | after |
|--------|-------|
| <img width="679" alt="Screen Shot 2020-11-30 at 10 04 19 AM" src="https://user-images.githubusercontent.com/1060248/100626148-7073a180-32f3-11eb-9445-362b58cd0483.png">   | <img width="679" alt="Screen Shot 2020-11-30 at 10 04 28 AM" src="https://user-images.githubusercontent.com/1060248/100626154-736e9200-32f3-11eb-9c75-e62e1442a8f3.png">  |

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
