### PR TITLE
Encode inline SVGs for IE11 support

### DIFF
--- a/packages/cfpb-icons/src/icons-svg-inline.js
+++ b/packages/cfpb-icons/src/icons-svg-inline.js
@@ -47,7 +47,7 @@ module.exports = {
         'class="cf-icon-svg"', `fill="${ svgFillColor.value }"`
       );
 
-      return svg;
+      return encodeURI( svg );
     } );
   }
 };


### PR DESCRIPTION
## Changes

- URL encodes inline SVGs for IE11 support.

## Testing

1. Visit the PR preview in IE11 in Sauce Labs and see that the inline background image SVGs are showing up on the dropdowns and in the checkboxes in the multiselect.

## Screenshots

<img width="581" alt="Screen Shot 2020-12-16 at 3 31 13 PM" src="https://user-images.githubusercontent.com/704760/102403105-c747cf00-3fb3-11eb-9f88-e66f8bbc0d82.png">
<img width="691" alt="Screen Shot 2020-12-16 at 3 31 18 PM" src="https://user-images.githubusercontent.com/704760/102403108-c747cf00-3fb3-11eb-9080-3cd8e8c98443.png">
