### PR TITLE
Inkwell: Remove border

### DIFF
--- a/packages/cfpb-layout/src/organisms/wells.less
+++ b/packages/cfpb-layout/src/organisms/wells.less
@@ -15,6 +15,7 @@
     &__inkwell {
         background-color: @gray-dark;
         color: @white;
+        border: none;
 
         a {
             // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.


### PR DESCRIPTION
Wells have borders. Inkwells have borders. Inkwells shouldn't have borders.

## Removals

- Remove inkwell border.

## Testing

1. Compare PR preview to http://localhost:4000/design-system/patterns/wells#inkwell and see that inkwell doesn't have a border anymore.
