### PR TITLE
Remove unnecessary u-hidden

### DIFF
--- a/docs/assets/css/toggle-code-button.less
+++ b/docs/assets/css/toggle-code-button.less
@@ -7,12 +7,9 @@
 
     .a-btn {
         text-transform: uppercase;
-        &.u-hidden {
-            display: none;
-        }
     }
 }
 
 .m-variation:last-child .a-toggle_code {
-        padding-bottom: 0;
+    padding-bottom: 0;
 }


### PR DESCRIPTION
The toggle code CSS includes a redundant `u-hidden` declaration (see https://github.com/cfpb/design-system/pull/466#discussion_r418563532). However, `u-hidden` has `!important` now (see https://github.com/cfpb/design-system/pull/1138) so the re-declaration is not necessary. 

## Removals

- Removes redundant `u-hidden` declaration.

## Testing

1. Visit a component page in the PR preview and see the SHOW/HIDE details toggle works as expected.
