### PR TITLE
Allow multiple instances of initializable components to be initialized

### DIFF
--- a/packages/cfpb-atomic-component/src/components/AtomicComponent.js
+++ b/packages/cfpb-atomic-component/src/components/AtomicComponent.js
@@ -72,7 +72,6 @@ assign( AtomicComponent.prototype, new EventObserver(), {
       if ( this.element.classList.contains( modifierClass ) ) {
         if ( modifier.initialize ) {
           this.initializers.push( modifier.initialize );
-          delete modifier.initialize;
         }
         assign( this, modifier );
       }


### PR DESCRIPTION
Closes https://github.com/cfpb/design-system/issues/1311

## Removals

- The `delete` command which allows each sortable table instance to properly initialize

## Testing

1. Make a page with two sortable tables
2. They should each sort as expected without the bug described in #1311 
3. Tests should pass/Expandables shouldn't break


## Notes

It looks like sortable tables are the only application of a `modifier`'s `initialize` method being called [by processModifiers](https://github.com/cfpb/design-system/blob/main/packages/cfpb-atomic-component/src/components/AtomicComponent.js#L73-L76). The only other component that is [added as a modifier at all is `TableRowLinks`](https://github.com/cfpb/design-system/blob/main/packages/cfpb-tables/src/Table.js#L15) and the only other component that has an `initialize` method [is the `Expandables`](https://github.com/cfpb/design-system/blob/main/packages/cfpb-expandables/src/Expandable.js#L46-L72).

However, since SortableTables are the only time we both (a) pass it as a modifier and (b) call a present `initialize` method, we can be confident this change is only affecting sortable tables, and so if they work as expected, this PR shouldn't harm the many other things inheriting from `AtomicComponent.js`.