### PR TITLE
Tagline: Adjust font-size, icon-text spacing, and max-width in inkwell

### DIFF
--- a/packages/cfpb-layout/src/organisms/wells.less
+++ b/packages/cfpb-layout/src/organisms/wells.less
@@ -25,6 +25,7 @@
         // If an inkwell contains a tagline, properly lay it out.
         .a-tagline {
             margin-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+            max-width: 41.875rem;
         }
     }
 }

--- a/packages/cfpb-typography/src/atoms/tagline.less
+++ b/packages/cfpb-typography/src/atoms/tagline.less
@@ -36,7 +36,8 @@
             background-image: url( 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAAqCAMAAAATdiw4AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAADlQTFRF////sxlC2YyhCjFhKUt1R2WJGT5rhZiwOFh/Zn6co7LEdYum0djhV3GS8PL1wszYsr/O4OXrlKW6gKQKnwAAAUhJREFUeNrslM2OwzAIhN2OHf/HSd//YXfYqGroZWWUS9XlgPgOGRmY4IAFjOXIr/Qsb5PhkEbglzHy4zAS3tkg6CIFWqNAdCKoeV7Qp4SIEJhS8iFohpsNGVVxGciuAH7f/ZlhEUzo0TNiZ1mrZoNgXuVlrcnLVnmZ5vtkcIYj0x6lMOXhl0WzYSmM2DrQG7frS/Fnhk2wrlTxa2U5hmZDy6kE9lkruw0lea/ZsJTkHjTyvtPIj8PYiucF6WVk9M7062rNNmNvjuOqbpPByfhebFpKQj6MnFnGqNkgWNftaeRNFvvGhuMwKj28bUz1MPaZbTOMTX65s7GfDKOgEyPLHURrmi2CD7DR3tmslF6z4U8JcvcOIxfH6//GhqV0qiBzaghdWtU8LRj+iOmWvzBuF8cHCH5h3C+OD9jy5S3/H4cvOA4/AgwAabgYexE/bU4AAAAASUVORK5CYII=' );
         }
 
-        font-size: unit( 24px / @base-font-size-px, rem );
+        font-size: unit( 26px / @base-font-size-px, rem );
+        grid-template-columns: 40px 1fr;
         grid-column-gap: 30px;
 
         // Mobile size.


### PR DESCRIPTION
## Changes

- Give the tagline a max-width inside inkwells.
- Increase the tagline gap between icon and text at the extra large size.
- Increase the font-size of the tagline at the extra large size.


## Testing

1. Compare PR preview tagline to https://cfpb.github.io/design-system/patterns/taglines#extra-large-tagline and https://cfpb.github.io/design-system/patterns/wells#inkwell

## Screenshots

Before:
<img width="794" alt="Screen Shot 2021-11-03 at 4 06 52 PM" src="https://user-images.githubusercontent.com/704760/140184890-5c6f695b-c2e2-4282-a0b6-a17b757788ba.png">
<img width="876" alt="Screen Shot 2021-11-03 at 4 07 05 PM" src="https://user-images.githubusercontent.com/704760/140184894-8bdffe9f-7b81-41d4-9a38-4b67f165247e.png">

After
<img width="876" alt="Screen Shot 2021-11-03 at 4 07 18 PM" src="https://user-images.githubusercontent.com/704760/140184916-29015271-14da-4fdd-ac68-0f689336fc28.png">
<img width="798" alt="Screen Shot 2021-11-03 at 4 07 30 PM" src="https://user-images.githubusercontent.com/704760/140184917-2ed85a30-2757-4ade-b660-bb4671b0615c.png">
:
