### PR TITLE
Fix multiselect infinite selections bug

### DIFF
--- a/docs/pages/dropdowns.md
+++ b/docs/pages/dropdowns.md
@@ -126,12 +126,12 @@ variation_groups:
               </label>
               <select class="o-multiselect" id="test_select__multiple" multiple>
                   <option value="option1" selected>Option 1</option>
-                  <option value="option2">Option 2</option>
-                  <option value="option3">Option 3</option>
+                  <option value="option2" selected>Option 2</option>
+                  <option value="option3" selected>Option 3</option>
                   <option value="option4">Option 4</option>
-                  <option value="option5">Option 5</option>
-                  <option value="option6">Option 6</option>
-                  <option value="option7">Option 7</option>
+                  <option value="option5" selected>Option 5</option>
+                  <option value="option6" selected>Option 6</option>
+                  <option value="option7" selected>Option 7</option>
                   <option value="option8">Multiselect options can also contain long words that will be wrapped like supercalifragilisticexpialidocious</option>
               </select>
           </div>

--- a/docs/pages/dropdowns.md
+++ b/docs/pages/dropdowns.md
@@ -126,7 +126,7 @@ variation_groups:
               </label>
               <select class="o-multiselect" id="test_select__multiple" multiple>
                   <option value="option1" selected>Option 1</option>
-                  <option value="option2" selected>Option 2</option>
+                  <option value="option2">Option 2</option>
                   <option value="option3">Option 3</option>
                   <option value="option4" selected>Option 4</option>
                   <option value="option5">Option 5</option>

--- a/docs/pages/dropdowns.md
+++ b/docs/pages/dropdowns.md
@@ -127,11 +127,11 @@ variation_groups:
               <select class="o-multiselect" id="test_select__multiple" multiple>
                   <option value="option1" selected>Option 1</option>
                   <option value="option2" selected>Option 2</option>
-                  <option value="option3" selected>Option 3</option>
-                  <option value="option4">Option 4</option>
-                  <option value="option5" selected>Option 5</option>
-                  <option value="option6" selected>Option 6</option>
-                  <option value="option7" selected>Option 7</option>
+                  <option value="option3">Option 3</option>
+                  <option value="option4" selected>Option 4</option>
+                  <option value="option5">Option 5</option>
+                  <option value="option6">Option 6</option>
+                  <option value="option7">Option 7</option>
                   <option value="option8">Multiselect options can also contain long words that will be wrapped like supercalifragilisticexpialidocious</option>
               </select>
           </div>

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -84,8 +84,8 @@ function Multiselect( element ) { // eslint-disable-line max-statements
     _options = _dom.options || [];
 
     if ( _options.length > 0 ) {
-      const newDom = _populateMarkup();
       _model = new MultiselectModel( _options, _name ).init();
+      const newDom = _populateMarkup();
 
       /* Removes <select> element,
          and re-assign DOM reference. */
@@ -165,16 +165,23 @@ function Multiselect( element ) { // eslint-disable-line max-statements
       'aria-hidden': 'true'
     } );
 
+    let optionsClasses = BASE_CLASS + '_options';
+    if ( _model.isAtMaxSelections() ) {
+      optionsClasses += ' u-max-selections';
+    }
+
     _optionsDom = MultiselectUtils.create( 'ul', {
-      className: BASE_CLASS + '_options',
+      className: optionsClasses,
       inside:    _fieldsetDom
     } );
 
     let option;
     let optionId;
+    let isChecked;
     for ( let i = 0, len = _options.length; i < len; i++ ) {
       option = _options[i];
       optionId = _getOptionId( option );
+      isChecked = _model.getOption( i ).checked;
       const optionsItemDom = MultiselectUtils.create( 'li', {
         'data-option': option.value,
         'class': 'm-form-field m-form-field__checkbox'
@@ -188,7 +195,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
         'name':    _name,
         'class':   CHECKBOX_INPUT_CLASS + ' ' + BASE_CLASS + '_checkbox',
         'inside':  optionsItemDom,
-        'checked': option.defaultSelected,
+        'checked': isChecked,
         'data-index': i
       } );
 
@@ -202,7 +209,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
       _optionItemDoms.push( optionsItemDom );
       _optionsDom.appendChild( optionsItemDom );
 
-      if ( option.defaultSelected ) {
+      if ( isChecked ) {
         _createSelectedItem( _selectionsDom, option );
       }
     }

--- a/packages/cfpb-forms/src/organisms/MultiselectModel.js
+++ b/packages/cfpb-forms/src/organisms/MultiselectModel.js
@@ -66,7 +66,7 @@ function MultiselectModel( options, name ) {
     let isChecked = false;
     for ( let i = 0, len = list.length; i < len; i++ ) {
       item = list[i];
-      isChecked = item.defaultSelected;
+      isChecked = isAtMaxSelections() ? false : item.defaultSelected;
       cleaned.push( {
         id:      _getOptionId( item ),
         value:   item.value,


### PR DESCRIPTION
It was possible to select infinite options in the multiselect if the multiselect was loaded with the max selection count. This PR fixes that loophole.

## Changes

- Changes multiselect model to stop checking options after the maximum selection number has been reached.
- Changes multiselect to initialize the model before populating the markup and to check the model for the selections.
- Updates the multiselect example in the DS docs to load with the maximum selection to begin with.
 
## Testing

1. Check the multiselect in the PR preview and add and remove items to see that it works.
2. If you really want to thoroughly vet this, pull the branch and run a local server and change the number of items in dropdowns.md that have the `selected` attribute so-as to change the number of items the multiselect has on page load.