### PR TITLE
Add title attributes to video iframes

### DIFF
--- a/docs/pages/video.md
+++ b/docs/pages/video.md
@@ -21,7 +21,8 @@ variation_groups:
       - variation_code_snippet: <iframe width="560" height="315"
           src="https://www.youtube.com/embed/B3LhSpxEW-o" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media;
-          gyroscope; picture-in-picture" allowfullscreen></iframe>
+          gyroscope; picture-in-picture" allowfullscreen
+          title="Branded Content"></iframe>
         variation_description: A custom-designed video that incorporates design elements
           for specific solutions. This type of video is usually consumer or
           industry facing and is representative of the Bureau's priorities.
@@ -30,7 +31,8 @@ variation_groups:
       - variation_code_snippet: <iframe width="560" height="315"
           src="https://www.youtube.com/embed/YB_7cy1poGA" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media;
-          gyroscope; picture-in-picture" allowfullscreen></iframe>
+          gyroscope; picture-in-picture" allowfullscreen
+          title="Documentary"></iframe>
         variation_description: This style utilizes interview footage and b-roll of real
           people. It can be used to communicate a personal, trustworthy
           aesthetic to a given message.
@@ -42,18 +44,21 @@ variation_groups:
         variation_code_snippet: <iframe width="560" height="315"
           src="https://www.youtube.com/embed/AcI3GDMVH5U" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media;
-          gyroscope; picture-in-picture" allowfullscreen></iframe>
+          gyroscope; picture-in-picture" allowfullscreen
+          title="iPhone"></iframe>
       - variation_code_snippet: <iframe width="560" height="315"
           src="https://www.youtube.com/embed/em6viyrSGCc" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media;
-          gyroscope; picture-in-picture" allowfullscreen></iframe>
+          gyroscope; picture-in-picture" allowfullscreen
+          title="Educational"></iframe>
         variation_description: Educational videos help answer questions or explain
           complex ideas about specific issues, tools, regulations, and more.
         variation_name: Educational
       - variation_code_snippet: <iframe width="560" height="315"
           src="https://www.youtube.com/embed/D8mS1tZMJ70" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media;
-          gyroscope; picture-in-picture" allowfullscreen></iframe>
+          gyroscope; picture-in-picture" allowfullscreen
+          title="Event"></iframe>
         variation_description: The bureau livestreams field hearings, consumer advisory
           board meetings, town halls, and more. After these events are broadcast
           live, we upload them to YouTube for documentation purposes.


### PR DESCRIPTION
Lighthouse tests currently fail on the video page due to missing titles on the (hard-coded) video iframes. This commit adds titles to them.

[Here's](https://github.com/cfpb/design-system/runs/3335572033?check_suite_focus=true) an example of a failing nightly Lighthouse run. With this change, Lighthouse now scores the video page 100% for accessibility:

![image](https://user-images.githubusercontent.com/654645/129581911-5c5fc1ec-70d2-4abd-95e3-4d6e054b67e3.png)