### PR TITLE
Add important! to u-hidden and u-no-animation rules

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/transition/transition.less
+++ b/packages/cfpb-atomic-component/src/utilities/transition/transition.less
@@ -14,7 +14,7 @@
 }
 
 .u-no-animation {
-    transition-duration: 0s;
+    transition-duration: 0s !important;
 }
 
 //

--- a/packages/cfpb-core/src/utilities.less
+++ b/packages/cfpb-core/src/utilities.less
@@ -73,7 +73,7 @@
 //
 
 .u-hidden {
-    display: none;
+    display: none !important;
 }
 
 //


### PR DESCRIPTION
If you target an element directly with CSS class that has a `display: block` value and then add `u-hidden` to the element, it will be more general than the targeted CSS class and won't override the display value. I can't think of a scenario where we wouldn't want `u-hidden` to not set `display: none`. If that was not wanted, the class would instead be removed.

Additionally, the `u-no-animation` class sets `transition-duration` to zero in order to override the value set in the element's `transition` value set by either `u-move-transition` or `u-alpha-transition`. However, if the `u-no-animation` class is used to override an animation class that appears in another stylesheet to that of `transitions.less`, then the priority can be wrong and it will not override the animation duration. Therefore we need to add `important!` to the style rule to ensure it always reduces the transition duration to zero.

## Changes

- Add `important!` to the `u-hidden` rule.
- Add `important!` to the `u-no-animation` rule.

## Testing

1. PR checks should pass.