### PR TITLE
Taglines: Move stacking to only affect extra-large size

### DIFF
--- a/docs/pages/taglines.md
+++ b/docs/pages/taglines.md
@@ -43,7 +43,7 @@ variation_groups:
               We're a government agency whose mission is to protect consumers
               from financial harm.
           </div>
-        variation_description: ""
+        variation_description: "An extra large tagline, which stacks on mobile."
         variation_implementation: >-
           A `div` container around the tagline is not needed if there is no
           markup inside the content.

--- a/packages/cfpb-typography/src/atoms/tagline.less
+++ b/packages/cfpb-typography/src/atoms/tagline.less
@@ -25,14 +25,14 @@
         }
 
         font-size: unit( 18px / @base-font-size-px, rem );
-    }
 
-    // Mobile size.
-    .respond-to-max( @bp-xs-max, {
-        grid-template-columns: initial;
-        grid-template-rows: 22px 1fr;
-        grid-row-gap: 5px;
-    } );
+        // Mobile size.
+        .respond-to-max( @bp-xs-max, {
+            grid-template-columns: initial;
+            grid-template-rows: 22px 1fr;
+            grid-row-gap: 5px;
+        } );
+    }
 }
 
 .u-usa-flag {


### PR DESCRIPTION
Preference is to have the tagline stack under 600px only when the extra-large size is used.

## Changes

- Taglines: Move stacking to only affect xtra-large size

## Testing

1. Visit taglines PR preview page and resize to mobile and see that only the extra-large size stacks with the flag on its own line.

## Screenshot

<img width="335" alt="Screen Shot 2021-10-04 at 12 49 52 PM" src="https://user-images.githubusercontent.com/704760/135891698-459f7f9e-bd0e-4e74-b090-1c6edc883a64.png">


