### PR TITLE
Multiselect: Pass clicks of the selected item's button down to the label it contains

### DIFF
--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -478,10 +478,10 @@ function Multiselect( element ) { // eslint-disable-line max-statements
    */
   function _selectionClickHandler( event ) {
     const target = event.target;
-    if ( target.tagName === 'BUTTON' ) {
+    if ( target.tagName === 'BUTTON' ) {
       event.preventDefault();
       target.removeEventListener( 'click', _selectionClickHandler );
-      target.querySelector('label').click();
+      target.querySelector( 'label' ).click();
     }
   }
 

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -477,9 +477,12 @@ function Multiselect( element ) { // eslint-disable-line max-statements
    * @param {MouseEvent} event - The mouse click event object.
    */
   function _selectionClickHandler( event ) {
-    event.preventDefault();
-    event.target.removeEventListener( 'click', _selectionClickHandler );
-    event.target.querySelector('label').click();
+    const target = event.target;
+    if ( target.tagName === 'BUTTON' ) {
+      event.preventDefault();
+      target.removeEventListener( 'click', _selectionClickHandler );
+      target.querySelector('label').click();
+    }
   }
 
   /**

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -217,6 +217,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
     selectionsDom.appendChild( selectionsItemDom );
     selectionsItemDom.appendChild( selectionsItemLabelDom );
 
+    selectionsItemLabelDom.addEventListener( 'click', _selectionClickHandler );
     selectionsItemLabelDom.addEventListener( 'keydown', _selectionKeyDownHandler );
   }
 
@@ -463,8 +464,22 @@ function Multiselect( element ) { // eslint-disable-line max-statements
     // Add event listeners to any selections that are present at page load.
     const labelButtons = _selectionsDom.querySelectorAll( 'button' );
     for ( let j = 0, len = labelButtons.length; j < len; j++ ) {
+      labelButtons[j].addEventListener( 'click', _selectionClickHandler );
       labelButtons[j].addEventListener( 'keydown', _selectionKeyDownHandler );
     }
+  }
+
+  /**
+   * This passes the click of the selected item button down to the label it
+   * contains. This is only required for browsers (IE11) that prevent the
+   * click of a selected item from cascading from the button down to the label
+   * it contains.
+   * @param {MouseEvent} event - The mouse click event object.
+   */
+  function _selectionClickHandler( event ) {
+    event.preventDefault();
+    event.target.removeEventListener( 'click', _selectionClickHandler );
+    event.target.querySelector('label').click();
   }
 
   /**


### PR DESCRIPTION
## Changes

- Listen for clicks of the selected item's button and pass that click down to the label it contains.

## Testing

1. Visit the PR preview in IE11 in Sauce Labs and see that the multiselect's selected items can be removed.
