### PR TITLE
MaxHeightTransition: Convert summary transition to px from ems

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/transition/MaxHeightTransition.js
+++ b/packages/cfpb-atomic-component/src/utilities/transition/MaxHeightTransition.js
@@ -31,7 +31,7 @@ function MaxHeightTransition( element ) {
   function init() {
     _baseTransition.init();
 
-    /* The scrollHeight of an element may incorrect if the page hasn't
+    /* The scrollHeight of an element may be incorrect if the page hasn't
        fully loaded yet, so we listen for that to happen before calculating
        the element max-height. */
     window.addEventListener( 'load', _pageLoaded );

--- a/packages/cfpb-atomic-component/src/utilities/transition/MaxHeightTransition.js
+++ b/packages/cfpb-atomic-component/src/utilities/transition/MaxHeightTransition.js
@@ -31,7 +31,10 @@ function MaxHeightTransition( element ) {
   function init() {
     _baseTransition.init();
 
-    refresh();
+    /* The scrollHeight of an element may incorrect if the page hasn't
+       fully loaded yet, so we listen for that to happen before calculating
+       the element max-height. */
+    window.addEventListener( 'load', _pageLoaded );
 
     const _transitionCompleteBinded = _transitionComplete.bind( this );
     _baseTransition.addEventListener(
@@ -40,6 +43,15 @@ function MaxHeightTransition( element ) {
     );
 
     return this;
+  }
+
+  /**
+   * The whole page has loaded,
+   * including all dependent resources such as stylesheets and images.
+   */
+  function _pageLoaded() {
+    window.removeEventListener( 'load', _pageLoaded );
+    refresh();
   }
 
   /**
@@ -93,6 +105,7 @@ function MaxHeightTransition( element ) {
 
   /**
    * Refresh the max height set on the element.
+   * This may be useful if resizing the window and the content height changes.
    */
   function refresh() {
     element.style.maxHeight = element.scrollHeight + 'px';

--- a/packages/cfpb-atomic-component/src/utilities/transition/transition.less
+++ b/packages/cfpb-atomic-component/src/utilities/transition/transition.less
@@ -81,5 +81,10 @@
 }
 
 .u-max-height-summary {
-    max-height: unit( @base-line-height-px * 4 / @base-font-size-px, em ) !important;
+    /* The value set here should show 4 lines of text at our standard 16px
+       base font size. The calculation comes from the following:
+       88px = 16 * 5.5em.
+       5.5em = base-line-height (22px) * 4 / base-font-size (16px)
+    */
+    max-height: 88px !important;
 }


### PR DESCRIPTION
Probably best to show a fixed height for the summary, regardless on base font size. This changes the max-height to pixels from ems, and match the value set in the Summary component https://github.com/cfpb/consumerfinance.gov/blob/c1bc097d598ffae6f1c2215e1bcac3c057f972d1/cfgov/unprocessed/js/organisms/Summary.js#L45

## Changes

- Change `u-max-height-summary` `max-height` to pixels from ems.
- Set the `max-height` on the element when the page has fully loaded, as the reported value from `scrollHeight` may be incorrect before then.

## Testing

1. max-height transition on the /design-system/patterns/transition-patterns page in the PR preview should work as before.
2. Change the font-size in the Chrome settings and reload the page. See that the box is the same height, whereas on https://cfpb.github.io/design-system/patterns/transition-patterns it is taller.
3. Expand the box by clicking it and the content should not be cropped at the bottom, whereas on https://cfpb.github.io/design-system/patterns/transition-patterns it may be (because the max-height was calculated before the page fully loaded).

## Screenshots

Before:
<img width="232" alt="Screen Shot 2021-02-05 at 3 23 46 PM" src="https://user-images.githubusercontent.com/704760/107085254-3678bd00-67c6-11eb-8ac8-401d326730e7.png">

After:
<img width="182" alt="Screen Shot 2021-02-05 at 3 25 02 PM" src="https://user-images.githubusercontent.com/704760/107085320-560fe580-67c6-11eb-861f-db46f1da66ad.png">

