### PR TITLE
Expand multiselect option targets

### DIFF
--- a/packages/cfpb-forms/src/organisms/multiselect.less
+++ b/packages/cfpb-forms/src/organisms/multiselect.less
@@ -93,12 +93,10 @@ select.o-multiselect {
 
     &_options {
         background-color: @white;
-        padding: unit( 10px / @base-font-size-px, em );
-        // Double padding on the right to accommodate the fieldset's forced y scrollbar above
-        padding-right: unit( 20px / @base-font-size-px, em );
+        padding: 0;
 
-        li:last-child {
-            margin-bottom: 0;
+        li {
+            margin: 0;
         }
 
         &.u-filtered li:not(.u-filter-match) {
@@ -125,6 +123,9 @@ select.o-multiselect {
         }
 
         .a-label {
+            box-sizing: border-box;
+            padding-top: unit( 10px / @base-font-size-px, em );
+            padding-left: unit( 10px / @base-font-size-px, em );
             width: 100%;
         }
     }


### PR DESCRIPTION
Remove all non-clickable area from around multiselect options to improve the UX and prevent a bug that causes misclicked multiselects to get permanently stuck open.

I was originally drafting a JS solution to the bug but a CSS solution ended up being much cleaner.

See https://github.local/CFPB/el-camino/issues/366

## Changes

- Add padding around the individual options instead of their container.

## Testing

1. Visit the PR preview link and confirm the problem described in the above issue no longer exists.

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
