### PR TITLE
Change mobile jump link background to @gray-5

### DIFF
--- a/docs/pages/variables.md
+++ b/docs/pages/variables.md
@@ -358,7 +358,7 @@ variation_groups:
           @link-underline-active:  @navy;
 
           // .a-link__jump
-          @jump-link_bg:           @gray-10;
+          @jump-link_bg:           @gray-5;
           @jump-link_border:       @gray-40;
 
           // code

--- a/packages/cfpb-typography/src/cfpb-typography.less
+++ b/packages/cfpb-typography/src/cfpb-typography.less
@@ -55,7 +55,7 @@
 // Links
 
 // .a-link__jump
-@jump-link_bg: @gray-10;
+@jump-link_bg: @gray-5;
 @jump-link_border: @gray-40;
 
 //

--- a/packages/cfpb-typography/usage.md
+++ b/packages/cfpb-typography/usage.md
@@ -80,7 +80,7 @@ Color variables referenced in comments are from [@cfpb/cfpb-core's brand-colors.
 // Links
 
 // .a-link__jump
-@jump-link_bg:              @gray-10;
+@jump-link_bg:              @gray-5;
 @jump-link_border:          @gray-40;
 ```
 


### PR DESCRIPTION
This improves the accessibility of jump links on mobile by increasing the contrast between the foreground text and background color.

Fixes #1201.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/109511445-07760400-7a71-11eb-8c95-e86083f4716b.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: