### PR TITLE
Only hide expandable content during animation

### DIFF
--- a/packages/cfpb-expandables/src/cfpb-expandables.less
+++ b/packages/cfpb-expandables/src/cfpb-expandables.less
@@ -73,8 +73,6 @@
         // collapse and extend past the bounds of the expandable.
         .u-clearfix();
 
-        overflow: hidden;
-
         &__transition {
             transition: max-height @expandable__transition-speed ease-in-out;
         }
@@ -85,6 +83,10 @@
 
         &__expanded {
             max-height: 1000px;
+        }
+
+        &.u-is-animating {
+            overflow: hidden;
         }
     }
 


### PR DESCRIPTION
Expandables' overflow is hidden to prevent their contents from spilling
outside their containers when collapsing. A side effect is that UI elements
that *should* be allowed to spill outside their containers  (like multiselect
dropdowns) are unable to do so. The solution is to only hide overflow during
the collapsing animation.

This will allow us to convert cf.gov's filterable list controls checkboxes into multiselects.

## Changes

- Expandables' contents' overflow.

## Testing

1. PR tests should pass.
2. Nothing visual should change at the PR preview [expandables page](https://cfpb.github.io/design-system/components/expandables).

## Screenshots

| before (overflow hidden all the time) | after (only hidden during animation) |
|--------|--------|
| ![before](https://user-images.githubusercontent.com/1060248/122793647-729a4f00-d289-11eb-85e3-315cc4c4ac7b.gif) | ![after](https://user-images.githubusercontent.com/1060248/122793639-70d08b80-d289-11eb-86c4-cf823bcaa35c.gif) |




## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
