### PR TITLE
Multiselect: Remove redundant _optionsData array

### DIFF
--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -243,7 +243,10 @@ function Multiselect( element ) { // eslint-disable-line max-statements
    * @returns {string} A hopefully unique ID.
    */
   function _getOptionId( option ) {
-    return _name + '-' + option.value.trim().replace( /\s+/g, '-' ).toLowerCase();
+    /* Replace any character that is not a word character with a dash.
+       https://regex101.com/r/ShHmRw/1
+    */
+    return _name + '-' + option.value.trim().replace( /[^\w]/g, '-' ).toLowerCase();
   }
 
   /**

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -54,7 +54,6 @@ function Multiselect( element ) { // eslint-disable-line max-statements
   let _placeholder;
   let _model;
   let _options;
-  let _optionsData;
 
   // Markup elems, conver this to templating engine in the future.
   let _containerDom;
@@ -85,9 +84,8 @@ function Multiselect( element ) { // eslint-disable-line max-statements
     _options = _dom.options || [];
 
     if ( _options.length > 0 ) {
-      _model = new MultiselectModel( _options, _name ).init();
-      _optionsData = _model.getOptions();
       const newDom = _populateMarkup();
+      _model = new MultiselectModel( _options, _name ).init();
 
       /* Removes <select> element,
          and re-assign DOM reference. */
@@ -171,37 +169,42 @@ function Multiselect( element ) { // eslint-disable-line max-statements
       inside:    _fieldsetDom
     } );
 
-    _optionsData.forEach( function( option ) {
-      const _optionsItemDom = MultiselectUtils.create( 'li', {
+    let option;
+    let optionId;
+    for ( let i = 0, len = _options.length; i < len; i++ ) {
+      option = _options[i];
+      optionId = _getOptionId( option );
+      const optionsItemDom = MultiselectUtils.create( 'li', {
         'data-option': option.value,
         'class': 'm-form-field m-form-field__checkbox'
       } );
 
       MultiselectUtils.create( 'input', {
-        'id':      option.id,
+        'id':      optionId,
         // Type must come before value or IE fails
         'type':    'checkbox',
         'value':   option.value,
         'name':    _name,
         'class':   CHECKBOX_INPUT_CLASS + ' ' + BASE_CLASS + '_checkbox',
-        'inside':  _optionsItemDom,
-        'checked': option.checked
+        'inside':  optionsItemDom,
+        'checked': option.defaultSelected,
+        'data-index': i
       } );
 
       MultiselectUtils.create( 'label', {
-        'for':         option.id,
+        'for':         optionId,
         'textContent': option.text,
         'className':   BASE_CLASS + '_label a-label',
-        'inside':      _optionsItemDom
+        'inside':      optionsItemDom
       } );
 
-      _optionItemDoms.push( _optionsItemDom );
-      _optionsDom.appendChild( _optionsItemDom );
+      _optionItemDoms.push( optionsItemDom );
+      _optionsDom.appendChild( optionsItemDom );
 
-      if ( option.checked ) {
+      if ( option.defaultSelected ) {
         _createSelectedItem( _selectionsDom, option );
       }
-    } );
+    }
 
     // Write our new markup to the DOM.
     _containerDom.appendChild( _headerDom );
@@ -215,13 +218,14 @@ function Multiselect( element ) { // eslint-disable-line max-statements
    * @param {HTMLNode} option - The OPTION item to extract content from.
    */
   function _createSelectedItem( selectionsDom, option ) {
+    const optionId = _getOptionId( option );
     const selectionsItemDom = MultiselectUtils.create( 'li', {
       'data-option': option.value
     } );
 
     const selectionsItemLabelDom = MultiselectUtils.create( 'button', {
       type: 'button',
-      innerHTML: '<label for=' + option.id + '>' +
+      innerHTML: '<label for=' + optionId + '>' +
                  option.text + closeIcon + '</label>',
       inside: selectionsItemDom
     } );
@@ -231,6 +235,15 @@ function Multiselect( element ) { // eslint-disable-line max-statements
 
     selectionsItemLabelDom.addEventListener( 'click', _selectionClickHandler );
     selectionsItemLabelDom.addEventListener( 'keydown', _selectionKeyDownHandler );
+  }
+
+  /**
+   * Create a unique ID based on a select's option HTML element.
+   * @param {HTMLNode} option - A option HTML element.
+   * @returns {string} A hopefully unique ID.
+   */
+  function _getOptionId( option ) {
+    return _name + '-' + option.value.trim().replace( /\s+/g, '-' ).toLowerCase();
   }
 
   /**
@@ -267,15 +280,10 @@ function Multiselect( element ) { // eslint-disable-line max-statements
 
   /**
    * Tracks a user's selections and updates the list in the dom.
-   * @param {string} value The value of the option the user has chosen.
+   * @param {number} optionIndex - The index position of the chosen option.
    */
-  function _updateSelections( value ) {
-    const optionIndex = MultiselectUtils.indexOfObject(
-      _optionsData,
-      'value',
-      value
-    );
-    const option = _optionsData[optionIndex] || _optionsData[_model.getIndex()];
+  function _updateSelections( optionIndex ) {
+    const option = _model.getOption( optionIndex ) || _model.getOption( _model.getIndex() );
 
     if ( option ) {
       if ( option.checked ) {
@@ -524,7 +532,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
    * @param   {Event} event The checkbox change event.
    */
   function _changeHandler( event ) {
-    _updateSelections( event.target.value );
+    _updateSelections( Number( event.target.getAttribute( 'data-index' ) ) );
     _resetSearch();
   }
 

--- a/packages/cfpb-forms/src/organisms/MultiselectModel.js
+++ b/packages/cfpb-forms/src/organisms/MultiselectModel.js
@@ -225,7 +225,6 @@ function MultiselectModel( options, name ) {
 
   // This is used to retrieve items from the collection.
   this.getOption = getOption;
-  this.getOptions = function() { return _optionsData; };
 
   return this;
 }

--- a/test/unit-test/src/cfpb-forms/src/organisms/MultiselectModel-spec.js
+++ b/test/unit-test/src/cfpb-forms/src/organisms/MultiselectModel-spec.js
@@ -233,12 +233,4 @@ describe( 'MultiselectModel', () => {
     } );
   } );
 
-  describe( 'getOptions()', () => {
-    it( 'should return the full options list', () => {
-      expect( multiselectModel.getOptions().length ).toBe( 6 );
-      multiselectModel.filterIndices( 'asdf' );
-      expect( multiselectModel.getOptions().length ).toBe( 6 );
-    } );
-  } );
-
 } );


### PR DESCRIPTION
`_optionsData` array is in `MultiselectModel` and `Multiselect`. It should only be in `MultiselectModel`.

## Changes

- Remove `_optionsData` array from `Multiselect`.
- Includes `data-index` attribute from https://github.com/cfpb/design-system/pull/1176

## Testing

1. Check dropdowns and multiselects page on the preview PR. The multiselect should be able to add and remove options same as before.
