### PR TITLE
Wells: Remove max-width and remove well variables

### DIFF
--- a/packages/cfpb-layout/src/cfpb-layout.less
+++ b/packages/cfpb-layout/src/cfpb-layout.less
@@ -53,13 +53,6 @@
 @fcm-bg:                        @block__bg;
 @fcm-border:                    @block__border;
 
-// Well variables
-
-@well-bg:                       @block__bg;
-@well-border:                   @block__border;
-// 8 columns plus gutters
-@well-max:                      ( ( @grid_wrapper-width - @grid_gutter-width ) / @grid_total-columns * 8 ) - @grid_gutter-width;
-
 //
 // Content layouts
 //

--- a/packages/cfpb-layout/src/organisms/wells.less
+++ b/packages/cfpb-layout/src/organisms/wells.less
@@ -1,13 +1,11 @@
 .o-well {
     box-sizing: border-box;
 
-    // 8 columns plus gutters
-    max-width: unit( @well-max / @base-font-size-px, em );
     padding:
         unit( @grid_gutter-width / @base-font-size-px, em )
         unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
-    border: 1px solid @well-border;
-    background-color: @well-bg;
+    border: 1px solid @gray-40;
+    background-color: @gray-5;
 
     .respond-to-min( @bp-sm-min, {
         padding-left: unit( @grid_gutter-width / @base-font-size-px, em );


### PR DESCRIPTION
Containers of wells should constrain their width, if needed.

## Changes

- Remove `max-width` from wells.
- Remove well variables that are only used once, to reduce obfuscation.

## Testing

1. Visit "well" page in PR preview and they should look the same as https://cfpb.github.io/design-system/patterns/wells
