### PR TITLE
Transitions: Call transitionComplete handler if transition duration is zero

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/transition/BaseTransition.js
+++ b/packages/cfpb-atomic-component/src/utilities/transition/BaseTransition.js
@@ -123,12 +123,15 @@ function BaseTransition( element, classes ) {
   function _addEventListener() {
     _dom.classList.add( BaseTransition.ANIMATING_CLASS );
     _isAnimating = true;
-    // If transition is not supported, call handler directly (IE9/OperaMini).
-    if ( _transitionEndEvent ) {
-      _dom.addEventListener(
-        _transitionEndEvent,
-        _transitionCompleteBinded
-      );
+
+    /*
+      If transition is not supported, call handler directly (IE9/OperaMini).
+      Also, if "transition-duration: 0s" is set, transitionEnd event will not
+      fire, so we need to call the handler straight away.
+    */
+    if ( _transitionEndEvent &&
+         !_dom.classList.contains( BaseTransition.NO_ANIMATION_CLASS ) ) {
+      _dom.addEventListener( _transitionEndEvent, _transitionCompleteBinded );
       this.dispatchEvent( BaseTransition.BEGIN_EVENT, { target: this } );
     } else {
       this.dispatchEvent( BaseTransition.BEGIN_EVENT, { target: this } );

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/transition/MoveTransition-spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/transition/MoveTransition-spec.js
@@ -8,11 +8,8 @@ let contentDom;
 const HTML_SNIPPET = '<div class="content-1"></div>';
 
 describe( 'MoveTransition', () => {
-  beforeAll( () => {
-    document.body.innerHTML = HTML_SNIPPET;
-  } );
-
   beforeEach( () => {
+    document.body.innerHTML = HTML_SNIPPET;
     contentDom = document.querySelector( '.content-1' );
     transition = new MoveTransition( contentDom );
     transition.init();
@@ -33,6 +30,19 @@ describe( 'MoveTransition', () => {
         expect( contentDom.className ).toStrictEqual( classes );
       } );
     } );
+
+    it( 'should remove u-is-animating class when transition duration is zero',
+      () => {
+        transition.animateOff();
+        transition.moveToOrigin();
+        const classes = 'content-1 u-move-transition ' +
+                      'u-no-animation u-move-to-origin';
+        expect( contentDom.className ).toStrictEqual( classes );
+        transition.addEventListener( 'transitionend', () => {
+          const classes = 'content-1 u-move-transition u-move-to-origin';
+          expect( contentDom.className ).toStrictEqual( classes );
+        } );
+      } );
   } );
 
   describe( '.moveRight()', () => {


### PR DESCRIPTION
`transitionEnd` event will not fire if the transition duration is zero, which leads to the `u-is-animating` class from not being removed. We therefore should manually called the transitionComplete event handler immediately if the `u-no-animation` class is present.

## Changes

- When using a transition, call the transitionComplete event handler immediately if the `u-no-animation` class is present.
- Add test to check for proper removal of `u-is-animating` class if transition duration is zero.

## Testing

1. PR checks should pass.
