### PR TITLE
Make Iconography tables full width of container

### DIFF
--- a/docs/pages/iconography.md
+++ b/docs/pages/iconography.md
@@ -65,8 +65,7 @@ variation_groups:
           | {% include icons/arrow-down.svg %}  | {% include icons/arrow-down-round.svg %}  | arrow-down     |               |
 
           | {% include icons/arrow-left.svg %}  | {% include icons/arrow-left-round.svg %}  | arrow-left     |               |
-
-
+          
           {: class="icon-table"}
 
 
@@ -99,7 +98,6 @@ variation_groups:
 
           | {% include icons/percentage.svg %} | {% include icons/percentage-round.svg %} | percentage     | percent                                            |
 
-
           {: class="icon-table"}
 
 
@@ -124,7 +122,6 @@ variation_groups:
 
           | {% include icons/youtube.svg %}  | {% include icons/youtube-square.svg %}  | youtube        |                         |
 
-
           {: class="icon-table"}
 
 
@@ -146,7 +143,6 @@ variation_groups:
           | {% include icons/technology.svg %} | {% include icons/technology-round.svg %} | technology     | cellphone, tablet  |
 
           | {% include icons/web.svg %}        | {% include icons/web-round.svg %}        | web            | globe, world       |
-
 
           {: class="icon-table"}
 
@@ -179,7 +175,6 @@ variation_groups:
           | {% include icons/save.svg %}       | {% include icons/save-round.svg %}       | save           | disk               |
 
           | {% include icons/supplement.svg %} | {% include icons/supplement-round.svg %} | supplement     |                    |
-
 
           {: class="icon-table"}
 
@@ -234,7 +229,6 @@ variation_groups:
           | {% include icons/piggy-bank-check.svg %}      | {% include icons/piggy-bank-check-round.svg %}      | piggy-bank-check      |                                           |
 
           | {% include icons/split.svg %}                 | {% include icons/split-round.svg %}                 | split                 |                                           |
-
 
           {: class="icon-table"}
 
@@ -315,7 +309,6 @@ variation_groups:
           | {% include icons/user.svg %}          | {% include icons/user-round.svg %}          | user           | person                           |
 
           | {% include icons/wifi.svg %}          | {% include icons/wifi-round.svg %}          | wifi           | wi-fi, wireless                  |
-
 
           {: class="icon-table"}
         variation_name: ""


### PR DESCRIPTION
This resolves #1136, where tables generated via markdown on the Iconography page were not expanding to the full width of their container. Someone had attempted to fix this before by creating an `icon-table` class, but because Markdown spacing is finicky the class wasn't being applied. To properly apply the class one line of space should come between the table markup and the `{: class="icon-table"}` class signifier.

For example:

```md

          | icon                                | icon-round                                | canonical name | aliases       |

          | ----------------------------------- | ----------------------------------------- | -------------- | ------------- |

          | {% include icons/up.svg %}          | {% include icons/up-round.svg %}          | up             | chevron-up    |

          | {% include icons/right.svg %}       | {% include icons/right-round.svg %}       | right          | chevron-right |

          | {% include icons/down.svg %}        | {% include icons/down-round.svg %}        | down           | chevron-down  |

          | {% include icons/left.svg %}        | {% include icons/left-round.svg %}        | left           | chevron-left  |

          | {% include icons/arrow-up.svg %}    | {% include icons/arrow-up-round.svg %}    | arrow-up       |               |

          | {% include icons/arrow-right.svg %} | {% include icons/arrow-right-round.svg %} | arrow-right    |               |

          | {% include icons/arrow-down.svg %}  | {% include icons/arrow-down-round.svg %}  | arrow-down     |               |

          | {% include icons/arrow-left.svg %}  | {% include icons/arrow-left-round.svg %}  | arrow-left     |               |
          
          {: class="icon-table"}
```

## Before

<img width="904" alt="103696999-4a35c700-4f6d-11eb-83e8-ba76272d1092" src="https://user-images.githubusercontent.com/212533/104356644-30026880-54da-11eb-81ff-b3a023cd7733.png">

## After

![Screen Shot 2021-01-12 at 1 29 11 PM](https://user-images.githubusercontent.com/212533/104356662-355fb300-54da-11eb-8f96-4211bafeb3a3.png)