### PR TITLE
MaxHeightTransition: Add refresh method

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/transition/MaxHeightTransition.js
+++ b/packages/cfpb-atomic-component/src/utilities/transition/MaxHeightTransition.js
@@ -31,7 +31,7 @@ function MaxHeightTransition( element ) {
   function init() {
     _baseTransition.init();
 
-    element.style.maxHeight = element.scrollHeight + 'px';
+    refresh();
 
     const _transitionCompleteBinded = _transitionComplete.bind( this );
     _baseTransition.addEventListener(
@@ -92,6 +92,13 @@ function MaxHeightTransition( element ) {
   }
 
   /**
+   * Refresh the max height set on the element.
+   */
+  function refresh() {
+    element.style.maxHeight = element.scrollHeight + 'px';
+  }
+
+  /**
    * Remove style attribute.
    * Remove all transition classes, if transition is initialized.
    * @returns {boolean}
@@ -113,6 +120,7 @@ function MaxHeightTransition( element ) {
   this.halt = _baseTransition.halt;
   this.isAnimated = _baseTransition.isAnimated;
   this.setElement = _baseTransition.setElement;
+  this.refresh = refresh;
   this.remove = remove;
 
   this.init = init;


### PR DESCRIPTION
If the window size is changing, we may need to recalculate the `max-height` of an element. This PR adds `refresh` method that does this re-calculation of the `max-height`.

## Additions

- Add `refresh` method to `MaxHeightTransition` for re-calculating the inline `max-height` of the element.

## Testing

1. No changes here. It'll get used in cf.gov.