### PR TITLE
Fix field-level error message margins

### DIFF
--- a/packages/cfpb-forms/src/molecules/form-fields.less
+++ b/packages/cfpb-forms/src/molecules/form-fields.less
@@ -238,6 +238,9 @@
         }
     }
 
+    // TODO: The same top margin is applied to field-level errors for input-
+    // with-button forms in organisms/form.less; we should find a way to merge
+    // these to be less repetitive.
     .a-form-alert,
     .a-error-message {
         margin-top: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );

--- a/packages/cfpb-forms/src/organisms/form.less
+++ b/packages/cfpb-forms/src/organisms/form.less
@@ -43,6 +43,9 @@
                 width: 100%;
             }
 
+            // TODO: The same top margin is applied to field-level errors for
+            // regular forms in molecules/form-fields.less; we should find a way
+            // to merge these to be less repetitive.
             .a-form-alert,
             .a-error-message {
                 margin-top: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );

--- a/packages/cfpb-forms/src/organisms/form.less
+++ b/packages/cfpb-forms/src/organisms/form.less
@@ -42,6 +42,11 @@
                 box-sizing: border-box;
                 width: 100%;
             }
+
+            .a-form-alert,
+            .a-error-message {
+                margin-top: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
+            }
         }
 
         &_btn-container {


### PR DESCRIPTION
Field-level error messages are meant to have a [15px margin between the field with the error and the message](https://cfpb.github.io/design-system/components/notifications#error-notification-field-level). That margin was only present [when the error message was in an `.m-form-field container`](https://github.com/cfpb/design-system/blob/main/packages/cfpb-forms/src/molecules/form-fields.less#L241-L244). Our [text input with button pattern](https://cfpb.github.io/design-system/components/text-inputs#text-input-with-a-button) (where the text field and the button are on the same line) don't have the `.m-form-field` wrapper, so error messages in those kinds of forms had no top margin.

## Additions

- Add top margin to field-level notifications in text input with button forms

## Testing

Whip up a test case that puts a field-level error in a text input with button form, like so:

```html
<div class="o-form__input-w-btn">
    <div class="o-form__input-w-btn_input-container">
        <input class="a-text-input a-text-input__error" type="text" title="Test input">
        <div class="a-form-alert a-form-alert__error" id="form-input-error_message" role="alert">
            {{ svg_icon('error-round') }}
            <span class="a-form-alert_text">
                This is an inline alert with an error state.
            </span>
        </div>
    </div>
    <div class="o-form__input-w-btn_btn-container">
        <button class="a-btn">Search</button>
    </div>
</div>
```
Without this fix, the error message will be flush against the bottom of the input. With the fix, there should a be a 15px margin between the two. See the screenshots below to see how everything should look.

## Screenshots

Before | After
---- | ----
![before](https://user-images.githubusercontent.com/1862695/125329765-de655a00-e313-11eb-8b1f-6f04192983c9.png) | ![after](https://user-images.githubusercontent.com/1862695/125329774-e32a0e00-e313-11eb-96e9-cbaed52ae066.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [x] Chrome on desktop
- [x] Firefox
- [x] Safari on macOS
- [x] Edge
- [x] Internet Explorer 9, 10, and 11
- [x] Safari on iOS
- [x] Chrome on Android

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Flexible from small to large screens
- [x] No linting errors or warnings
- [x] JavaScript tests are passing