### PR TITLE
Cards: Set a white background on topic cards

### DIFF
--- a/packages/cfpb-layout/src/molecules/card.less
+++ b/packages/cfpb-layout/src/molecules/card.less
@@ -167,6 +167,7 @@
     &__topic {
         text-align: center;
         width: 170px;
+        background: @white;
 
         & > a {
             border: 1px solid @gray-20;


### PR DESCRIPTION
## Changes

- Set a white background on topic cards so they don't have a transparent background.

## Testing

1. Check cards page in the PR preview and compare to https://cfpb.github.io/design-system/patterns/cards
