### PR TITLE
DS website: Update sidebar to add bottom margin to menu items at desktop/tablet

### DIFF
--- a/docs/assets/css/sidebar.less
+++ b/docs/assets/css/sidebar.less
@@ -25,6 +25,11 @@
 
 // Desktop and tablet size.
 .respond-to-min( @bp-sm-min, {
+
+    .ds-nav ul:last-child {
+        margin-bottom: 30px;
+    }
+
     // Hide the top-level expandable details on desktop.
     .ds-nav-container > summary {
         display: none;
@@ -45,7 +50,7 @@
 
 // Mobile size.
 .respond-to-max( @bp-xs-max, {
-    
+
     .ds-nav a {
         border-style: solid;
         border-top-width: 0;
@@ -56,7 +61,7 @@
         margin-top: 15px;
         margin-left: 10px;
     }
-    
+
     .ds-nav .h4,
     .ds-nav .h5,
     .ds-nav .h6 {


### PR DESCRIPTION
Follow up to https://github.com/cfpb/design-system/pull/1259 to fix issue where margin was missing on desktop third-level items in the sidebar.
 
## Changes

- Add bottom margin to nav last item on desktop/tablet only (not mobile).

## Testing

1. Check the PR preview pages like https://cfpb.github.io/design-system/patterns/ that have three levels of items and ensure they're correct on desktop and mobile.
