### PR TITLE
Buttons: Darken red warning button text

### DIFF
--- a/docs/pages/variables.md
+++ b/docs/pages/variables.md
@@ -30,7 +30,7 @@ variation_groups:
 
           // .btn__warning
           @btn__warning-text:         @white;
-          @btn__warning-bg:           @red;
+          @btn__warning-bg:           @red-mid-dark;
           @btn__warning-bg-hover:     @red-dark;
           @btn__warning-bg-active:    @gray-dark;
 

--- a/packages/cfpb-buttons/src/cfpb-buttons.less
+++ b/packages/cfpb-buttons/src/cfpb-buttons.less
@@ -23,7 +23,7 @@
 
 // .btn__warning
 @btn__warning-text:             @white;
-@btn__warning-bg:               @red;
+@btn__warning-bg:               @red-mid-dark;
 @btn__warning-bg-hover:         @red-dark;
 @btn__warning-bg-active:        @gray-dark;
 

--- a/packages/cfpb-buttons/usage.md
+++ b/packages/cfpb-buttons/usage.md
@@ -55,7 +55,7 @@ Color variables referenced in comments are from [@cfpb/cfpb-core's brand-colors.
 
 // .btn__warning
 @btn__warning-text:         @white;
-@btn__warning-bg:           @red;
+@btn__warning-bg:           @red-mid-dark;
 @btn__warning-bg-hover:     @red-dark;
 @btn__warning-bg-active:    @gray-dark;
 


### PR DESCRIPTION
Fixes [GHE]/CFGOV/platform/issues/3915

## Changes

- Darkens red warning text buttons.

## Testing

1. Visit the buttons page in the PR preview and check the "Destructive action" example and compare to https://cfpb.github.io/design-system/components/buttons
