### PR TITLE
Add unit test for data-hook and instantiateAll

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/atomic-helpers.js
+++ b/packages/cfpb-atomic-component/src/utilities/atomic-helpers.js
@@ -9,7 +9,7 @@
    - Atom
    ========================================================================= */
 
-import * as dataHook from './data-hook';
+import { add, contains, remove } from './data-hook';
 import { STATE_PREFIX } from './standard-type';
 
 /**
@@ -86,11 +86,11 @@ function _verifyClassExists( element, baseClass ) {
  *   false otherwise.
  */
 function setInitFlag( element ) {
-  if ( dataHook.contains( element, INIT_FLAG ) ) {
+  if ( contains( element, INIT_FLAG ) ) {
     return false;
   }
 
-  dataHook.add( element, INIT_FLAG );
+  add( element, INIT_FLAG );
 
   return true;
 }
@@ -103,11 +103,11 @@ function setInitFlag( element ) {
  *   otherwise false if it didn't exist.
  */
 function destroyInitFlag( element ) {
-  if ( !dataHook.contains( element, INIT_FLAG ) ) {
+  if ( !contains( element, INIT_FLAG ) ) {
     return false;
   }
 
-  dataHook.remove( element, INIT_FLAG );
+  remove( element, INIT_FLAG );
 
   return true;
 }
@@ -127,7 +127,7 @@ function instantiateAll( selector, Constructor, scope ) {
   let element;
   for ( let i = 0, len = elements.length; i < len; i++ ) {
     element = elements[i];
-    if ( dataHook.contains( element, INIT_FLAG ) === false ) {
+    if ( contains( element, INIT_FLAG ) === false ) {
       inst = new Constructor( element );
       inst.init();
       insts.push( inst );

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/atomic-helpers-spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/atomic-helpers-spec.js
@@ -62,12 +62,22 @@ describe( 'atomic-helpers', () => {
       const instArr = instantiateAll( `.${ testClass }`, AtomicComponent );
       expect( instArr ).toBeInstanceOf( Array );
       expect( instArr.length ).toBe( 2 );
+      const instArr2 = instantiateAll( `.${ testClass }`, AtomicComponent );
+      expect( instArr2 ).toBeInstanceOf( Array );
+      expect( instArr2.length ).toBe( 0 );
     } );
 
     it( 'should return an empty array if no instances found', () => {
       const instArr = instantiateAll( '.missing-class', AtomicComponent );
       expect( instArr ).toBeInstanceOf( Array );
       expect( instArr.length ).toBe( 0 );
+    } );
+
+    it( 'should not return instances that have already been initialized', () => {
+      componentDom.setAttribute( 'data-js-hook', 'state_atomic_init' );
+      const instArr = instantiateAll( `.${ testClass }`, AtomicComponent );
+      expect( instArr ).toBeInstanceOf( Array );
+      expect( instArr.length ).toBe( 1 );
     } );
   } );
 

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/data-hook-spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/data-hook-spec.js
@@ -1,0 +1,47 @@
+import {
+  add,
+  contains,
+  remove
+} from '../../../../../../packages/cfpb-atomic-component/src/utilities/data-hook.js';
+
+let testComponent;
+
+const HTML_SNIPPET = `
+<div id="test-component" data-js-hook="test_behavior">
+</div>
+`;
+
+describe( 'Data hook', () => {
+  beforeEach( () => {
+    document.body.innerHTML = HTML_SNIPPET;
+    testComponent = document.querySelector( '#test-component' );
+  } );
+
+  describe( 'add()', () => {
+    it( 'should add a value to the data-* attribute of the element', () => {
+      add( testComponent, 'test_state' );
+      expect( testComponent.getAttribute( 'data-js-hook' ) ).toBe( 'test_behavior test_state' );
+    } );
+  } );
+
+  describe( 'contains()', () => {
+    it( 'should contain a value in the data-* attribute of the element', () => {
+      expect( contains( testComponent, 'test_state' ) ).toBe( false );
+      expect( contains( testComponent, 'test_behavior' ) ).toBe( true );
+    } );
+  } );
+
+  describe( 'remove()', () => {
+    it( 'should remove a value to the data-* attribute of the element', () => {
+      remove( testComponent, 'test_behavior' );
+      expect( testComponent.getAttribute( 'data-js-hook' ) ).toBe( '' );
+    } );
+  } );
+
+  describe( 'remove()', () => {
+    it( 'should remove a value to the data-* attribute of the element', () => {
+      remove( testComponent, 'test_behavior' );
+      expect( testComponent.getAttribute( 'data-js-hook' ) ).toBe( '' );
+    } );
+  } );
+} );

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/data-hook-spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/data-hook-spec.js
@@ -37,11 +37,4 @@ describe( 'Data hook', () => {
       expect( testComponent.getAttribute( 'data-js-hook' ) ).toBe( '' );
     } );
   } );
-
-  describe( 'remove()', () => {
-    it( 'should remove a value to the data-* attribute of the element', () => {
-      remove( testComponent, 'test_behavior' );
-      expect( testComponent.getAttribute( 'data-js-hook' ) ).toBe( '' );
-    } );
-  } );
 } );


### PR DESCRIPTION
## Changes

- Add unit test spec for `data-hook.js`.
- Adjust data-hook import to import specific methods.
- Add additional `instantiateAll` test.

## Testing

1. `gulp test:unit` should pass.