### PR TITLE
Fix multiselect filtering

### DIFF
--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 // Required modules.
 import EventObserver from '../../../cfpb-atomic-component/src/mixins/EventObserver.js';
 import MultiselectModel from './MultiselectModel.js';
@@ -349,14 +350,14 @@ function Multiselect( element ) { // eslint-disable-line max-statements
   /**
    * Set the filtered matched state.
    */
-  function _filterMatches() {
+  function _filterMatches( filterIndices ) {
     _optionsDom.classList.remove( 'u-no-results' );
     _optionsDom.classList.add( 'u-filtered' );
-    for ( let i = 0, len = _model.getLastFilterIndices(); i < len; i++ ) {
+    for ( let i = 0, len = filterIndices.length; i < len; i++ ) {
       _optionItemDoms[i].classList.remove( 'u-filter-match' );
     }
-    for ( let j = 0, len = _model.getFilterIndices(); j < len; j++ ) {
-      _optionItemDoms[j].classList.add( 'u-filter-match' );
+    for ( let j = 0, len = filterIndices.length; j < len; j++ ) {
+      _optionItemDoms[ filterIndices[j] ].classList.add( 'u-filter-match' );
     }
   }
 

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -326,7 +326,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
    */
   function _filterList( filterIndices ) {
     if ( filterIndices.length > 0 ) {
-      _filterMatches( filterIndices );
+      _filterMatches();
       return true;
     }
 
@@ -350,14 +350,18 @@ function Multiselect( element ) { // eslint-disable-line max-statements
   /**
    * Set the filtered matched state.
    */
-  function _filterMatches( filterIndices ) {
+  function _filterMatches() {
     _optionsDom.classList.remove( 'u-no-results' );
     _optionsDom.classList.add( 'u-filtered' );
-    for ( let i = 0, len = filterIndices.length; i < len; i++ ) {
-      _optionItemDoms[i].classList.remove( 'u-filter-match' );
+
+    let filteredIndices = _model.getLastFilterIndices();
+    for ( let i = 0, len = filteredIndices.length; i < len; i++ ) {
+      _optionItemDoms[filteredIndices[i]].classList.remove( 'u-filter-match' );
     }
-    for ( let j = 0, len = filterIndices.length; j < len; j++ ) {
-      _optionItemDoms[ filterIndices[j] ].classList.add( 'u-filter-match' );
+
+    filteredIndices = _model.getFilterIndices();
+    for ( let j = 0, len = filteredIndices.length; j < len; j++ ) {
+      _optionItemDoms[filteredIndices[j]].classList.add( 'u-filter-match' );
     }
   }
 

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines-per-function */
 // Required modules.
 import EventObserver from '../../../cfpb-atomic-component/src/mixins/EventObserver.js';
 import MultiselectModel from './MultiselectModel.js';

--- a/test/browser/packages/cfpb-forms.js
+++ b/test/browser/packages/cfpb-forms.js
@@ -36,4 +36,27 @@ describe( 'Multiselect', function() {
     expect( multiselectFieldsetScrollTop ).toBeGreaterThan( 0 );
   } );
 
+  it( 'should correctly filter the multiselect options', function() {
+    multiselectInput.scrollIntoView();
+    multiselectInput.click();
+    // Ensure multiselect has fully expanded
+    browser.pause( 300 );
+
+    const firstMultiSelectOption = $( '.a-live_code .o-multiselect_options li[data-option=option1]' );
+    const fourthMultiSelectOption = $( '.a-live_code .o-multiselect_options li[data-option=option4]' );
+    const longMultiSelectOption = $( '.a-live_code .o-multiselect_options li[data-option=option8]' );
+
+    // Find option #4
+    multiselectInput.setValue( 'ion 4' );
+    expect( firstMultiSelectOption.isDisplayed() ).toBeFalsy();
+    expect( fourthMultiSelectOption.isDisplayed() ).toBeTruthy();
+    expect( longMultiSelectOption.isDisplayed() ).toBeFalsy();
+
+    // Find the last really long option
+    multiselectInput.setValue( 'superca' );
+    expect( firstMultiSelectOption.isDisplayed() ).toBeFalsy();
+    expect( fourthMultiSelectOption.isDisplayed() ).toBeFalsy();
+    expect( longMultiSelectOption.isDisplayed() ).toBeTruthy();
+  } );
+
 } );


### PR DESCRIPTION
While exploring the IE11 issue I discovered the cause is a larger issue with the multiselect not correctly filtering options.

## Changes

- Pass the indices of the filtered options to the `_filterMatches` function.

## Testing

1. Visit https://cfpb.github.io/design-system/components/dropdowns-and-multiselects and enter some text like "super" into the multiselect field. It should only display option 8 that contains the text "super". Instead, it shows everything but option 8.
1. Visit the PR preview link and verify it works as expected.
