### PR TITLE
Make nav links unstyled by default

### DIFF
--- a/packages/cfpb-core/src/base.less
+++ b/packages/cfpb-core/src/base.less
@@ -471,6 +471,15 @@ ol ol {
     }
 }
 
+// Lists in the nav should be unstyled
+nav ul,
+nav ol,
+nav ul ul,
+nav ol ol {
+    list-style: none;
+    list-style-image: none;
+}
+
 //
 // Tables
 //


### PR DESCRIPTION
This was pulled from an [enhancement in cf.gov](https://github.com/cfpb/consumerfinance.gov/blob/8660b3a845f8dc983c951ab45ae125366a180743/cfgov/unprocessed/css/enhancements/base.less) but belongs here.