### PR TITLE
Update transitions and add transitions page to DS

### DIFF
--- a/docs/_data/side-navigation.yml
+++ b/docs/_data/side-navigation.yml
@@ -60,6 +60,9 @@ first-level:
             nav-items:
               - page: Filterable list control panels
               - page: Pagination
+          - heading: Transitions
+            nav-items:
+              - page: Transition patterns
       - heading: Layout patterns
         third-level:
           - heading: Introductions

--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -85,6 +85,9 @@
             {% assign variation_name = variation.variation_name | strip %}
             {% assign variation_description = variation.variation_description | strip | markdownify %}
             {% assign variation_code_snippet = variation.variation_code_snippet %}
+            {% if variation.variation_code_snippet_rendered and variation.variation_code_snippet_rendered != '' %}
+                {% assign variation_code_snippet = variation.variation_code_snippet_rendered %}
+            {% endif %}
 
             {% if variation_name and variation_name != '' %}
             <div class="m-variation_name">

--- a/docs/admin/config.yml
+++ b/docs/admin/config.yml
@@ -189,6 +189,11 @@ collections:
                 label: 'Variation code snippet'
                 widget: 'text'
                 required: false
+              - name: 'variation_code_snippet_rendered'
+                label: 'Variation code snippet rendered'
+                hint: 'This code snippet is optional and will be rendered in place of the above code snippet. Use it if you want to secretly include some JS in order to get the snippet to properly render.'
+                widget: 'text'
+                required: false
               - name: 'variation_jinja_code_snippet'
                 label: 'Variation Jinja links or snippet'
                 hint: 'Use this field to add links to Jinja2 templates in cfgov-refresh.'

--- a/docs/assets/css/main.less
+++ b/docs/assets/css/main.less
@@ -144,6 +144,24 @@ main {
     }
 } );
 
