### PR TITLE
Update "taglines" page

### DIFF
--- a/docs/pages/taglines.md
+++ b/docs/pages/taglines.md
@@ -3,12 +3,11 @@ title: Taglines
 layout: variation
 section: patterns
 status: Released
-description: >-
-  Taglines are short paragraphs of text with a USA flag to their left.
+description: Taglines are short paragraphs of text with a USA flag to their left.
 variation_groups:
   - variations:
-      - variation_name: "Standard tagline"
-        variation_code_snippet: >-
+      - variation_name: Standard tagline
+        variation_code_snippet: |-
           <div class="a-tagline">
               <span class="u-usa-flag"></span>
               <div>
@@ -17,13 +16,11 @@ variation_groups:
               </div>
           </div>
         variation_description: ""
-        variation_implementation: >-
-          The flag itself is a stand-alone element of
-          `<span class="u-usa-flag"></span>`
-          that uses a utility class that embeds a double-resolution flag png
-          via a data URI.
-      - variation_name: "Large tagline"
-        variation_code_snippet: >-
+        variation_implementation: The flag itself is a stand-alone element of `<span
+          class="u-usa-flag"></span>` that uses a utility class that embeds a
+          double-resolution flag png via a data URI.
+      - variation_name: Large tagline
+        variation_code_snippet: |-
           <div class="a-tagline a-tagline__large">
               <span class="u-usa-flag"></span>
               <div>
@@ -32,29 +29,27 @@ variation_groups:
               </div>
           </div>
         variation_description: ""
-        variation_implementation: >-
-          The `u-nowrap` container prevents wrapping of the
+        variation_implementation: The `u-nowrap` container prevents wrapping of the
           "United States government" text. If the content of the tagline
           contains markup it needs to go inside a generic `div` container.
-      - variation_name: "Extra large tagline"
-        variation_code_snippet: >-
+      - variation_name: Extra large tagline
+        variation_code_snippet: |-
           <div class="a-tagline a-tagline__xlarge">
               <span class="u-usa-flag"></span>
               We're a government agency whose mission is to protect consumers
               from financial harm.
           </div>
         variation_description: ""
-        variation_implementation: >-
-          A `div` container around the tagline is not needed if there is no
-          markup inside the content.
-use_cases: >-
-  Taglines are used in the header and footer across consumerfinance.gov and within
-  inkwells.
-guidelines: ''
-behavior: ''
-accessibility: ''
-research: ''
-related_items: ''
+        variation_implementation: A `div` container around the tagline is not needed if
+          there is no markup inside the content.
+    variation_group_name: Types
+use_cases: Taglines are used in the header and footer across consumerfinance.gov
+  and within inkwells.
+guidelines: ""
+behavior: ""
+accessibility: ""
+research: ""
+related_items: ""
 last_updated: 2019-10-21T20:38:39.851Z
 secondary_section: Layout options
 ---


### PR DESCRIPTION
The current [taglines page](https://cfpb.github.io/design-system/patterns/taglines) fails Lighthouse accessibility due to a missing `<h2>`. See example Lighthouse run [here](https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1632961839718-84104.report.html):

![image](https://user-images.githubusercontent.com/654645/135371079-14aa56ba-ba4e-4e09-9ac6-532321ac8d97.png)

This commit adds a variation group name so that we get the missing `<h2>`; I used the name "Types" since that's what we seem to use elsewhere, for example on the [Cards](https://cfpb.github.io/design-system/patterns/cards) page.