### PR TITLE
Add deprecate toggle to variations

### DIFF
--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -91,7 +91,12 @@
 
             {% if variation_name and variation_name != '' %}
             <div class="m-variation_name">
-                <h3>{{ variation_name }}</h3>
+                <h3>
+                    {{ variation_name }}
+                    {% if variation.variation_is_deprecated %}
+                    <span class="m-variation_deprecated">DEPRECATED</span>
+                    {% endif %}
+                </h3>
             </div>
             {% endif %}
 

--- a/docs/admin/config.yml
+++ b/docs/admin/config.yml
@@ -180,6 +180,11 @@ collections:
                 label: 'Variation name'
                 widget: 'string-trimmed'
                 required: false
+              - name: 'variation_is_deprecated'
+                label: 'Is this variation deprecated?'
+                widget: 'boolean'
+                required: true
+                default: false
               - name: 'variation_description'
                 label: 'Variation description'
                 widget: 'markdown'

--- a/docs/assets/css/variation.less
+++ b/docs/assets/css/variation.less
@@ -45,6 +45,14 @@
         margin-top: 2rem;
     }
 
+    &_deprecated {
+        background: @gray-10;
+        font-size: unit( 10px / @base-font-size-px, em);
+        font-variant: small-caps;
+        border-radius: 5px;
+        padding: 5px;
+    }
+
     &:first-child .m-variation_name {
         margin-top: 0;
     }


### PR DESCRIPTION
We will be updating the card patterns as we develop a new homepage, however, both the old and new patterns will need to remain in the design system as we develop the new homepage. When it's switched over to the new page we'll be able to remove the old ones in the design system. This feature adds a toggle to the DS netlify admin to flag a variation pattern as "deprecated" so we know to not reference it anymore and that it is slated for deletion.

## Additions

- Add "is deprecated" toggle to individual variations.

## Testing

1. Edit a page in the PR preview and find the "is deprecated" toggle in the variation and turn it on to see the "DEPRECATED" label show up next to the name.

## Screenshots

<img width="372" alt="Screen Shot 2021-08-16 at 2 12 00 PM" src="https://user-images.githubusercontent.com/704760/129610133-dd5b2b72-55e4-4bfd-ba70-775a0af3a379.png">

<img width="307" alt="Screen Shot 2021-08-16 at 2 03 57 PM" src="https://user-images.githubusercontent.com/704760/129609984-25c7ea38-65f3-4b1e-9456-417bdaf5d8af.png">

