### PR TITLE
Makes a-label__heading respond like an h4 on small screens

### DIFF
--- a/packages/cfpb-forms/src/atoms/label.less
+++ b/packages/cfpb-forms/src/atoms/label.less
@@ -30,5 +30,13 @@
                 margin-top: unit( 10px / @base-font-size-px, em );
             }
         }
+
+        .respond-to-max( @bp-xs-max, {
+            @h4-font-size-on-xs: @base-font-size-px;
+
+            margin-bottom: unit( 10px / @h4-font-size-on-xs, em );
+            font-size: unit( @h4-font-size-on-xs / @base-font-size-px, em );
+            line-height: unit( 18px / @h4-font-size-on-xs );
+        } );
     }
 }

--- a/packages/cfpb-forms/src/atoms/label.less
+++ b/packages/cfpb-forms/src/atoms/label.less
@@ -14,7 +14,7 @@
     }
 
     &__heading {
-        .heading-4();
+        .h4();
 
         display: block;
 
@@ -30,13 +30,5 @@
                 margin-top: unit( 10px / @base-font-size-px, em );
             }
         }
-
-        .respond-to-max( @bp-xs-max, {
-            @h4-font-size-on-xs: @base-font-size-px;
-
-            margin-bottom: unit( 10px / @h4-font-size-on-xs, em );
-            font-size: unit( @h4-font-size-on-xs / @base-font-size-px, em );
-            line-height: unit( 18px / @h4-font-size-on-xs );
-        } );
     }
 }


### PR DESCRIPTION
`.a-label__heading` is designed to function as an `h4` (via its call to the `.heading-4` mixin) but doesn't respond to small screens [like an `h4`](https://github.com/cfpb/design-system/blob/main/packages/cfpb-core/src/base.less#L250-L256). This PR fixes that.