### PR TITLE
Bugfix: multiselect missing padding on max selection

### DIFF
--- a/packages/cfpb-forms/src/organisms/multiselect.less
+++ b/packages/cfpb-forms/src/organisms/multiselect.less
@@ -131,8 +131,12 @@ select.o-multiselect {
             content: 'No results found';
         }
 
-        &.u-max-selections:after {
-            content: 'Reached maximum of five selections';
+        &.u-max-selections {
+            padding: unit( 10px / @base-font-size-px, em );
+
+            &:after {
+                content: 'Reached maximum of five selections';
+            }
         }
 
         .a-label {

--- a/packages/cfpb-forms/src/organisms/multiselect.less
+++ b/packages/cfpb-forms/src/organisms/multiselect.less
@@ -133,6 +133,7 @@ select.o-multiselect {
 
         &.u-max-selections {
             padding: unit( 10px / @base-font-size-px, em );
+            pointer-events: none;
 
             &:after {
                 content: 'Reached maximum of five selections';


### PR DESCRIPTION
## Changes

- Adds padding to max selections view of drop-down.
- Adds `pointer-events: none` to max selections view, so that clicking the drop-down closes it.

## Testing

1. In PR preview open multiselects page and interact with multiselect to select five options. Max selections view should have padding and close when clicked.

## Screenshots

<img width="609" alt="Screen Shot 2021-02-04 at 11 48 33 AM" src="https://user-images.githubusercontent.com/704760/106926273-ed9a0900-66de-11eb-8134-b73f3a051e02.png">


## Todos

- Arrow doesn't work to close the drop-down (on max selection view) as we don't have a good way yet to know when the drop-down is completely open.
