### PR TITLE
Add variation group name to fix missing h2

### DIFF
--- a/docs/pages/carousel.md
+++ b/docs/pages/carousel.md
@@ -15,7 +15,7 @@ description: >-
 
   Carousels offer poor usability and are considered an [anti-pattern](https://thegood.com/insights/ecommerce-image-carousels/). Their use is discouraged.
 variation_groups:
-  - variation_group_name: ""
+  - variation_group_name: Types
     variations:
       - variation_description: >-
           The standard carousel organism is comprised of a set of blocks of


### PR DESCRIPTION
The carousel anti-pattern page currently fails Lighthouse accessibility testing because it lacks an h2:

"Heading elements are not in a sequentially-descending order"

This causes the nightly Lighthouse tests to fail, for example:

https://github.com/cfpb/design-system/actions/runs/612274827