### PR TITLE
Fix imports in cfpb-design-system.js

### DIFF
--- a/packages/cfpb-design-system/src/cfpb-design-system.js
+++ b/packages/cfpb-design-system/src/cfpb-design-system.js
@@ -1,6 +1,6 @@
 // List yer JS modules
-const Expandable = require( '@cfpb/cfpb-expandables/src/Expandable' );
-const Table = require( '@cfpb/cfpb-tables/src/Table' );
+import Expandable from '@cfpb/cfpb-expandables/src/Expandable';
+import Table from '@cfpb/cfpb-tables/src/Table';
 
 Expandable.init();
 Table.init();


### PR DESCRIPTION
cfpb-design-system.js includes requires for modules instead of imports, which makes it unusable.

## Changes

- Change incorrect requires to imports in cfpb-design-system.js
