### PR TITLE
Ensure correct multiselect input labels and IDs

### DIFF
--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -71,7 +71,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
     }
 
     _instance = this;
-    _name = _dom.name;
+    _name = _dom.name || _dom.id;
     _placeholder = _dom.getAttribute( 'placeholder' );
     _options = _dom.options || [];
 
@@ -172,8 +172,10 @@ function Multiselect( element ) { // eslint-disable-line max-statements
         'class': 'm-form-field m-form-field__checkbox'
       } );
 
+      const _checkboxId = _name + '-' + option.value;
+
       MultiselectUtils.create( 'input', {
-        'id':     option.value,
+        'id':     _checkboxId,
         // Type must come before value or IE fails
         'type':    'checkbox',
         'value':   option.value,
@@ -184,7 +186,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
       } );
 
       MultiselectUtils.create( 'label', {
-        'for':         option.value,
+        'for':         _checkboxId,
         'textContent': option.text,
         'className':   BASE_CLASS + '_label a-label',
         'inside':      _optionsItemDom

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -172,10 +172,10 @@ function Multiselect( element ) { // eslint-disable-line max-statements
         'class': 'm-form-field m-form-field__checkbox'
       } );
 
-      const _checkboxId = _name + '-' + option.value;
+      const checkboxId = _name + '-' + option.value.trim().replace( /\s+/g, '-' ).toLowerCase();
 
       MultiselectUtils.create( 'input', {
-        'id':     _checkboxId,
+        'id':      checkboxId,
         // Type must come before value or IE fails
         'type':    'checkbox',
         'value':   option.value,
@@ -186,7 +186,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
       } );
 
       MultiselectUtils.create( 'label', {
-        'for':         _checkboxId,
+        'for':         checkboxId,
         'textContent': option.text,
         'className':   BASE_CLASS + '_label a-label',
         'inside':      _optionsItemDom

--- a/test/unit-test/src/cfpb-forms/src/organisms/Multiselect-spec.js
+++ b/test/unit-test/src/cfpb-forms/src/organisms/Multiselect-spec.js
@@ -79,6 +79,7 @@ describe( 'Multiselect', () => {
       search.click();
       simulateEvent( 'keydown', search, { keyCode: 40 } );
 
+      expect( document.activeElement.id ).toBe( 'test-select-debt-collection' );
       expect( document.activeElement.value ).toBe( 'Debt collection' );
     } );
 

--- a/test/unit-test/src/cfpb-forms/src/organisms/Multiselect-spec.js
+++ b/test/unit-test/src/cfpb-forms/src/organisms/Multiselect-spec.js
@@ -79,7 +79,7 @@ describe( 'Multiselect', () => {
       search.click();
       simulateEvent( 'keydown', search, { keyCode: 40 } );
 
-      expect( document.activeElement.id ).toBe( 'Debt collection' );
+      expect( document.activeElement.value ).toBe( 'Debt collection' );
     } );
 
     it( 'should open when the search input is focused', function() {


### PR DESCRIPTION
This change properly handles multiselects defined with an `id` but not a `name`, as in [the example in the design system docs](https://cfpb.github.io/design-system/components/dropdowns-and-multiselects#multiselects-1).

```html
<select class="o-multiselect" id="something" multiple>
```

Currently, the JS code generates a text `<input>` with an empty `id` attribute. This means that the associated `<label>` points to the wrong thing, causing failures in accessibility audits, [for example](https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1607472905780-28501.report.html).

Additionally, the current behavior fails to ensure that the generated checkboxes have unique `id`s, simply copying the option `value`s. This commit prepends each `id` with the enclosing `input` ID, ensuring uniqueness on the page.