### PR TITLE
Cards: Make highlight card colors accessible

### DIFF
--- a/packages/cfpb-layout/src/molecules/card.less
+++ b/packages/cfpb-layout/src/molecules/card.less
@@ -20,6 +20,10 @@
         color: @v;
     }
 
+    // Border changes on the regular cards happen on the top-level `article`
+    // element, so for consistency we trigger the hover styles on the parent
+    // instead of on the link. This differs from the visited, focus,
+    // and active states, which add styles onto the link.
     &:hover .m-card_footer > span {
         border-style: solid;
         border-color: @h;

--- a/packages/cfpb-layout/src/molecules/card.less
+++ b/packages/cfpb-layout/src/molecules/card.less
@@ -1,25 +1,38 @@
-.u-card-link-text() {
+// @c = default state.
+// @v = `:visited` state.
+// @h = `:hover` state.
+// @f = `:focus` state.
+// @a = `:active` state.
+.u-link-card__colors( @c, @v, @h, @f, @a ) {
     .m-card_footer > span {
         display: inline;
         border-width: 0;
         border-bottom-width: 1px;
-        border-color: @pacific;
+        border-color: @c;
         border-style: dotted;
         font-weight: 500;
-        color: @pacific;
+        color: @c;
         text-decoration: none;
     }
 
     & > a:visited .m-card_footer > span {
-        color: @teal;
-        border-color: @teal !important;
+        color: @v;
+        border-color: @v !important;
     }
 
-    &:hover {
-        .m-card_footer > span {
-            border-style: solid;
-            color: @pacific-dark;
-        }
+    &:hover .m-card_footer > span {
+        border-style: solid;
+        color: @h;
+    }
+
+    & > a:focus .m-card_footer > span {
+        color: @f;
+        border-color: @f !important;
+    }
+
+    & > a:active .m-card_footer > span {
+        color: @a;
+        border-color: @a !important;
     }
 }
 
@@ -188,7 +201,9 @@
 
             .u-card-bottom-bar();
         }
-        .u-card-link-text();
+
+        // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.
+        .u-link-card__colors( @pacific, @teal, @pacific-dark, @pacific-dark, @pacific-dark );
     }
 
     &__topic-action {
@@ -245,7 +260,9 @@
 
             .u-card-bottom-bar();
         }
-        .u-card-link-text();
+
+        // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.
+        .u-link-card__colors( @pacific, @teal, @pacific-dark, @pacific-dark, @pacific-dark );
     }
 
     // Highlight cards.
@@ -272,6 +289,7 @@
             .u-card-bottom-bar();
         }
 
-        .u-card-link-text();
+        // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.
+        .u-link-card__colors( @pacific-mid-dark, @teal-mid-dark, @pacific-dark, @pacific-dark, @pacific-dark );
     }
 }

--- a/packages/cfpb-layout/src/molecules/card.less
+++ b/packages/cfpb-layout/src/molecules/card.less
@@ -16,23 +16,25 @@
     }
 
     & > a:visited .m-card_footer > span {
+        border-color: @v;
         color: @v;
-        border-color: @v !important;
     }
 
     &:hover .m-card_footer > span {
         border-style: solid;
+        border-color: @h;
         color: @h;
     }
 
     & > a:focus .m-card_footer > span {
+        border-color: @f;
         color: @f;
-        border-color: @f !important;
     }
 
     & > a:active .m-card_footer > span {
+        border-color: @a;
+        border-style: solid;
         color: @a;
-        border-color: @a !important;
     }
 }
 
@@ -262,7 +264,7 @@
         }
 
         // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.
-        .u-link-card__colors( @pacific, @teal, @pacific-dark, @pacific-dark, @pacific-dark );
+        .u-link-card__colors( @pacific, @teal, @pacific-dark, @pacific, @navy );
     }
 
     // Highlight cards.
@@ -290,6 +292,6 @@
         }
 
         // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.
-        .u-link-card__colors( @pacific-mid-dark, @teal-mid-dark, @pacific-dark, @pacific-dark, @pacific-dark );
+        .u-link-card__colors( @pacific-mid-dark, @teal-mid-dark, @pacific-dark, @pacific-mid-dark, @navy );
     }
 }

--- a/packages/cfpb-layout/src/organisms/wells.less
+++ b/packages/cfpb-layout/src/organisms/wells.less
@@ -19,7 +19,7 @@
         color: @white;
 
         a {
-            // default, `:visited`, `:hover`, `:focus`, and `:active` states in the first five arguments)
+            // default, `:visited`, `:hover`, `:focus`, and `:active` states are the first five arguments.
             .u-link__colors( @pacific-40, @teal-40, @pacific-50, @pacific-40, @navy-40 );
         }
     }

--- a/packages/cfpb-layout/src/organisms/wells.less
+++ b/packages/cfpb-layout/src/organisms/wells.less
@@ -19,7 +19,7 @@
         color: @white;
 
         a {
-            // default, `:visited`, `:hover`, `:focus`, and `:active` states are the first five arguments.
+            // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.
             .u-link__colors( @pacific-40, @teal-40, @pacific-50, @pacific-40, @navy-40 );
         }
     }


### PR DESCRIPTION
Fixes https://github.com/cfpb/design-system/issues/1300

## Changes

- Adds a utility for setting all the states of the cards and darkens the highlight card link text to be an accessible contrast.

## Testing

1. Visit the cards page in the PR preview and check for contrast accessibility errors.