### PR TITLE
InstantiateAll: Check for value in data-js-hook as opposed to existence of attribute

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/atomic-helpers.js
+++ b/packages/cfpb-atomic-component/src/utilities/atomic-helpers.js
@@ -127,7 +127,7 @@ function instantiateAll( selector, Constructor, scope ) {
   let element;
   for ( let i = 0, len = elements.length; i < len; i++ ) {
     element = elements[i];
-    if ( element.hasAttribute( 'data-js-hook' ) === false ) {
+    if ( dataHook.contains( element, INIT_FLAG ) === false ) {
       inst = new Constructor( element );
       inst.init();
       insts.push( inst );


### PR DESCRIPTION
`InstantiateAll` was checking for the existence of the `data-js-hook` attribute, instead of checking its value, meaning it would be prevented from creating new instances if a component already had the `data-js-hook` attribute, but had not yet been initialized.

## Changes

- Makes `instantiateAll` check `data-js-hook` value instead of only the existence of the attribute.

## Testing

1. Hard to test till it's released, but it could be used at https://github.com/cfpb/consumerfinance.gov/pull/6206#discussion_r556570024
