### PR TITLE
Redirect to new accessbility URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 gem "nokogiri", "~> 1.10"
 gem "jekyll", "~> 4.0"
 gem "jekyll-last-modified-at", "~> 1.1.0"
+gem 'jekyll-redirect-from'

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 gem "nokogiri", "~> 1.10"
 gem "jekyll", "~> 4.0"
 gem "jekyll-last-modified-at", "~> 1.1.0"
-gem 'jekyll-redirect-from'
+gem "jekyll-redirect-from", "~> 0.16.0"

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 # Redirects
 plugins:
   - jekyll-last-modified-at
+  - jekyll-redirect-from
 
 # Base configuration
 permalink: /:title

--- a/docs/pages/accessibility.md
+++ b/docs/pages/accessibility.md
@@ -306,4 +306,7 @@ accessibility: >-
 last_updated: 2019-12-10T22:50:48.793Z
 behavior: ""
 secondary_section: null
+
+redirect_from:
+  - /guidelines/accessibility
 ---


### PR DESCRIPTION
Redirect https://cfpb.github.io/design-system/guidelines/accessibility
to
https://cfpb.github.io/design-system/guidelines/accessibility-principles

## Additions

- Added `gem 'jekyll-redirect-from'` plugin to redirect

## Testing

1. Put /design-system/guidelines/accessibility in URL and test if it redirects to new accessibility page

Resolves https://github.com/cfpb/design-system/issues/1324