### PR TITLE
Multiselect: Make arrow open/close drop-down

### DIFF
--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -124,7 +124,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
     _fieldsetDom.classList.add( 'u-invisible' );
     _fieldsetDom.setAttribute( 'aria-hidden', true );
     _model.resetIndex();
-    _instance.dispatchEvent( 'expandEnd', { target: _instance } );
+    _instance.dispatchEvent( 'collapseBegin', { target: _instance } );
 
     return _instance;
   }
@@ -413,6 +413,20 @@ function Multiselect( element ) { // eslint-disable-line max-statements
         target.style.cursor = 'pointer';
       } else {
         target.style.cursor = 'auto';
+      }
+    } );
+
+    _headerDom.addEventListener( 'mouseup', function( event ) {
+      const target = event.target;
+
+      /* Check if we're over the down-arrow on the right side of the input.
+         Also check if the fieldset is open.
+         35 = width of the arrow on the right of the search input.
+         140 = the max-height value set in multiselect.less for the fieldset.
+      */
+      if ( event.layerX > target.offsetWidth - 35 &&
+           _fieldsetDom.offsetHeight === 140 ) {
+        _searchDom.blur();
       }
     } );
 

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -410,7 +410,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
     _headerDom.addEventListener( 'mousemove', function( event ) {
       const target = event.target;
       // Check if we're over the down-arrow on the right side of the input.
-      if ( event.layerX > target.offsetWidth - 35 ) {
+      if ( event.offsetX > target.offsetWidth - 35 ) {
         target.style.cursor = 'pointer';
       } else {
         target.style.cursor = 'auto';
@@ -425,7 +425,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
          35 = width of the arrow on the right of the search input.
          140 = the max-height value set in multiselect.less for the fieldset.
       */
-      if ( event.layerX > target.offsetWidth - 35 &&
+      if ( event.offsetX > target.offsetWidth - 35 &&
            _fieldsetDom.offsetHeight === 140 ) {
         _searchDom.blur();
       }

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -124,7 +124,8 @@ function Multiselect( element ) { // eslint-disable-line max-statements
     _fieldsetDom.classList.add( 'u-invisible' );
     _fieldsetDom.setAttribute( 'aria-hidden', true );
     _model.resetIndex();
-    _instance.dispatchEvent( 'collapseBegin', { target: _instance } );
+    // TODO: This should be collapseBegin, not expandEnd, but we have a dependency on this event in the filters in cf.gov.
+    _instance.dispatchEvent( 'expandEnd', { target: _instance } );
 
     return _instance;
   }

--- a/packages/cfpb-forms/src/organisms/multiselect.less
+++ b/packages/cfpb-forms/src/organisms/multiselect.less
@@ -46,6 +46,13 @@ select.o-multiselect {
         }
     }
 
+    // Reverse arrow when search drop-down is open.
+    &.u-active {
+        .o-multiselect_header:after {
+            .u-svg-inline-bg( 'up' );
+        }
+    }
+
     &_search[type="text"] {
         display: block;
 


### PR DESCRIPTION
When you open the multiselect, let's make it so the down-arrow on the right-hand side closes it when clicked, yaaay! Also, let's flip the arrow when it is open! Yaaaah!

## Changes

- Make clicking the arrow in the search input open AND close the drop-down.
- Switch the drop-down arrow to an up arrow when the drop-down is open.

## Testing

1. Open the PR preview and go to the dropdowns and multiselects page and open and close the multiselect by clicking the arrow.

## Screenshots

![mm-dropdown](https://user-images.githubusercontent.com/704760/106785190-22448c80-661b-11eb-850f-6d460865156e.gif)
