### PR TITLE
Tables: Adjust table header style

### DIFF
--- a/packages/cfpb-core/src/base.less
+++ b/packages/cfpb-core/src/base.less
@@ -485,11 +485,12 @@ td {
     padding: unit( 10px / @base-font-size-px, em );
 
     thead & {
-        .h5();
-
-        padding: unit( 10px / @font-size, em );
+        // 10px / 14px
+        padding: unit( 10px / @size-v, em );
         background: @table-head-bg;
         color: @table-head-text;
+        font-size: unit( 16px / @base-font-size-px, em );
+        vertical-align: top;
     }
 }
 


### PR DESCRIPTION
## Changes

- Changes table headers from H5 to paragraph medium, sentence case, and top-aligning the baseline.

## Testing

1. Check tables page in this PR and compare table headers to https://cfpb.github.io/design-system/components/tables

## Screenshots

Before:
<img width="431" alt="Screen Shot 2021-01-12 at 1 21 24 PM" src="https://user-images.githubusercontent.com/704760/104355946-5c69b500-54d9-11eb-9ed4-c81d1e2fbde0.png">

After:
<img width="424" alt="Screen Shot 2021-01-12 at 1 30 35 PM" src="https://user-images.githubusercontent.com/704760/104356817-6344f780-54da-11eb-96e3-a1fb58e7643a.png">

