### PR TITLE
Multiselect: Remove indexOfObject utility

### DIFF
--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -171,7 +171,9 @@ function Multiselect( element ) { // eslint-disable-line max-statements
       inside:    _fieldsetDom
     } );
 
-    _optionsData.forEach( function( option ) {
+    let option;
+    for ( let i = 0, len = _optionsData.length; i < len; i++ ) {
+      option = _optionsData[i];
       const _optionsItemDom = MultiselectUtils.create( 'li', {
         'data-option': option.value,
         'class': 'm-form-field m-form-field__checkbox'
@@ -185,7 +187,8 @@ function Multiselect( element ) { // eslint-disable-line max-statements
         'name':    _name,
         'class':   CHECKBOX_INPUT_CLASS + ' ' + BASE_CLASS + '_checkbox',
         'inside':  _optionsItemDom,
-        'checked': option.checked
+        'checked': option.checked,
+        'data-index': i
       } );
 
       MultiselectUtils.create( 'label', {
@@ -201,7 +204,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
       if ( option.checked ) {
         _createSelectedItem( _selectionsDom, option );
       }
-    } );
+    }
 
     // Write our new markup to the DOM.
     _containerDom.appendChild( _headerDom );
@@ -267,14 +270,9 @@ function Multiselect( element ) { // eslint-disable-line max-statements
 
   /**
    * Tracks a user's selections and updates the list in the dom.
-   * @param {string} value The value of the option the user has chosen.
+   * @param {number} optionIndex - The index position of the chosen option.
    */
-  function _updateSelections( value ) {
-    const optionIndex = MultiselectUtils.indexOfObject(
-      _optionsData,
-      'value',
-      value
-    );
+  function _updateSelections( optionIndex ) {
     const option = _optionsData[optionIndex] || _optionsData[_model.getIndex()];
 
     if ( option ) {
@@ -524,7 +522,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
    * @param   {Event} event The checkbox change event.
    */
   function _changeHandler( event ) {
-    _updateSelections( event.target.value );
+    _updateSelections( Number( event.target.getAttribute( 'data-index' ) ) );
     _resetSearch();
   }
 

--- a/packages/cfpb-forms/src/organisms/MultiselectUtils.js
+++ b/packages/cfpb-forms/src/organisms/MultiselectUtils.js
@@ -1,29 +1,6 @@
 import { queryOne } from '@cfpb/cfpb-atomic-component/src/utilities/dom-traverse.js';
 
 /**
- * Searches an array for the first object with the matching key:value pair.
- * @param   {Array}  array - List to query through for the expected value.
- * @param   {string} key   - The key to check the value against.
- * @param   {string} val   - The value to match to the key.
- * @returns {number}       Returns the index of a match, otherwise -1.
- */
-function indexOfObject( array, key, val ) {
-  let match = -1;
-
-  if ( !array.length > 0 ) {
-    return match;
-  }
-
-  array.forEach( function( item, index ) {
-    if ( item[key] === val ) {
-      match = index;
-    }
-  } );
-
-  return match;
-}
-
-/**
  * Shortcut for creating new dom elements.
  * @param {string} tag - The html elem to create.
  * @param {Object} options - The options for building the elem.
@@ -57,6 +34,5 @@ function create( tag, options ) {
 }
 
 export default {
-  indexOfObject: indexOfObject,
   create: create
 };

--- a/test/unit-test/src/cfpb-forms/src/organisms/MultiselectUtils-spec.js
+++ b/test/unit-test/src/cfpb-forms/src/organisms/MultiselectUtils-spec.js
@@ -1,39 +1,6 @@
 import MultiselectUtils from '../../../../../../packages/cfpb-forms/src/organisms/MultiselectUtils.js';
-let array;
-let index;
 
 describe( 'MultiselectUtils', () => {
-
-  describe( 'indexOfObject()', () => {
-
-    it( 'should return -1 if the array is empty', () => {
-      array = [];
-      index = MultiselectUtils.indexOfObject( array, 'foo' );
-
-      expect( index ).toBe( -1 );
-    } );
-
-    it( 'should return -1 if there is no match', () => {
-      array = [
-        { value: 'bar' },
-        { value: 'baz' }
-      ];
-      index = MultiselectUtils.indexOfObject( array, 'value', 'foo' );
-
-      expect( index ).toBe( -1 );
-    } );
-
-    it( 'should return the matched index', () => {
-      array = [
-        { value: 'foo' },
-        { value: 'bar' },
-        { value: 'baz' }
-      ];
-      index = MultiselectUtils.indexOfObject( array, 'value', 'foo' );
-
-      expect( index ).toBe( 0 );
-    } );
-  } );
 
   describe( 'create()', () => {
     beforeAll( () => {


### PR DESCRIPTION
For every selection of a multiselect item, the stored list of option data is iterated over for a match. This PR places an attribute on the `inputs`, `data-index`, which records their original index position in the underlying `<select>` element. In the future maybe we can pass this index around within the multiselect and not require storing it in the dom, but this gets rid of the search step through removal of the `indexOfObject` utility.

## Removals

- Multiselect `indexOfObject` utility.

## Changes

- Store checkbox input's index position within a `data-index` attribute in the markup.

## Testing

1. Check dropdowns and multiselects page on the preview PR. The multiselect should be able to add and remove options same as before.
