### PR TITLE
Expand DS documentation tables to full width

### DIFF
--- a/docs/assets/css/variation.less
+++ b/docs/assets/css/variation.less
@@ -36,9 +36,11 @@
         padding-left: 1rem;
         padding-right: 1rem;
     }
+
+    table {
+        .u-w100pct();
+    }
 }
-
-
 
 .m-variation {
     border-bottom: 1px solid @gray-40;


### PR DESCRIPTION
Editors of the DS website use markdown tables to organize content side-by-side. The HTML tables generated by the markdown are often unreasonably narrow because none of their inner content has a width specified.

I'm not modifying our .o-table organism because I only want to force tables to be full-width on the DS website, and not across cf.gov.

Fixes https://github.com/cfpb/design-system/issues/1239

## Testing

1. The [landing pages page](https://cfpb.github.io/design-system/pages/landing-pages) of the PR preview should have non-squished tables.

