### PR TITLE
Fix multiselect removal bug

### DIFF
--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -75,7 +75,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
     _options = _dom.options || [];
 
     if ( _options.length > 0 ) {
-      _model = new MultiselectModel( _options ).init();
+      _model = new MultiselectModel( _options, _name ).init();
       _optionsData = _model.getOptions();
       const newDom = _populateMarkup();
 
@@ -166,8 +166,6 @@ function Multiselect( element ) { // eslint-disable-line max-statements
         'data-option': option.value,
         'class': 'm-form-field m-form-field__checkbox'
       } );
-
-      option.id = _name + '-' + option.value.trim().replace( /\s+/g, '-' ).toLowerCase();
 
       MultiselectUtils.create( 'input', {
         'id':      option.id,

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -167,10 +167,10 @@ function Multiselect( element ) { // eslint-disable-line max-statements
         'class': 'm-form-field m-form-field__checkbox'
       } );
 
-      const checkboxId = _name + '-' + option.value.trim().replace( /\s+/g, '-' ).toLowerCase();
+      option.id = _name + '-' + option.value.trim().replace( /\s+/g, '-' ).toLowerCase();
 
       MultiselectUtils.create( 'input', {
-        'id':      checkboxId,
+        'id':      option.id,
         // Type must come before value or IE fails
         'type':    'checkbox',
         'value':   option.value,
@@ -181,7 +181,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
       } );
 
       MultiselectUtils.create( 'label', {
-        'for':         checkboxId,
+        'for':         option.id,
         'textContent': option.text,
         'className':   BASE_CLASS + '_label a-label',
         'inside':      _optionsItemDom
@@ -212,7 +212,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
     } );
 
     const selectionsItemLabelDom = MultiselectUtils.create( 'button', {
-      innerHTML: '<label for=' + option.value + '>' + option.text + closeIcon + '</label>',
+      innerHTML: '<label for=' + option.id + '>' + option.text + closeIcon + '</label>',
       inside:    selectionsItemDom
     } );
 

--- a/packages/cfpb-forms/src/organisms/MultiselectModel.js
+++ b/packages/cfpb-forms/src/organisms/MultiselectModel.js
@@ -28,9 +28,11 @@ function stringMatch( x, y ) {
  * MultiselectModel
  * @param {HTMLOptionsCollection} options -
  *   Set of options from a <select> element.
+ * @param {string} name - a unique name for this multiselect.
  */
-function MultiselectModel( options ) {
+function MultiselectModel( options, name ) {
   const _options = options;
+  const _name = name;
   let _optionsData = [];
 
   let _selectedIndices = [];
@@ -66,6 +68,7 @@ function MultiselectModel( options ) {
       item = list[i];
       isChecked = item.defaultSelected;
       cleaned.push( {
+        id:      _getOptionId( item ),
         value:   item.value,
         text:    item.text,
         checked: isChecked
@@ -185,6 +188,15 @@ function MultiselectModel( options ) {
    */
   function getIndex() {
     return _index;
+  }
+
+  /**
+   * @param {HTMLNode} item - An option HTML node.
+   * @returns {string} A (hopefully) unique ID.
+   *   If it's not unique, we have a duplicate option value.
+   */
+  function _getOptionId( item ) {
+    return _name + '-' + item.value.trim().replace( /\s+/g, '-' ).toLowerCase();
   }
 
   this.init = init;

--- a/test/browser/packages/cfpb-forms.js
+++ b/test/browser/packages/cfpb-forms.js
@@ -59,4 +59,29 @@ describe( 'Multiselect', function() {
     expect( longMultiSelectOption.isDisplayed() ).toBeTruthy();
   } );
 
+  it( 'should let the user remove a choice', function() {
+    multiselectInput.scrollIntoView();
+
+    // Verify option1 is selected by default
+    const multiSelectChoice = $( '.o-multiselect_choices label[for=test_select__multiple-option1]' );
+    expect( multiSelectChoice.isDisplayed() ).toBeTruthy();
+
+    // Verify option1 can be removed
+    multiSelectChoice.click();
+    expect( multiSelectChoice.isDisplayed() ).toBeFalsy();
+  } );
+
+  it( 'should let the user add a choice', function() {
+    multiselectInput.scrollIntoView();
+    multiselectInput.click();
+    // Ensure multiselect has fully expanded
+    browser.pause( 300 );
+
+    const secondMultiSelectOption = $( '.a-live_code .o-multiselect_options li[data-option=option2] label' );
+    secondMultiSelectOption.click();
+
+    const secondMultiSelectChoice = $( '.a-live_code .o-multiselect_choices label[for=test_select__multiple-option2]' );
+    expect( secondMultiSelectChoice.isDisplayed() ).toBeTruthy();
+  } );
+
 } );


### PR DESCRIPTION
The multiselect option IDs weren't being transferred to the removal buttons making it impossible to remove a selected option.

## Changes

- Moves the `checkboxId` value to a property of `option` so that we can use it when rendering the selected options.

## Testing

1. You should be able to remove selected multiselect options from this PR preview while you currently cannot at https://cfpb.github.io/design-system/components/dropdowns-and-multiselects
1. `yarn test:browser` should pass.