+// Example shapes - for transition examples.
+
+.example-box {
+    width: 100px;
+    height: 100px;
+    background-color: @red;
+    text-align: center;
+    vertical-align: middle;
+    color: @white;
+    display: table-cell;
+    cursor: pointer;
+
+    &.u-is-animating {
+        outline: 5px solid @gray-40;
+    }
+}
+
+
 
 // custom modules
 @import (less) "sidebar.less";

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -5,6 +5,8 @@ import {
 import AnchorJS from 'anchor-js';
 import Expandable from '@cfpb/cfpb-expandables/src/Expandable';
 import Multiselect from '@cfpb/cfpb-forms/src/organisms/Multiselect';
+import AlphaTransition from '@cfpb/cfpb-atomic-component/src/utilities/transition/AlphaTransition.js';
+import MoveTransition from '@cfpb/cfpb-atomic-component/src/utilities/transition/MoveTransition.js';
 import Table from '@cfpb/cfpb-tables/src/Table';
 import { Tabs } from 'govuk-frontend';
 import redirectBanner from './redirect-banner.js';
@@ -34,6 +36,23 @@ if ( multiselectDom ) {
 
 Expandable.init();
 Table.init();
+
+// Transition example code.
+const moveTransitionExample = document.querySelector( '.example-box.u-move-transition' );
+if ( moveTransitionExample !== null ) {
+  const moveTransition = new MoveTransition( moveTransitionExample ).init();
+  moveTransitionExample.addEventListener( 'click', () => {
+    moveTransition.moveRight();
+  } );
+}
+
+const alphaTransitionExample = document.querySelector( '.example-box.u-alpha-transition' );
+if ( alphaTransitionExample !== null ) {
+  const alphaTransition = new AlphaTransition( alphaTransitionExample ).init();
+  alphaTransitionExample.addEventListener( 'click', () => {
+    alphaTransition.fadeOut();
+  } );
+}
 
 const main = document.querySelector( '#main' );
 const tabs = document.querySelectorAll( '[data-module="tabs"]' );

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -51,6 +51,9 @@ if ( alphaTransitionExample !== null ) {
   const alphaTransition = new AlphaTransition( alphaTransitionExample ).init();
   alphaTransitionExample.addEventListener( 'click', () => {
     alphaTransition.fadeOut();
+    setTimeout( () => {
+      alphaTransition.fadeIn();
+    }, 2000 );
   } );
 }
 

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -43,6 +43,9 @@ if ( moveTransitionExample !== null ) {
   const moveTransition = new MoveTransition( moveTransitionExample ).init();
   moveTransitionExample.addEventListener( 'click', () => {
     moveTransition.moveRight();
+    setTimeout( () => {
+      moveTransition.moveToOrigin();
+    }, 2000 );
   } );
 }
 

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -37,28 +37,10 @@ if ( multiselectDom ) {
 Expandable.init();
 Table.init();
 
-// Transition example code.
-const moveTransitionExample = document.querySelector( '.example-box.u-move-transition' );
-if ( moveTransitionExample !== null ) {
-  const moveTransition = new MoveTransition( moveTransitionExample ).init();
-  moveTransitionExample.addEventListener( 'click', () => {
-    moveTransition.moveRight();
-    setTimeout( () => {
-      moveTransition.moveToOrigin();
-    }, 2000 );
-  } );
-}
-
-const alphaTransitionExample = document.querySelector( '.example-box.u-alpha-transition' );
-if ( alphaTransitionExample !== null ) {
-  const alphaTransition = new AlphaTransition( alphaTransitionExample ).init();
-  alphaTransitionExample.addEventListener( 'click', () => {
-    alphaTransition.fadeOut();
-    setTimeout( () => {
-      alphaTransition.fadeIn();
-    }, 2000 );
-  } );
-}
+// Exporting these classes to the window so that the transition-patterns.md
+// page can use them in its code snippets.
+window.AlphaTransition = AlphaTransition;
+window.MoveTransition = MoveTransition;
 
 const main = document.querySelector( '#main' );
 const tabs = document.querySelectorAll( '[data-module="tabs"]' );

--- a/docs/pages/transition-patterns.md
+++ b/docs/pages/transition-patterns.md
@@ -65,7 +65,7 @@ variation_groups:
 
           ```
       - variation_name: Alpha transition
-        variation_description: A transition that fades from one position to another.
+        variation_description: A transition that fades from one opacity to another.
         variation_code_snippet: >-
           <div class="u-alpha-transition example-box">Click me!</div>
 

--- a/docs/pages/transition-patterns.md
+++ b/docs/pages/transition-patterns.md
@@ -11,14 +11,32 @@ variation_groups:
       - variation_name: Move transition
         variation_description: A transition that moves from one position to another.
         variation_code_snippet: >-
-            <div class="u-move-transition example-box">Click me!</div>
-            <script>
-                const moveTransitionExample = document.querySelector( '.example-box.u-move-transition' );
-                const moveTransition = new MoveTransition( moveTransitionExample ).init();
-                moveTransitionExample.addEventListener( 'click', () => {
-                    moveTransition.moveRight();
-                } );
-            </script>
+          <div class="u-move-transition example-box">Click me!</div>
+
+          <script>
+            const moveTransitionExample = document.querySelector( '.example-box.u-move-transition' );
+            const moveTransition = new MoveTransition( moveTransitionExample ).init();
+            moveTransitionExample.addEventListener( 'click', () => {
+                moveTransition.moveRight();
+                setTimeout( () => {
+                  moveTransition.moveToOrigin();
+                }, 1000 );
+            } );
+          </script>
+        variation_code_snippet_rendered: >-
+          <div class="u-move-transition example-box">Click me!</div>
+          <script>
+            document.addEventListener( 'DOMContentLoaded', function() {
+              const moveTransitionExample = document.querySelector( '.example-box.u-move-transition' );
+              const moveTransition = new MoveTransition( moveTransitionExample ).init();
+              moveTransitionExample.addEventListener( 'click', function() {
+                moveTransition.moveRight();
+                setTimeout( function() {
+                  moveTransition.moveToOrigin();
+                }, 1000 );
+              } );
+            } );
+          </script>
         variation_implementation: >-
           The move transition is added to an element by creating a new
           MoveTransition instance in JavaScript and calling its methods:
@@ -48,7 +66,33 @@ variation_groups:
           ```
       - variation_name: Alpha transition
         variation_description: A transition that fades from one position to another.
-        variation_code_snippet: <div class="u-alpha-transition example-box">Click me!</div>
+        variation_code_snippet: >-
+          <div class="u-alpha-transition example-box">Click me!</div>
+
+          <script>
+            const alphaTransitionExample = document.querySelector( '.example-box.u-alpha-transition' );
+            const alphaTransition = new AlphaTransition( alphaTransitionExample ).init();
+            alphaTransitionExample.addEventListener( 'click', () => {
+              alphaTransition.fadeOut();
+              setTimeout( () => {
+                alphaTransition.fadeIn();
+              }, 1000 );
+            } );
+          </script>
+        variation_code_snippet_rendered: >-
+          <div class="u-alpha-transition example-box">Click me!</div>
+          <script>
+            document.addEventListener( 'DOMContentLoaded', function() {
+              const alphaTransitionExample = document.querySelector( '.example-box.u-alpha-transition' );
+              const alphaTransition = new AlphaTransition( alphaTransitionExample ).init();
+              alphaTransitionExample.addEventListener( 'click', function() {
+                alphaTransition.fadeOut();
+                setTimeout( function() {
+                  alphaTransition.fadeIn();
+                }, 1000 );
+              } );
+            } );
+          </script>
         variation_implementation: >-
           The alpha (opacity) transition is added to an element by creating a
           new AlphaTransition instance in JavaScript and calling its methods:

--- a/docs/pages/transition-patterns.md
+++ b/docs/pages/transition-patterns.md
@@ -1,0 +1,79 @@
+---
+title: Transition patterns
+layout: variation
+section: patterns
+status: Released
+description: Transition patterns are animations that happen when a user
+  interacts with an element on the page. They are CSS transition styles that are
+  controlled via JavaScript.
+variation_groups:
+  - variations:
+      - variation_name: Move transition
+        variation_description: A transition that moves from one position to another.
+        variation_code_snippet: <div class="u-move-transition example-box">Click me!</div>
+        variation_implementation: >-
+          The move transition is added to an element by creating a new
+          MoveTransition instance in JavaScript and calling its methods:
+
+
+          ```
+
+          // Create reference to an element in the DOM.
+
+          const element = document.querySelector( '.example-box' );
+
+
+          // Create a new transition instance and pass in the element reference.
+
+          const transition = new MoveTransition( element );
+
+
+          // Initialize the transition.
+
+          transition.init();
+
+
+          // Call methods on the transition.
+
+          transition.moveRight();
+
+          ```
+      - variation_name: Alpha transition
+        variation_description: A transition that fades from one position to another.
+        variation_code_snippet: <div class="u-alpha-transition example-box">Click me!</div>
+        variation_implementation: >-
+          The alpha (opacity) transition is added to an element by creating a
+          new AlphaTransition instance in JavaScript and calling its methods:
+
+
+          ```
+
+          // Create reference to an element in the DOM.
+
+          const element = document.querySelector( '.example-box' );
+
+
+          // Create a new transition instance and pass in the element reference.
+
+          const transition = new AlphaTransition( element );
+
+
+          // Initialize the transition.
+
+          transition.init();
+
+
+          // Call methods on the transition.
+
+          transition.fadeOut();
+
+          ```
+    variation_group_name: Types
+    variation_group_description: ""
+use_cases: ""
+guidelines: ""
+behavior: ""
+accessibility: ""
+last_updated: 2020-01-28T15:55:47.394Z
+research: ""
+---

--- a/docs/pages/transition-patterns.md
+++ b/docs/pages/transition-patterns.md
@@ -10,7 +10,15 @@ variation_groups:
   - variations:
       - variation_name: Move transition
         variation_description: A transition that moves from one position to another.
-        variation_code_snippet: <div class="u-move-transition example-box">Click me!</div>
+        variation_code_snippet: >-
+            <div class="u-move-transition example-box">Click me!</div>
+            <script>
+                const moveTransitionExample = document.querySelector( '.example-box.u-move-transition' );
+                const moveTransition = new MoveTransition( moveTransitionExample ).init();
+                moveTransitionExample.addEventListener( 'click', () => {
+                    moveTransition.moveRight();
+                } );
+            </script>
         variation_implementation: >-
           The move transition is added to an element by creating a new
           MoveTransition instance in JavaScript and calling its methods:

--- a/packages/cfpb-atomic-component/src/utilities/transition/AlphaTransition.js
+++ b/packages/cfpb-atomic-component/src/utilities/transition/AlphaTransition.js
@@ -1,12 +1,13 @@
 // Required modules.
 import BaseTransition from './BaseTransition.js';
-import EventObserver from '../../mixins/EventObserver.js';
+import EventObserver from '@cfpb/cfpb-atomic-component/src/mixins/EventObserver.js';
 
 // Exported constants.
 const CLASSES = {
-  BASE_CLASS: 'u-alpha-transition',
-  ALPHA_100:  'u-alpha-100',
-  ALPHA_0:    'u-alpha-0'
+  CSS_PROPERTY: 'opacity',
+  BASE_CLASS:   'u-alpha-transition',
+  ALPHA_100:    'u-alpha-100',
+  ALPHA_0:      'u-alpha-0'
 };
 
 /**

--- a/packages/cfpb-atomic-component/src/utilities/transition/MoveTransition.js
+++ b/packages/cfpb-atomic-component/src/utilities/transition/MoveTransition.js
@@ -1,9 +1,10 @@
 // Required modules.
 import BaseTransition from './BaseTransition.js';
-import EventObserver from '../../mixins/EventObserver.js';
+import EventObserver from '@cfpb/cfpb-atomic-component/src/mixins/EventObserver.js';
 
 // Exported constants.
 const CLASSES = {
+  CSS_PROPERTY:   'transform',
   BASE_CLASS:     'u-move-transition',
   MOVE_TO_ORIGIN: 'u-move-to-origin',
   MOVE_LEFT:      'u-move-left',
@@ -13,7 +14,6 @@ const CLASSES = {
   MOVE_UP:        'u-move-up'
 };
 
-/* eslint-disable max-lines-per-function */
 /**
  * MoveTransition
  * @class
@@ -122,7 +122,6 @@ function MoveTransition( element ) {
 
   return this;
 }
-/* eslint-enable max-lines-per-function */
 
 // Public static properties.
 MoveTransition.CLASSES = CLASSES;

--- a/packages/cfpb-expandables/src/ExpandableTransition.js
+++ b/packages/cfpb-expandables/src/ExpandableTransition.js
@@ -4,6 +4,7 @@ import EventObserver from '@cfpb/cfpb-atomic-component/src/mixins/EventObserver.
 
 // Exported constants.
 const CLASSES = {
+  CSS_PROPERTY: 'max-height',
   BASE_CLASS:   'o-expandable_content__transition',
   EXPANDED:     'o-expandable_content__expanded',
   COLLAPSED:    'o-expandable_content__collapsed',

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/transition/AlphaTransition-spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/transition/AlphaTransition-spec.js
@@ -25,8 +25,12 @@ describe( 'AlphaTransition', () => {
 
     it( 'should apply u-alpha-100 class', () => {
       transition.fadeIn();
-      const classes = 'content-1 u-alpha-transition u-alpha-100';
-      expect( contentDom.className ).toEqual( classes );
+      let classes = 'content-1 u-alpha-transition u-is-animating u-alpha-100';
+      expect( contentDom.className ).toStrictEqual( classes );
+      transition.addEventListener( 'transitionend', () => {
+        classes = 'content-1 u-alpha-transition u-alpha-100';
+        expect( contentDom.className ).toStrictEqual( classes );
+      } );
     } );
   } );
 
@@ -37,8 +41,12 @@ describe( 'AlphaTransition', () => {
 
     it( 'should apply u-alpha-0 class', () => {
       transition.fadeOut();
-      const classes = 'content-1 u-alpha-transition u-alpha-0';
-      expect( contentDom.className ).toEqual( classes );
+      let classes = 'content-1 u-alpha-transition u-is-animating u-alpha-0';
+      expect( contentDom.className ).toStrictEqual( classes );
+      transition.addEventListener( 'transitionend', () => {
+        classes = 'content-1 u-alpha-transition u-alpha-0';
+        expect( contentDom.className ).toStrictEqual( classes );
+      } );
     } );
   } );
 } );

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/transition/BaseTransition-spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/transition/BaseTransition-spec.js
@@ -15,14 +15,20 @@ describe( 'BaseTransition', () => {
     contentDom = document.querySelector( '.content-1' );
     content2Dom = document.querySelector( '.content-2' );
     transition =
-      new BaseTransition( contentDom, { BASE_CLASS: 'u-test-transition' } );
+      new BaseTransition(
+        contentDom,
+        {
+          CSS_PROPERTY: 'top',
+          BASE_CLASS: 'u-test-transition'
+        }
+      );
   } );
 
   describe( '.init()', () => {
     it( 'should have public static methods', () => {
-      expect( BaseTransition.BEGIN_EVENT ).toEqual( 'transitionBegin' );
-      expect( BaseTransition.END_EVENT ).toEqual( 'transitionEnd' );
-      expect( BaseTransition.NO_ANIMATION_CLASS ).toEqual( 'u-no-animation' );
+      expect( BaseTransition.BEGIN_EVENT ).toStrictEqual( 'transitionBegin' );
+      expect( BaseTransition.END_EVENT ).toStrictEqual( 'transitionEnd' );
+      expect( BaseTransition.NO_ANIMATION_CLASS ).toStrictEqual( 'u-no-animation' );
     } );
 
     it( 'should have correct state before initializing', () => {

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/transition/MoveTransition-spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/transition/MoveTransition-spec.js
@@ -25,8 +25,13 @@ describe( 'MoveTransition', () => {
 
     it( 'should apply u-move-to-origin class', () => {
       transition.moveToOrigin();
-      const classes = 'content-1 u-move-transition u-move-to-origin';
-      expect( contentDom.className ).toEqual( classes );
+      const classes = 'content-1 u-move-transition ' +
+                      'u-is-animating u-move-to-origin';
+      expect( contentDom.className ).toStrictEqual( classes );
+      transition.addEventListener( 'transitionend', () => {
+        const classes = 'content-1 u-move-transition u-move-to-origin';
+        expect( contentDom.className ).toStrictEqual( classes );
+      } );
     } );
   } );
 
@@ -37,8 +42,12 @@ describe( 'MoveTransition', () => {
 
     it( 'should apply u-move-to-origin class', () => {
       transition.moveRight();
-      const classes = 'content-1 u-move-transition u-move-right';
-      expect( contentDom.className ).toEqual( classes );
+      let classes = 'content-1 u-move-transition u-is-animating u-move-right';
+      expect( contentDom.className ).toStrictEqual( classes );
+      transition.addEventListener( 'transitionend', () => {
+        classes = 'content-1 u-move-transition u-move-right';
+        expect( contentDom.className ).toStrictEqual( classes );
+      } );
     } );
   } );
 
@@ -49,8 +58,12 @@ describe( 'MoveTransition', () => {
 
     it( 'should apply u-move-to-origin class', () => {
       transition.moveUp();
-      const classes = 'content-1 u-move-transition u-move-up';
-      expect( contentDom.className ).toEqual( classes );
+      let classes = 'content-1 u-move-transition u-is-animating u-move-up';
+      expect( contentDom.className ).toStrictEqual( classes );
+      transition.addEventListener( 'transitionend', () => {
+        classes = 'content-1 u-move-transition u-move-up';
+        expect( contentDom.className ).toStrictEqual( classes );
+      } );
     } );
   } );
 
@@ -61,20 +74,32 @@ describe( 'MoveTransition', () => {
 
     it( 'should apply u-move-left class', () => {
       transition.moveLeft();
-      const classes = 'content-1 u-move-transition u-move-left';
-      expect( contentDom.className ).toEqual( classes );
+      let classes = 'content-1 u-move-transition u-is-animating u-move-left';
+      expect( contentDom.className ).toStrictEqual( classes );
+      transition.addEventListener( 'transitionend', () => {
+        classes = 'content-1 u-move-transition u-move-left';
+        expect( contentDom.className ).toStrictEqual( classes );
+      } );
     } );
 
     it( 'should apply u-move-left-2x class', () => {
       transition.moveLeft( 2 );
-      const classes = 'content-1 u-move-transition u-move-left-2x';
-      expect( contentDom.className ).toEqual( classes );
+      let classes = 'content-1 u-move-transition u-is-animating u-move-left-2x';
+      expect( contentDom.className ).toStrictEqual( classes );
+      transition.addEventListener( 'transitionend', () => {
+        classes = 'content-1 u-move-transition u-move-left-2x';
+        expect( contentDom.className ).toStrictEqual( classes );
+      } );
     } );
 
     it( 'should apply u-move-left-3x class', () => {
       transition.moveLeft( 3 );
-      const classes = 'content-1 u-move-transition u-move-left-3x';
-      expect( contentDom.className ).toEqual( classes );
+      let classes = 'content-1 u-move-transition u-is-animating u-move-left-3x';
+      expect( contentDom.className ).toStrictEqual( classes );
+      transition.addEventListener( 'transitionend', () => {
+        classes = 'content-1 u-move-transition u-move-left-3x';
+        expect( contentDom.className ).toStrictEqual( classes );
+      } );
     } );
 
     it( 'should throw error when move left range is out-of-range', () => {


### PR DESCRIPTION
Transitions add an event listener that listens for the `transitionEnd` event, however, the element may have transitions that are performed outside of the transition class, making their `transitionEnd` event fire early and multiple times. To get around this, I've added a `CSS_PROPERTY` value that gets passed into the `BaseTransition` constructor, that is then checked in the `transitionEnd` handler when it fires.

## Additions

- Adds transitions page and example code to design system.

## Changes

- Adds `CSS_PROPERTY` value to transitions to pass to `BaseTransition` and associated logic.
- Updates transition tests to match those in cf.gov repo.

## Testing

1. Check patterns > transition patterns in the PR's preview.

## Screenshots

<img width="1350" alt="Screen Shot 2020-12-30 at 3 58 57 PM" src="https://user-images.githubusercontent.com/704760/103381744-aeaedd00-4aba-11eb-9615-d04644935d57.png">
