### PR TITLE
Maintain text input modifier colors on focus/hover

### DIFF
--- a/packages/cfpb-forms/src/atoms/text-input.less
+++ b/packages/cfpb-forms/src/atoms/text-input.less
@@ -45,11 +45,15 @@
         border-color: @input-border__error;
         outline: 1px solid @input-border__error;
         &:hover,
-        &.hover,
+        &.hover {
+            border-color: @input-border__error;
+            outline: 1px solid @input-border__error;
+        }
         &:focus,
         &.focus {
             border-color: @input-border__error;
             box-shadow: 0 0 0 1px @input-border__error;
+            outline: 1px dotted @input-border__error;
         }
     }
 
@@ -57,11 +61,15 @@
         border-color: @input-border__warning;
         outline: 1px solid @input-border__warning;
         &:hover,
-        &.hover,
+        &.hover {
+            border-color: @input-border__warning;
+            outline: 1px solid @input-border__warning;
+        }
         &:focus,
         &.focus {
             border-color: @input-border__warning;
             box-shadow: 0 0 0 1px @input-border__warning;
+            outline: 1px dotted @input-border__warning;
         }
     }
 
@@ -69,11 +77,15 @@
         border-color: @input-border__success;
         outline: 1px solid @input-border__success;
         &:hover,
-        &.hover,
+        &.hover {
+            border-color: @input-border__success;
+            outline: 1px solid @input-border__success;
+        }
         &:focus,
         &.focus {
             border-color: @input-border__success;
             box-shadow: 0 0 0 1px @input-border__success;
+            outline: 1px dotted @input-border__success;
         }
     }
 }

--- a/packages/cfpb-forms/src/atoms/text-input.less
+++ b/packages/cfpb-forms/src/atoms/text-input.less
@@ -44,11 +44,6 @@
     &__error {
         border-color: @input-border__error;
         outline: 1px solid @input-border__error;
-        &:hover,
-        &.hover {
-            border-color: @input-border__error;
-            outline: 1px solid @input-border__error;
-        }
         &:focus,
         &.focus {
             border-color: @input-border__error;
@@ -60,11 +55,6 @@
     &__warning {
         border-color: @input-border__warning;
         outline: 1px solid @input-border__warning;
-        &:hover,
-        &.hover {
-            border-color: @input-border__warning;
-            outline: 1px solid @input-border__warning;
-        }
         &:focus,
         &.focus {
             border-color: @input-border__warning;
@@ -76,11 +66,6 @@
     &__success {
         border-color: @input-border__success;
         outline: 1px solid @input-border__success;
-        &:hover,
-        &.hover {
-            border-color: @input-border__success;
-            outline: 1px solid @input-border__success;
-        }
         &:focus,
         &.focus {
             border-color: @input-border__success;

--- a/packages/cfpb-forms/src/atoms/text-input.less
+++ b/packages/cfpb-forms/src/atoms/text-input.less
@@ -44,16 +44,37 @@
     &__error {
         border-color: @input-border__error;
         outline: 1px solid @input-border__error;
+        &:hover,
+        &.hover,
+        &:focus,
+        &.focus {
+            border-color: @input-border__error;
+            box-shadow: 0 0 0 1px @input-border__error;
+        }
     }
 
     &__warning {
         border-color: @input-border__warning;
         outline: 1px solid @input-border__warning;
+        &:hover,
+        &.hover,
+        &:focus,
+        &.focus {
+            border-color: @input-border__warning;
+            box-shadow: 0 0 0 1px @input-border__warning;
+        }
     }
 
     &__success {
         border-color: @input-border__success;
         outline: 1px solid @input-border__success;
+        &:hover,
+        &.hover,
+        &:focus,
+        &.focus {
+            border-color: @input-border__success;
+            box-shadow: 0 0 0 1px @input-border__success;
+        }
     }
 }
 


### PR DESCRIPTION
The pacific focus state of our text inputs overrides any modification
colors for error/warning/success. This means that if an input field
is modified while the user is actively focused on it, they won't receive
visual feedback that something has changed.

## Additions

- Hover/focus states to text input modifiers.

## Testing

1. Compare the three production [modified text inputs](https://cfpb.github.io/design-system/components/notifications#warning-notification-field-level) to the [PR preview](https://deploy-preview-1257--cfpb-design-system.netlify.app/design-system/components/notifications#warning-notification-field-level). Also compare them to the [default text inputs](https://cfpb.github.io/design-system/components/text-inputs).

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
