### PR TITLE
Anchor linking: Fix live code example

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -21,10 +21,10 @@ const anchors = new AnchorJS();
 anchors.add( 'h2:not(.title), h3, h4, h5' );
 // Ensure there are no anchors in inconvenient places
 anchors.remove( `
-  .live-code-example h2,
-  .live-code-example h3,
-  .live-code-example h4,
-  .live-code-example h5,
+  .a-live_code h2,
+  .a-live_code h3,
+  .a-live_code h4,
+  .a-live_code h5,
   .o-expandable_label,
   #search-results h3
 ` );


### PR DESCRIPTION
https://github.com/cfpb/design-system/pull/443/ exempted live code examples from anchor linking, but targets `live-code-example` while the live code blocks use `a-live_code` as changed in https://github.com/cfpb/design-system/pull/466/. Erroneous links appear within the code examples as seen on https://cfpb.github.io/design-system/patterns/cards

<img width="262" alt="Screen Shot 2021-08-16 at 9 33 20 AM" src="https://user-images.githubusercontent.com/704760/129573309-b73af78f-a8c7-490b-b903-0c937bc185f9.png">

<img width="414" alt="Screen Shot 2021-08-16 at 9 38 43 AM" src="https://user-images.githubusercontent.com/704760/129573316-6b7aaebf-89c6-4ad9-89ab-6279bdddd6ad.png">


## Changes

- Change anchor linking to fix class name.

## Testing

1. Visit the cards pattern and see that there is no anchor link in the links within the card patterns.
