### PR TITLE
Move imports to top and changes to absolute imports

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/transition/transition.less
+++ b/packages/cfpb-atomic-component/src/utilities/transition/transition.less
@@ -1,3 +1,6 @@
+// Import external dependencies
+@import (reference) '@cfpb/cfpb-core/src/vars.less';
+
 /* ==========================================================================
    Utility classes for transitions.
 

--- a/packages/cfpb-buttons/src/cfpb-buttons.less
+++ b/packages/cfpb-buttons/src/cfpb-buttons.less
@@ -1,3 +1,7 @@
+// Import external dependencies
+@import (less) '@cfpb/cfpb-core/src/cfpb-core.less';
+@import (less) '@cfpb/cfpb-icons/src/cfpb-icons.less';
+
 /* ==========================================================================
    Design System
    Button Styling
@@ -43,12 +47,6 @@
 
 // .btn__super
 @btn__super-font-size:          18px;
-
-
-// Import external dependencies
-
-@import (less) '../../cfpb-core/src/cfpb-core.less';
-@import (less) '../../cfpb-icons/src/cfpb-icons.less';
 
 
 // Import atomic components of @cfpb/buttons

--- a/packages/cfpb-core/src/vars.less
+++ b/packages/cfpb-core/src/vars.less
@@ -1,3 +1,6 @@
+// Import external dependencies
+@import (reference) '@cfpb/cfpb-core/src/brand-colors.less';
+
 /* ==========================================================================
    Design System
    Less variables

--- a/packages/cfpb-expandables/src/cfpb-expandables.less
+++ b/packages/cfpb-expandables/src/cfpb-expandables.less
@@ -1,3 +1,8 @@
+// Import external dependencies
+@import (less) '@cfpb/cfpb-core/src/cfpb-core.less';
+@import (less) '@cfpb/cfpb-buttons/src/cfpb-buttons.less';
+@import (less) '@cfpb/cfpb-icons/src/cfpb-icons.less';
+
 /* ==========================================================================
    Design System
    Expandable Styling
@@ -30,14 +35,6 @@
 
 // .o-expandable_content__transition
 @expandable__transition-speed:  0.25s;
-
-
-// Import external dependencies
-
-@import (less) '../../cfpb-core/src/cfpb-core.less';
-@import (less) '../../cfpb-buttons/src/cfpb-buttons.less';
-@import (less) '../../cfpb-icons/src/cfpb-icons.less';
-
 
 //
 // Recommended expandable pattern

--- a/packages/cfpb-forms/src/atoms/select.less
+++ b/packages/cfpb-forms/src/atoms/select.less
@@ -1,8 +1,5 @@
-//
 // Import external dependencies
-//
-
-@import (reference) '../../../cfpb-icons/src/cfpb-icons.less';
+@import (reference) '@cfpb/cfpb-icons/src/cfpb-icons.less';
 
 .a-select {
     position: relative;

--- a/packages/cfpb-forms/src/cfpb-forms.less
+++ b/packages/cfpb-forms/src/cfpb-forms.less
@@ -1,3 +1,9 @@
+// Import external dependencies
+@import (less) '@cfpb/cfpb-grid/src/cfpb-grid.less';
+@import (less) '@cfpb/cfpb-core/src/cfpb-core.less';
+@import (less) '@cfpb/cfpb-buttons/src/cfpb-buttons.less';
+@import (less) '@cfpb/cfpb-icons/src/cfpb-icons.less';
+
 /* ==========================================================================
    Design System
    Form Element Styling
@@ -56,17 +62,6 @@
 
 // .a-select
 @select-height:                           35px;
-
-
-//
-// Import external dependencies
-//
-
-@import (less) '../../cfpb-grid/src/cfpb-grid.less';
-@import (less) '../../cfpb-core/src/cfpb-core.less';
-@import (less) '../../cfpb-buttons/src/cfpb-buttons.less';
-@import (less) '../../cfpb-icons/src/cfpb-icons.less';
-
 
 //
 // Import atoms

--- a/packages/cfpb-layout/src/cfpb-layout.less
+++ b/packages/cfpb-layout/src/cfpb-layout.less
@@ -1,3 +1,7 @@
+// Import external dependencies
+@import (less) '@cfpb/cfpb-core/src/cfpb-core.less';
+@import (less) '@cfpb/cfpb-grid/src/cfpb-grid.less';
+
 /* ==========================================================================
    Design System
    Layout Helpers
@@ -55,13 +59,6 @@
 @well-border:                   @block__border;
 // 8 columns plus gutters
 @well-max:                      ( ( @grid_wrapper-width - @grid_gutter-width ) / @grid_total-columns * 8 ) - @grid_gutter-width;
-
-//
-// Import external dependencies
-//
-
-@import (less) '../../cfpb-core/src/cfpb-core.less';
-@import (less) '../../cfpb-grid/src/cfpb-grid.less';
 
 //
 // Content layouts

--- a/packages/cfpb-notifications/src/cfpb-notifications.less
+++ b/packages/cfpb-notifications/src/cfpb-notifications.less
@@ -1,3 +1,7 @@
+// Import external dependencies
+@import (less) '@cfpb/cfpb-core/src/cfpb-core.less';
+@import (less) '@cfpb/cfpb-icons/src/cfpb-icons.less';
+
 /* ==========================================================================
    Design System
    Notifications Styling
@@ -27,15 +31,6 @@
 // Sizing variables
 
 @notification-padding__px:    15px;
-
-
-//
-// Import external dependencies
-//
-
-@import (less) '../../cfpb-core/src/cfpb-core.less';
-@import (less) '../../cfpb-icons/src/cfpb-icons.less';
-
 
 //
 // Molecules

--- a/packages/cfpb-notifications/src/organisms/banner.less
+++ b/packages/cfpb-notifications/src/organisms/banner.less
@@ -1,10 +1,10 @@
+// Import required component dependencies.
+@import (reference) '@cfpb/cfpb-grid/src/cfpb-grid.less';
+
 //
 // Banner
 // Global banner in the header.
 //
-
-// Import required component dependencies.
-@import (reference) '../../../cfpb-grid/src/cfpb-grid.less';
 
 .o-banner {
     padding: unit( @grid_gutter-width / 2 / @base-font-size-px, em ) 0;

--- a/packages/cfpb-pagination/src/cfpb-pagination.less
+++ b/packages/cfpb-pagination/src/cfpb-pagination.less
@@ -1,3 +1,8 @@
+// Import external dependencies
+@import (less) '@cfpb/cfpb-core/src/cfpb-core.less';
+@import (less) '@cfpb/cfpb-buttons/src/cfpb-buttons.less';
+@import (less) '@cfpb/cfpb-icons/src/cfpb-icons.less';
+
 /* ==========================================================================
    Design System
    Pagination Styling
@@ -15,14 +20,6 @@
 // Sizing variables
 
 @pagination-btn-min-width-px: 130px;
-
-//
-// Import external dependencies
-//
-
-@import (less) '../../cfpb-core/src/cfpb-core.less';
-@import (less) '../../cfpb-buttons/src/cfpb-buttons.less';
-@import (less) '../../cfpb-icons/src/cfpb-icons.less';
 
 //
 // Molecules

--- a/packages/cfpb-tables/src/cfpb-tables.less
+++ b/packages/cfpb-tables/src/cfpb-tables.less
@@ -1,3 +1,7 @@
+// Import external dependencies
+@import (reference) '@cfpb/cfpb-core/src/cfpb-core.less';
+@import (reference) '@cfpb/cfpb-icons/src/cfpb-icons.less';
+
 /* ==========================================================================
    Design System
    Table Styling
@@ -15,13 +19,6 @@
 @table-row-link-hover-color: @white;
 @table-scrolling-border:     @gray-40;
 @table-border:               @gray;
-
-//
-// Import external dependencies
-//
-
-@import (reference) '../../cfpb-core/src/cfpb-core.less';
-@import (reference) '../../cfpb-icons/src/cfpb-icons.less';
 
 // Mixins
 .striped-table() {

--- a/packages/cfpb-typography/src/cfpb-typography.less
+++ b/packages/cfpb-typography/src/cfpb-typography.less
@@ -1,3 +1,7 @@
+// Import external dependencies
+@import (less) '@cfpb/cfpb-core/src/cfpb-core.less';
+@import (less) '@cfpb/cfpb-icons/src/cfpb-icons.less';
+
 /* ==========================================================================
    Design System
    Advanced Typography
@@ -53,13 +57,6 @@
 // .a-link__jump
 @jump-link_bg: @gray-10;
 @jump-link_border: @gray-40;
-
-//
-// Import external dependencies
-//
-
-@import (less) '../../cfpb-core/src/cfpb-core.less';
-@import (less) '../../cfpb-icons/src/cfpb-icons.less';
 
 //
 // Import atoms


### PR DESCRIPTION
`gulp build` was not passing because the `transitions.less` file needs a variable from `vars.less`. `vars.less` needs a variable from `brand-colors.less`.

## Changes

- Move imports to top of file.
- Changes to absolute imports.
- Add reference import to `brand-colors.less` inside `vars.less`.

## Testing

1. `gulp build` should pass.
2. DS PR preview should be unchanged from production.
