### PR TITLE
cfpb-notifications: Add margin-bottom to notification explanation

### DIFF
--- a/packages/cfpb-notifications/src/molecules/notification.less
+++ b/packages/cfpb-notifications/src/molecules/notification.less
@@ -56,6 +56,7 @@
 
     &_explanation {
         margin-top: unit( 5px / @base-font-size-px, em );
+        margin-bottom: unit( 15px / @base-font-size-px, em );
     }
 
     // We need to provide a margin for links if an explanation is absent.


### PR DESCRIPTION
Notification explanation was acquiring a bottom margin from the `<p>` element, however, if the notification explanation is not a paragraph the bottom margin would be lost. This PR adds the bottom margin to the `m-notification_explanation` element so that it is present, regardless of the HTML tag of the element.

## Changes

- Adds margin-bottom to notification explanation.

## Testing

1. Visit the notification page in the PR preview.
2. Resize to mobile.
3. Inspect the notification and look at the `m-notification_explanation` and see it has a margin bottom that overrides the same value in the `p` element.
