### PR TITLE
Pull old ie support

### DIFF
--- a/packages/cfpb-buttons/src/atoms/buttons-with-icons.less
+++ b/packages/cfpb-buttons/src/atoms/buttons-with-icons.less
@@ -4,13 +4,6 @@
 // TODO: Replace magic numbers with calculations based off of the
 // button padding size
 
-.lt-ie9 .a-btn_icon__on-left,
-.lt-ie9 .a-btn_icon__on-right {
-    // IE 8 doesn't support currentColor, hide icons and let the paired
-    // text stand on its own.
-    display: none;
-}
-
 .a-btn_icon__on-left {
     padding-right: unit( 11px / @btn-font-size, em );
     border-right: 1px solid mix( @btn-bg, @btn-text, 50% );

--- a/packages/cfpb-forms/src/atoms/select.less
+++ b/packages/cfpb-forms/src/atoms/select.less
@@ -81,15 +81,3 @@
         .u-svg-inline-bg( 'down', @gray );
     }
 }
-
-// TODO: Add modernizr to CF so this works.
-// IE10 and below doesn't support pointer events
-// causing nothing to happen when you click on the dropdown arrow.
-.no-csspointerevents .a-select {
-    &:after {
-        height: 0;
-        width: 0;
-        border: 0;
-        content: '';
-    }
-}

--- a/packages/cfpb-forms/src/molecules/form-fields.less
+++ b/packages/cfpb-forms/src/molecules/form-fields.less
@@ -45,10 +45,6 @@
                 position: relative;
                 top: 1px;
                 left: 1px;
-
-                .lt-ie9 & {
-                    display: none !important;
-                }
             }
 
             &:hover:before,
@@ -65,17 +61,6 @@
         .a-checkbox,
         .a-radio {
             .u-visually-hidden();
-
-            .lt-ie9 & {
-                height: unit( 20px / @base-font-size-px, em );
-                width: unit( 20px / @base-font-size-px, em );
-                width: auto;
-                border: 0;
-                float: left;
-                margin: 1em;
-                position: static;
-                clear: both;
-            }
 
             &:focus + .a-label,
             &.focus + .a-label {

--- a/packages/cfpb-icons/src/cfpb-icons.less
+++ b/packages/cfpb-icons/src/cfpb-icons.less
@@ -46,17 +46,6 @@
     // IE 10 & 11 require a max-width otherwise the SVG takes up 100%.
     max-width: 1em;
 
-    .lt-ie10 & {
-        // IE 9 require a width otherwise the SVG takes up 100%.
-        width: 1em;
-    }
-
-    .lt-ie9 & {
-        // IE 8 doesn't support currentColor;
-        // hide icons and let the paired text stand on its own.
-        display: none;
-    }
-
     &__updating {
         animation: updating-animation 1.25s infinite linear;
         transform-origin: 50% 50%;

--- a/packages/cfpb-layout/src/cfpb-layout.less
+++ b/packages/cfpb-layout/src/cfpb-layout.less
@@ -552,16 +552,6 @@
     }
 }
 
-.lt-ie9 {
-    & .wrapper {
-        max-width: 960px;
-    }
-
-    & body {
-        min-width: 800px;
-    }
-}
-
 .grid_column__top-divider {
     margin-top: unit( ( @grid_gutter-width * 2 ) / @base-font-size-px, em );
     border-left-width: @grid_gutter-width / 2;

--- a/packages/cfpb-layout/src/organisms/featured-content-module.less
+++ b/packages/cfpb-layout/src/organisms/featured-content-module.less
@@ -60,13 +60,6 @@
             left: 50%;
 
             transform: translateX( -50% );
-
-            .lt-ie9 & {
-                position: absolute;
-                right: -100%;
-                left: -100%;
-                margin: auto;
-            }
         }
 
     } );


### PR DESCRIPTION
We ship css to all our users that is only targeting browsers that are sub-0.5% usage. This is wasteful and blocking for people on slow connections and mobile phones with slower processing speeds (which are a much greater proportion of our users that ie8, ie9, and ie10).

Thus, this removes those classes. There will be another PR coming in https://github.com/cfpb/consumerfinance.gov to match this behavior and remove modernizr (which was only really used by the `.no-csspointerevents` class here).