### PR TITLE
Change stylelint default to 2 spaces

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/transition/transition.less
+++ b/packages/cfpb-atomic-component/src/utilities/transition/transition.less
@@ -9,7 +9,7 @@
    ========================================================================== */
 
 .u-no-animation {
-    transition-duration: 0s !important;
+  transition-duration: 0s !important;
 }
 
 //
@@ -17,32 +17,32 @@
 //
 
 .u-move-transition {
-    transition: transform 0.25s ease-out;
+  transition: transform 0.25s ease-out;
 }
 
 .u-move-to-origin {
-    transform: translate3d( 0, 0, 0 );
+  transform: translate3d( 0, 0, 0 );
 }
 
 .u-move-left {
-    transform: translate3d( -100%, 0, 0 );
+  transform: translate3d( -100%, 0, 0 );
 }
 
 // TODO: Look into adding a mixin for movement multiples.
 .u-move-left-2x {
-    transform: translate3d( -200%, 0, 0 );
+  transform: translate3d( -200%, 0, 0 );
 }
 
 .u-move-left-3x {
-    transform: translate3d( -300%, 0, 0 );
+  transform: translate3d( -300%, 0, 0 );
 }
 
 .u-move-right {
-    transform: translate3d( 100%, 0, 0 );
+  transform: translate3d( 100%, 0, 0 );
 }
 
 .u-move-up {
-    transform: translate3d( 0, -100%, 0 );
+  transform: translate3d( 0, -100%, 0 );
 }
 
 //
@@ -50,15 +50,15 @@
 //
 
 .u-alpha-transition {
-    transition: opacity 0.25s linear;
+  transition: opacity 0.25s linear;
 }
 
 .u-alpha-100 {
-    opacity: 1;
+  opacity: 1;
 }
 
 .u-alpha-0 {
-    opacity: 0;
+  opacity: 0;
 }
 
 //
@@ -66,25 +66,25 @@
 //
 
 .u-max-height-transition {
-    // This is an arbitrary value to give max-height an initial value.
-    max-height: 1000px;
+  // This is an arbitrary value to give max-height an initial value.
+  max-height: 1000px;
 
-    transition: max-height 0.25s ease-out;
+  transition: max-height 0.25s ease-out;
 }
 
 .u-max-height-default {
-    max-height: 1000px;
+  max-height: 1000px;
 }
 
 .u-max-height-zero {
-    max-height: 0 !important;
+  max-height: 0 !important;
 }
 
 .u-max-height-summary {
-    /* The value set here should show 4 lines of text at our standard 16px
+  /* The value set here should show 4 lines of text at our standard 16px
        base font size. The calculation comes from the following:
        88px = 16 * 5.5em.
        5.5em = base-line-height (22px) * 4 / base-font-size (16px)
     */
-    max-height: 88px !important;
+  max-height: 88px !important;
 }

--- a/packages/cfpb-buttons/src/atoms/button-links.less
+++ b/packages/cfpb-buttons/src/atoms/button-links.less
@@ -5,98 +5,98 @@
 // TODO: Refactor the rule combos for simplicity
 
 .a-btn__link {
-    padding: 0;
-    border-bottom: 1px dotted @link-underline;
-    border-radius: 0;
+  padding: 0;
+  border-bottom: 1px dotted @link-underline;
+  border-radius: 0;
 
+  &,
+  &:link,
+  &:visited {
+    border-bottom-color: @link-underline;
+    background-color: transparent;
+    color: @link-text;
+  }
+
+  &:hover,
+  &.hover {
+    border-bottom: 1px solid @link-underline-hover;
+    background-color: transparent;
+    color: @link-text-hover;
+  }
+
+  &:focus,
+  &.focus {
+    border-bottom-style: solid;
+    background-color: transparent;
+    outline: 1px dotted @link-underline;
+  }
+
+  &:active,
+  &.active {
+    border-bottom: 1px solid @link-underline-active;
+    background-color: transparent;
+    color: @link-text-active;
+  }
+
+  //
+  // Secondary button link
+  //
+
+  &.a-btn__secondary {
     &,
     &:link,
     &:visited {
-        border-bottom-color: @link-underline;
-        background-color: transparent;
-        color: @link-text;
+      border-bottom-color: @btn__secondary-bg;
+      background-color: transparent;
+      color: @btn__secondary-bg;
     }
 
     &:hover,
     &.hover {
-        border-bottom: 1px solid @link-underline-hover;
-        background-color: transparent;
-        color: @link-text-hover;
+      border-bottom-color: @btn__secondary-bg-hover;
+      color: @btn__secondary-bg-hover;
     }
 
     &:focus,
     &.focus {
-        border-bottom-style: solid;
-        background-color: transparent;
-        outline: 1px dotted @link-underline;
+      outline-color: @btn__secondary-bg;
     }
 
     &:active,
     &.active {
-        border-bottom: 1px solid @link-underline-active;
-        background-color: transparent;
-        color: @link-text-active;
+      border-bottom-color: @btn__secondary-bg-active;
+      color: @btn__secondary-bg-active;
+    }
+  }
+
+  //
+  // Destructive action button link
+  //
+
+  &.a-btn__warning {
+    &,
+    &:link,
+    &:visited {
+      border-bottom-color: @btn__warning-bg;
+      background-color: transparent;
+      color: @btn__warning-bg;
     }
 
-    //
-    // Secondary button link
-    //
-
-    &.a-btn__secondary {
-        &,
-        &:link,
-        &:visited {
-            border-bottom-color: @btn__secondary-bg;
-            background-color: transparent;
-            color: @btn__secondary-bg;
-        }
-
-        &:hover,
-        &.hover {
-            border-bottom-color: @btn__secondary-bg-hover;
-            color: @btn__secondary-bg-hover;
-        }
-
-        &:focus,
-        &.focus {
-            outline-color: @btn__secondary-bg;
-        }
-
-        &:active,
-        &.active {
-            border-bottom-color: @btn__secondary-bg-active;
-            color: @btn__secondary-bg-active;
-        }
+    &:hover,
+    &.hover {
+      border-bottom-color: @btn__warning-bg-hover;
+      color: @btn__warning-bg-hover;
     }
 
-    //
-    // Destructive action button link
-    //
-
-    &.a-btn__warning {
-        &,
-        &:link,
-        &:visited {
-            border-bottom-color: @btn__warning-bg;
-            background-color: transparent;
-            color: @btn__warning-bg;
-        }
-
-        &:hover,
-        &.hover {
-            border-bottom-color: @btn__warning-bg-hover;
-            color: @btn__warning-bg-hover;
-        }
-
-        &:focus,
-        &.focus {
-            outline-color: @btn__warning-bg;
-        }
-
-        &:active,
-        &.active {
-            border-bottom-color: @btn__warning-bg-active;
-            color: @btn__warning-bg-active;
-        }
+    &:focus,
+    &.focus {
+      outline-color: @btn__warning-bg;
     }
+
+    &:active,
+    &.active {
+      border-bottom-color: @btn__warning-bg-active;
+      color: @btn__warning-bg-active;
+    }
+  }
 }

--- a/packages/cfpb-buttons/src/atoms/buttons-with-icons.less
+++ b/packages/cfpb-buttons/src/atoms/buttons-with-icons.less
@@ -5,28 +5,28 @@
 // button padding size
 
 .a-btn_icon__on-left {
-    padding-right: unit( 11px / @btn-font-size, em );
-    border-right: 1px solid mix( @btn-bg, @btn-text, 50% );
-    margin-right: unit( 7px / @btn-font-size, em );
+  padding-right: unit( 11px / @btn-font-size, em );
+  border-right: 1px solid mix( @btn-bg, @btn-text, 50% );
+  margin-right: unit( 7px / @btn-font-size, em );
 }
 
 .a-btn_icon__on-right {
-    padding-left: unit( 11px / @btn-font-size, em );
-    border-left: 1px solid mix( @btn-bg, @btn-text, 50% );
-    margin-left: unit( 7px / @btn-font-size, em );
+  padding-left: unit( 11px / @btn-font-size, em );
+  border-left: 1px solid mix( @btn-bg, @btn-text, 50% );
+  margin-left: unit( 7px / @btn-font-size, em );
 }
 
 .a-btn_icon {
-    .a-btn__secondary & {
-        border-color: mix( @btn__secondary-bg, @btn__secondary-text, 50% );
-    }
+  .a-btn__secondary & {
+    border-color: mix( @btn__secondary-bg, @btn__secondary-text, 50% );
+  }
 
-    .a-btn__warning & {
-        border-color: mix( @btn__warning-bg, @btn__warning-text, 50% );
-    }
+  .a-btn__warning & {
+    border-color: mix( @btn__warning-bg, @btn__warning-text, 50% );
+  }
 
-    .a-btn__disabled &,
-    .a-btn[disabled] & {
-        border-color: mix( @btn__disabled-bg, @btn__disabled-text, 50% );
-    }
+  .a-btn__disabled &,
+  .a-btn[disabled] & {
+    border-color: mix( @btn__disabled-bg, @btn__disabled-text, 50% );
+  }
 }

--- a/packages/cfpb-buttons/src/atoms/buttons.less
+++ b/packages/cfpb-buttons/src/atoms/buttons.less
@@ -3,162 +3,162 @@
 //
 
 .a-btn {
-    appearance: none;
-    display: inline-block;
-    box-sizing: border-box;
-    padding:
+  appearance: none;
+  display: inline-block;
+  box-sizing: border-box;
+  padding:
         unit( @btn-v-padding / @btn-font-size, em )
         unit( @btn-h-padding / @btn-font-size, em );
-    border: 0;
-    margin: 0;
-    border-radius: unit( @btn-border-radius-size / @btn-font-size, em );
-    cursor: pointer;
-    font-size: unit( @btn-font-size / @base-font-size-px, em );
-    font-weight: 500;
-    line-height: normal;
-    text-align: center;
-    text-decoration: none;
-    transition: background-color 0.1s;
+  border: 0;
+  margin: 0;
+  border-radius: unit( @btn-border-radius-size / @btn-font-size, em );
+  cursor: pointer;
+  font-size: unit( @btn-font-size / @base-font-size-px, em );
+  font-weight: 500;
+  line-height: normal;
+  text-align: center;
+  text-decoration: none;
+  transition: background-color 0.1s;
 
+  &,
+  &:link,
+  &:visited {
+    background-color: @btn-bg;
+    color: @btn-text;
+  }
+
+  &:hover,
+  &.hover,
+  &:focus,
+  &.focus {
+    background-color: @btn-bg-hover;
+  }
+
+  &:focus,
+  &.focus {
+    outline: 1px dotted @btn-bg;
+    // The outline-offset property is not supported everywhere (e.g. IE)
+    // but it adds a nice touch in browsers where it is.
+    outline-offset: 1px;
+  }
+
+  &:active,
+  &.active {
+    background-color: @btn-bg-active;
+  }
+
+  button&::-moz-focus-inner,
+  input&::-moz-focus-inner {
+    // Fixes inconsistent button.btn height in Firefox.
+    // Helps with inconsistent input.btn height in Firefox but not completely.
+    border: 0;
+  }
+
+  //
+  // Secondary button
+  //
+
+  &__secondary {
     &,
     &:link,
     &:visited {
-        background-color: @btn-bg;
-        color: @btn-text;
+      background-color: @btn__secondary-bg;
+      color: @btn__secondary-text;
     }
 
     &:hover,
     &.hover,
     &:focus,
     &.focus {
-        background-color: @btn-bg-hover;
+      background-color: @btn__secondary-bg-hover;
     }
 
     &:focus,
     &.focus {
-        outline: 1px dotted @btn-bg;
-        // The outline-offset property is not supported everywhere (e.g. IE)
-        // but it adds a nice touch in browsers where it is.
-        outline-offset: 1px;
+      outline-color: @btn__secondary-bg;
     }
 
     &:active,
     &.active {
-        background-color: @btn-bg-active;
+      background-color: @btn__secondary-bg-active;
+    }
+  }
+
+  //
+  // Destructive action button
+  //
+
+  &__warning {
+    &,
+    &:link,
+    &:visited {
+      background-color: @btn__warning-bg;
+      color: @btn__warning-text;
     }
 
-    button&::-moz-focus-inner,
-    input&::-moz-focus-inner {
-        // Fixes inconsistent button.btn height in Firefox.
-        // Helps with inconsistent input.btn height in Firefox but not completely.
-        border: 0;
+    &:hover,
+    &.hover,
+    &:focus,
+    &.focus {
+      background-color: @btn__warning-bg-hover;
     }
 
-    //
-    // Secondary button
-    //
-
-    &__secondary {
-        &,
-        &:link,
-        &:visited {
-            background-color: @btn__secondary-bg;
-            color: @btn__secondary-text;
-        }
-
-        &:hover,
-        &.hover,
-        &:focus,
-        &.focus {
-            background-color: @btn__secondary-bg-hover;
-        }
-
-        &:focus,
-        &.focus {
-            outline-color: @btn__secondary-bg;
-        }
-
-        &:active,
-        &.active {
-            background-color: @btn__secondary-bg-active;
-        }
+    &:focus,
+    &.focus {
+      outline-color: @btn__warning-bg;
     }
 
-    //
-    // Destructive action button
-    //
+    &:active,
+    &.active {
+      background-color: @btn__warning-bg-active;
+    }
+  }
 
-    &__warning {
-        &,
-        &:link,
-        &:visited {
-            background-color: @btn__warning-bg;
-            color: @btn__warning-text;
-        }
+  //
+  // Disabled button
+  //
 
-        &:hover,
-        &.hover,
-        &:focus,
-        &.focus {
-            background-color: @btn__warning-bg-hover;
-        }
-
-        &:focus,
-        &.focus {
-            outline-color: @btn__warning-bg;
-        }
-
-        &:active,
-        &.active {
-            background-color: @btn__warning-bg-active;
-        }
+  &__disabled,
+  &[disabled] {
+    &,
+    &:link,
+    &:visited,
+    &:hover,
+    &.hover,
+    &:focus,
+    &.focus,
+    &:active,
+    &.active {
+      background-color: @btn__disabled-bg;
+      color: @btn__disabled-text;
+      cursor: default; // Fallback for IE/Opera
+      cursor: not-allowed;
     }
 
-    //
-    // Disabled button
-    //
-
-    &__disabled,
-    &[disabled] {
-        &,
-        &:link,
-        &:visited,
-        &:hover,
-        &.hover,
-        &:focus,
-        &.focus,
-        &:active,
-        &.active {
-            background-color: @btn__disabled-bg;
-            color: @btn__disabled-text;
-            cursor: default; // Fallback for IE/Opera
-            cursor: not-allowed;
-        }
-
-        &:focus,
-        &.focus {
-            outline-color: @btn__disabled-outline;
-        }
+    &:focus,
+    &.focus {
+      outline-color: @btn__disabled-outline;
     }
+  }
 
-    //
-    // Super button
-    //
+  //
+  // Super button
+  //
 
-    &__super {
-        padding:
+  &__super {
+    padding:
             unit( 11px / @btn__super-font-size, em )
             unit( 29px / @btn__super-font-size, em );
-        font-size: unit( @btn__super-font-size / @base-font-size-px, em );
-    }
+    font-size: unit( @btn__super-font-size / @base-font-size-px, em );
+  }
 
-    //
-    // Full width button on x-small screens
-    //
-    &__full-on-xs {
-        .respond-to-max( @bp-xs-max, {
-            display: block;
+  //
+  // Full width button on x-small screens
+  //
+  &__full-on-xs {
+    .respond-to-max( @bp-xs-max, {
+      display: block;
             width: 100%;
         } );
-    }
+  }
 }

--- a/packages/cfpb-buttons/src/molecules/button-groups.less
+++ b/packages/cfpb-buttons/src/molecules/button-groups.less
@@ -5,36 +5,36 @@
 //
 
 .m-btn-group {
-    .a-btn + .a-btn {
-        margin-left: unit( 6px / @btn-font-size, em );
-    }
+  .a-btn + .a-btn {
+    margin-left: unit( 6px / @btn-font-size, em );
+  }
 
-    .a-btn__super + .a-btn__super {
-        margin-left: unit( 6px / @btn__super-font-size, em );
-    }
+  .a-btn__super + .a-btn__super {
+    margin-left: unit( 6px / @btn__super-font-size, em );
+  }
 }
 
 .m-btn-group__combined {
 
-    .a-btn {
-        border-radius: 0;
-        margin-right: 1px;
-    }
+  .a-btn {
+    border-radius: 0;
+    margin-right: 1px;
+  }
 
-    // TODO: There's a strange disappearing border issue on Chrome.
-    // This might have to be revisited.
-    .a-btn + .a-btn,
-    .a-btn__super + .a-btn__super {
-        margin-left: -4px;
-    }
+  // TODO: There's a strange disappearing border issue on Chrome.
+  // This might have to be revisited.
+  .a-btn + .a-btn,
+  .a-btn__super + .a-btn__super {
+    margin-left: -4px;
+  }
 
-    .a-btn:first-child {
-        border-top-left-radius: unit( 4px / @btn-font-size, em );
-        border-bottom-left-radius: unit( 4px / @btn-font-size, em );
-    }
+  .a-btn:first-child {
+    border-top-left-radius: unit( 4px / @btn-font-size, em );
+    border-bottom-left-radius: unit( 4px / @btn-font-size, em );
+  }
 
-    .a-btn:last-child {
-        border-top-right-radius: unit( 4px / @btn-font-size, em );
-        border-bottom-right-radius: unit( 4px / @btn-font-size, em );
-    }
+  .a-btn:last-child {
+    border-top-right-radius: unit( 4px / @btn-font-size, em );
+    border-bottom-right-radius: unit( 4px / @btn-font-size, em );
+  }
 }

--- a/packages/cfpb-core/src/base.less
+++ b/packages/cfpb-core/src/base.less
@@ -8,90 +8,90 @@
 //
 
 body {
-    color: @text;
-    font-family: 'Avenir Next', Arial, sans-serif;
-    font-size: unit( @base-font-size-px / 16 * 100, % );
-    line-height: @base-line-height;
+  color: @text;
+  font-family: 'Avenir Next', Arial, sans-serif;
+  font-size: unit( @base-font-size-px / 16 * 100, % );
+  line-height: @base-line-height;
 }
 
 button,
 input,
 select,
 textarea {
-    // Must set these explicitly to override Normalize.css's provided default
-    // of `font-family: sans-serif;`
-    font-family: 'Avenir Next', Arial, sans-serif;
+  // Must set these explicitly to override Normalize.css's provided default
+  // of `font-family: sans-serif;`
+  font-family: 'Avenir Next', Arial, sans-serif;
 }
 
 strong,
 b {
-    font-weight: 600;
+  font-weight: 600;
 }
 
 .heading-1( @fs: @size-i ) {
-    @font-size: @fs;
+  @font-size: @fs;
 
-    margin-bottom: unit( 15px / @font-size, em );
-    font-size: unit( @font-size / @base-font-size-px, em );
-    font-weight: normal;
-    letter-spacing: inherit;
-    line-height: 1.25;
-    text-transform: inherit;
+  margin-bottom: unit( 15px / @font-size, em );
+  font-size: unit( @font-size / @base-font-size-px, em );
+  font-weight: normal;
+  letter-spacing: inherit;
+  line-height: 1.25;
+  text-transform: inherit;
 }
 
 .heading-2( @fs: @size-ii ) {
-    @font-size: @fs;
+  @font-size: @fs;
 
-    margin-bottom: unit( 15px / @font-size, em );
-    font-size: unit( @font-size / @base-font-size-px, em );
-    font-weight: normal;
-    letter-spacing: inherit;
-    line-height: 1.25;
-    text-transform: inherit;
+  margin-bottom: unit( 15px / @font-size, em );
+  font-size: unit( @font-size / @base-font-size-px, em );
+  font-weight: normal;
+  letter-spacing: inherit;
+  line-height: 1.25;
+  text-transform: inherit;
 }
 
 .heading-3( @fs: @size-iii ) {
-    @font-size: @fs;
+  @font-size: @fs;
 
-    margin-bottom: unit( 15px / @font-size, em );
-    font-size: unit( @font-size / @base-font-size-px, em );
-    font-weight: normal;
-    letter-spacing: inherit;
-    line-height: 1.25;
-    text-transform: inherit;
+  margin-bottom: unit( 15px / @font-size, em );
+  font-size: unit( @font-size / @base-font-size-px, em );
+  font-weight: normal;
+  letter-spacing: inherit;
+  line-height: 1.25;
+  text-transform: inherit;
 }
 
 .heading-4( @fs: @size-iv ) {
-    @font-size: @fs;
+  @font-size: @fs;
 
-    margin-bottom: unit( 15px / @font-size, em );
-    font-size: unit( @font-size / @base-font-size-px, em );
-    font-weight: 500;
-    letter-spacing: inherit;
-    line-height: 1.25;
-    text-transform: inherit;
+  margin-bottom: unit( 15px / @font-size, em );
+  font-size: unit( @font-size / @base-font-size-px, em );
+  font-weight: 500;
+  letter-spacing: inherit;
+  line-height: 1.25;
+  text-transform: inherit;
 }
 
 .heading-5( @fs: @size-v, @text-shadow: @text ) {
-    @font-size: @fs;
+  @font-size: @fs;
 
-    margin-bottom: unit( 15px / @font-size, em );
-    font-size: unit( @font-size / @base-font-size-px, em );
-    font-weight: 600;
-    letter-spacing: 1px;
-    line-height: 1.25;
-    text-transform: uppercase;
+  margin-bottom: unit( 15px / @font-size, em );
+  font-size: unit( @font-size / @base-font-size-px, em );
+  font-weight: 600;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
 }
 
 .heading-6( @fs: @size-vi, @text-shadow: @text ) {
-    @font-size: @fs;
+  @font-size: @fs;
 
-    margin-bottom: unit( 15px / @font-size, em );
-    font-size: unit( @font-size / @base-font-size-px, em );
-    font-weight: 600;
-    letter-spacing: 1px;
-    line-height: 1.25;
-    text-transform: uppercase;
+  margin-bottom: unit( 15px / @font-size, em );
+  font-size: unit( @font-size / @base-font-size-px, em );
+  font-weight: 600;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
 }
 
 // Resetting default browser styling for margin-top on headings
@@ -101,26 +101,26 @@ h3,
 h4,
 h5,
 h6 {
-    margin-top: 0;
+  margin-top: 0;
 }
 
 h1,
 .h1 {
-    .heading-1();
+  .heading-1();
 
-    p + &,
-    ul + &,
-    ol + &,
-    dl + &,
-    figure + &,
-    img + &,
-    table + &,
-    blockquote + & {
-        margin-top: unit( 60px / @font-size, em );
-    }
+  p + &,
+  ul + &,
+  ol + &,
+  dl + &,
+  figure + &,
+  img + &,
+  table + &,
+  blockquote + & {
+    margin-top: unit( 60px / @font-size, em );
+  }
 
-    .respond-to-max( @bp-xs-max, {
-        .heading-2();
+  .respond-to-max( @bp-xs-max, {
+    .heading-2();
 
         p + &,
         ul + &,
@@ -150,34 +150,34 @@ h1,
 
 h2,
 .h2 {
-    .heading-2();
+  .heading-2();
 
-    p + &,
-    ul + &,
-    ol + &,
-    dl + &,
-    figure + &,
-    img + &,
-    table + &,
-    blockquote + & {
-        margin-top: unit( 45px / @font-size, em );
-    }
+  p + &,
+  ul + &,
+  ol + &,
+  dl + &,
+  figure + &,
+  img + &,
+  table + &,
+  blockquote + & {
+    margin-top: unit( 45px / @font-size, em );
+  }
 
-    h1 + &,
-    .h1 + &,
-    h3 + &,
-    .h3 + &,
-    h4 + &,
-    .h4 + &,
-    h5 + &,
-    .h5 + &,
-    h6 + &,
-    .h6 + & {
-        margin-top: unit( 30px / @font-size, em );
-    }
+  h1 + &,
+  .h1 + &,
+  h3 + &,
+  .h3 + &,
+  h4 + &,
+  .h4 + &,
+  h5 + &,
+  .h5 + &,
+  h6 + &,
+  .h6 + & {
+    margin-top: unit( 30px / @font-size, em );
+  }
 
-    .respond-to-max( @bp-xs-max, {
-        .heading-3();
+  .respond-to-max( @bp-xs-max, {
+    .heading-3();
 
         p + &,
         ul + &,
@@ -194,61 +194,61 @@ h2,
 
 h3,
 .h3 {
-    .heading-3();
+  .heading-3();
 
-    p + &,
-    ul + &,
-    ol + &,
-    dl + &,
-    figure + &,
-    img + &,
-    table + &,
-    blockquote + &,
-    h1 + &,
-    .h1 + &,
-    h2 + &,
-    .h2 + &,
-    h4 + &,
-    .h4 + &,
-    h5 + &,
-    .h5 + &,
-    h6 + &,
-    .h6 + & {
-        margin-top: unit( 30px / @font-size, em );
-    }
+  p + &,
+  ul + &,
+  ol + &,
+  dl + &,
+  figure + &,
+  img + &,
+  table + &,
+  blockquote + &,
+  h1 + &,
+  .h1 + &,
+  h2 + &,
+  .h2 + &,
+  h4 + &,
+  .h4 + &,
+  h5 + &,
+  .h5 + &,
+  h6 + &,
+  .h6 + & {
+    margin-top: unit( 30px / @font-size, em );
+  }
 
-    .respond-to-max( @bp-xs-max, {
-        .heading-4();
+  .respond-to-max( @bp-xs-max, {
+    .heading-4();
     } );
 }
 
 h4,
 .h4 {
-    .heading-4();
+  .heading-4();
 
-    p + &,
-    ul + &,
-    ol + &,
-    dl + &,
-    figure + &,
-    img + &,
-    table + &,
-    blockquote + &,
-    h1 + &,
-    .h1 + &,
-    h2 + &,
-    .h2 + &,
-    h3 + &,
-    .h3 + &,
-    h5 + &,
-    .h5 + &,
-    h6 + &,
-    .h6 + & {
-        margin-top: unit( 30px / @font-size, em );
-    }
+  p + &,
+  ul + &,
+  ol + &,
+  dl + &,
+  figure + &,
+  img + &,
+  table + &,
+  blockquote + &,
+  h1 + &,
+  .h1 + &,
+  h2 + &,
+  .h2 + &,
+  h3 + &,
+  .h3 + &,
+  h5 + &,
+  .h5 + &,
+  h6 + &,
+  .h6 + & {
+    margin-top: unit( 30px / @font-size, em );
+  }
 
-    .respond-to-max( @bp-xs-max, {
-        @h4-font-size-on-xs: @base-font-size-px;
+  .respond-to-max( @bp-xs-max, {
+    @h4-font-size-on-xs: @base-font-size-px;
 
         margin-bottom: unit( 10px / @h4-font-size-on-xs, em );
         font-size: unit( @h4-font-size-on-xs / @base-font-size-px, em );
@@ -258,77 +258,77 @@ h4,
 
 h5,
 .h5 {
-    .heading-5();
+  .heading-5();
 
-    p + &,
-    ul + &,
-    ol + &,
-    dl + &,
-    figure + &,
-    img + &,
-    table + &,
-    blockquote + &,
-    h1 + &,
-    .h1 + &,
-    h2 + &,
-    .h2 + &,
-    h3 + &,
-    .h3 + &,
-    h4 + &,
-    .h4 + &,
-    h6 + &,
-    .h6 + & {
-        margin-top: unit( 30px / @font-size, em );
-    }
+  p + &,
+  ul + &,
+  ol + &,
+  dl + &,
+  figure + &,
+  img + &,
+  table + &,
+  blockquote + &,
+  h1 + &,
+  .h1 + &,
+  h2 + &,
+  .h2 + &,
+  h3 + &,
+  .h3 + &,
+  h4 + &,
+  .h4 + &,
+  h6 + &,
+  .h6 + & {
+    margin-top: unit( 30px / @font-size, em );
+  }
 }
 
 h6,
 .h6 {
-    .heading-6();
+  .heading-6();
 
-    p + &,
-    ul + &,
-    ol + &,
-    dl + &,
-    figure + &,
-    img + &,
-    table + &,
-    blockquote + &,
-    h1 + &,
-    .h1 + &,
-    h2 + &,
-    .h2 + &,
-    h3 + &,
-    .h3 + &,
-    h4 + &,
-    .h4 + &,
-    h5 + &,
-    .h5 + & {
-        margin-top: unit( 30px / @font-size, em );
-    }
+  p + &,
+  ul + &,
+  ol + &,
+  dl + &,
+  figure + &,
+  img + &,
+  table + &,
+  blockquote + &,
+  h1 + &,
+  .h1 + &,
+  h2 + &,
+  .h2 + &,
+  h3 + &,
+  .h3 + &,
+  h4 + &,
+  .h4 + &,
+  h5 + &,
+  .h5 + & {
+    margin-top: unit( 30px / @font-size, em );
+  }
 }
 
 .lead-paragraph {
-    .heading-3();
+  .heading-3();
 
-    margin-top: unit( 30px / @font-size, em );
-    margin-bottom: unit( 15px / 18px, em );
+  margin-top: unit( 30px / @font-size, em );
+  margin-bottom: unit( 15px / 18px, em );
 
-    .respond-to-max(@bp-xs-max, {
-        // Use the same regular weight but reduce the sizes to h4 size
+  .respond-to-max(@bp-xs-max, {
+    // Use the same regular weight but reduce the sizes to h4 size
         margin-top: unit( 30px / 18px, em );
         font-size: unit( 18px / @base-font-size-px, em );
     });
 }
 
 .superheading {
-    // For when you want a heading that's bigger than a normal H1
-    @font-size: @size-xl;
+  // For when you want a heading that's bigger than a normal H1
+  @font-size: @size-xl;
 
-    margin-bottom: unit( 20px / @font-size, em );
-    font-size: unit( @font-size / @base-font-size-px, em );
-    font-weight: normal;
-    line-height: 1.25;
+  margin-bottom: unit( 20px / @font-size, em );
+  font-size: unit( @font-size / @base-font-size-px, em );
+  font-weight: normal;
+  line-height: 1.25;
 }
 
 //
@@ -342,41 +342,41 @@ dl,
 figure,
 table,
 blockquote {
-    margin-top: 0;
-    margin-bottom: unit( 15px / @base-font-size-px, em );
+  margin-top: 0;
+  margin-bottom: unit( 15px / @base-font-size-px, em );
 
-    &:last-child {
-        margin-bottom: 0;
-    }
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
 p + ul,
 p + ol {
-    margin-top: unit( -5px / @base-font-size-px, em );
+  margin-top: unit( -5px / @base-font-size-px, em );
 }
 
 ul ul,
 ol ol,
 ul ol,
 ol ul {
-    margin-top: unit( 8px / @base-font-size-px, em );
+  margin-top: unit( 8px / @base-font-size-px, em );
 }
 
 li {
-    margin-bottom: unit( 8px / @base-font-size-px, em );
+  margin-bottom: unit( 8px / @base-font-size-px, em );
 
-    &:last-child,
-    nav & {
-        margin-bottom: 0;
-    }
+  &:last-child,
+  nav & {
+    margin-bottom: 0;
+  }
 }
 
 ol ol {
-    list-style-type: lower-alpha;
+  list-style-type: lower-alpha;
 }
 
 ol ol ol {
-    list-style-type: lower-roman;
+  list-style-type: lower-roman;
 }
 
 //
@@ -384,40 +384,40 @@ ol ol ol {
 //
 
 a {
-    border-width: 0;
-    border-style: dotted;
-    border-color: @link-underline;
-    color: @link-text;
-    text-decoration: none;
+  border-width: 0;
+  border-style: dotted;
+  border-color: @link-underline;
+  color: @link-text;
+  text-decoration: none;
 
-    // Note: The class definitions below are only for use in
-    // demonstrating link states. Do not use in production.
+  // Note: The class definitions below are only for use in
+  // demonstrating link states. Do not use in production.
 
-    &:visited,
-    &.visited {
-        border-color: @link-underline-visited;
-        color: @link-text-visited;
-    }
+  &:visited,
+  &.visited {
+    border-color: @link-underline-visited;
+    color: @link-text-visited;
+  }
 
-    &:hover,
-    &.hover {
-        border-style: solid;
-        border-color: @link-underline-hover;
-        color: @link-text-hover;
-    }
+  &:hover,
+  &.hover {
+    border-style: solid;
+    border-color: @link-underline-hover;
+    color: @link-text-hover;
+  }
 
-    &:focus,
-    &.focus {
-        border-style: solid;
-        outline: thin dotted;
-    }
+  &:focus,
+  &.focus {
+    border-style: solid;
+    outline: thin dotted;
+  }
 
-    &:active,
-    &.active {
-        border-style: solid;
-        border-color: @link-underline-active;
-        color: @link-text-active;
-    }
+  &:active,
+  &.active {
+    border-style: solid;
+    border-color: @link-underline-active;
+    color: @link-text-active;
+  }
 }
 
 //
@@ -427,16 +427,16 @@ a {
 p,
 li,
 dd {
-    // Restrict bottom borders to inline text links ...
+  // Restrict bottom borders to inline text links ...
 
-    a {
-        border-bottom-width: 1px;
-    }
+  a {
+    border-bottom-width: 1px;
+  }
 }
 
 nav a {
-    // ... unless they're part of a nav list
-    border-bottom-width: 0;
+  // ... unless they're part of a nav list
+  border-bottom-width: 0;
 }
 
 //
@@ -444,31 +444,31 @@ nav a {
 //
 
 ul {
-    padding-left: unit( 18px / @base-font-size-px, em );
-    list-style: square;
+  padding-left: unit( 18px / @base-font-size-px, em );
+  list-style: square;
 }
 
 ul ul {
-    list-style-type: circle;
+  list-style-type: circle;
 }
 
 ol {
-    // Slightly larger than necessary, but this is the minimum value
-    // for numbers to not be partially in the margin in Internet Explorer.
-    padding-left: unit( 21px / @base-font-size-px, em );
+  // Slightly larger than necessary, but this is the minimum value
+  // for numbers to not be partially in the margin in Internet Explorer.
+  padding-left: unit( 21px / @base-font-size-px, em );
 
-    li:nth-last-child( n+10 ),
-    li:nth-last-child( n+10 ) ~ li {
-        // 0.5625rem
-        margin-left: unit( 9px / @base-font-size-px, rem );
-    }
+  li:nth-last-child( n+10 ),
+  li:nth-last-child( n+10 ) ~ li {
+    // 0.5625rem
+    margin-left: unit( 9px / @base-font-size-px, rem );
+  }
 }
 
 ol ol {
-    // Negate margin added to lists longer than 9 items.
-    li {
-        margin-left: 0 !important;
-    }
+  // Negate margin added to lists longer than 9 items.
+  li {
+    margin-left: 0 !important;
+  }
 }
 
 // Lists in the nav should be unstyled
@@ -476,8 +476,8 @@ nav ul,
 nav ol,
 nav ul ul,
 nav ol ol {
-    list-style: none;
-    list-style-image: none;
+  list-style: none;
+  list-style-image: none;
 }
 
 //
@@ -485,49 +485,49 @@ nav ol ol {
 //
 
 caption {
-    margin-bottom: unit( 10px / @base-font-size-px, em );
-    text-align: left;
+  margin-bottom: unit( 10px / @base-font-size-px, em );
+  text-align: left;
 }
 
 th,
 td {
-    padding: unit( 10px / @base-font-size-px, em );
+  padding: unit( 10px / @base-font-size-px, em );
 
-    thead & {
-        // 10px / 14px
-        padding: unit( 10px / @size-v, em );
-        background: @table-head-bg;
-        color: @table-head-text;
-        font-size: unit( 16px / @base-font-size-px, em );
-        vertical-align: top;
-    }
+  thead & {
+    // 10px / 14px
+    padding: unit( 10px / @size-v, em );
+    background: @table-head-bg;
+    color: @table-head-text;
+    font-size: unit( 16px / @base-font-size-px, em );
+    vertical-align: top;
+  }
 }
 
 thead,
 tbody tr {
-    border-bottom: 1px solid @table-border;
+  border-bottom: 1px solid @table-border;
 }
 
 th {
-    font-weight: 600;
-    text-align: left;
+  font-weight: 600;
+  text-align: left;
 
-    thead & {
-        // Heading elements may at times appear inside `th` elements
-        // as required for navigating the page's content with screenreaders.
-        // These rules prevent those headings from overriding the desired style
-        // of their parent `th` elements.
-        h2, .h2,
-        h3, .h3,
-        h4, .h4,
-        h5, .h5,
-        h6, .h6 {
-            .h5();
+  thead & {
+    // Heading elements may at times appear inside `th` elements
+    // as required for navigating the page's content with screenreaders.
+    // These rules prevent those headings from overriding the desired style
+    // of their parent `th` elements.
+    h2, .h2,
+    h3, .h3,
+    h4, .h4,
+    h5, .h5,
+    h6, .h6 {
+      .h5();
 
-            margin: 0;
-            font-size: inherit;
-        }
+      margin: 0;
+      font-size: inherit;
     }
+  }
 }
 
 //
@@ -535,11 +535,11 @@ th {
 //
 
 blockquote {
-    margin-right: unit( 15px / @base-font-size-px, em );
-    margin-left: unit( 15px / @base-font-size-px, em );
+  margin-right: unit( 15px / @base-font-size-px, em );
+  margin-left: unit( 15px / @base-font-size-px, em );
 
-    .respond-to-min( @bp-sm-min, {
-        margin-right: unit( 30px / @base-font-size-px, em );
+  .respond-to-min( @bp-sm-min, {
+    margin-right: unit( 30px / @base-font-size-px, em );
         margin-left: unit( 30px / @base-font-size-px, em );
     } );
 }
@@ -553,7 +553,7 @@ blockquote {
 //
 
 img {
-    max-width: 100%;
+  max-width: 100%;
 }
 
 //
@@ -561,15 +561,15 @@ img {
 //
 
 figure {
-    // reset browser default side margins
-    margin-right: 0;
-    margin-left: 0;
+  // reset browser default side margins
+  margin-right: 0;
+  margin-left: 0;
 
-    img {
-        // Removes weird vertical spacing below images.
-        // TODO: Discuss whether this could just be universally applied to img
-        vertical-align: middle;
-    }
+  img {
+    // Removes weird vertical spacing below images.
+    // TODO: Discuss whether this could just be universally applied to img
+    vertical-align: middle;
+  }
 }
 
 //
@@ -578,30 +578,30 @@ figure {
 
 pre,
 code {
-    background: @code-bg;
-    border-radius: 4px;
-    color: @code-text;
-    font-family: 'Input Mono', Consolas, Monaco, 'Courier New', monospace;
+  background: @code-bg;
+  border-radius: 4px;
+  color: @code-text;
+  font-family: 'Input Mono', Consolas, Monaco, 'Courier New', monospace;
 }
 
 code {
-    padding:
+  padding:
         unit( 3px / @size-code, em )
         unit( 3px / @size-code, em )
         0;
-    font-size: unit( @size-code / @base-font-size-px, em );
+  font-size: unit( @size-code / @base-font-size-px, em );
 }
 
 pre {
-    display: block;
-    padding:
+  display: block;
+  padding:
         unit( 10px / @base-font-size-px, em )
         unit( 15px / @base-font-size-px, em );
-    white-space: pre-wrap;
-    overflow-wrap: break-word;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 
-    code {
-        padding: 0;
-        background-color: transparent;
-    }
+  code {
+    padding: 0;
+    background-color: transparent;
+  }
 }

--- a/packages/cfpb-core/src/media-queries.less
+++ b/packages/cfpb-core/src/media-queries.less
@@ -8,46 +8,46 @@
 //
 
 .respond-to-min( @bp, @rules ) {
-    @ems: unit( ( @bp / @base-font-size-px ), em );
+  @ems: unit( ( @bp / @base-font-size-px ), em );
 
-    @media only all and ( min-width: @ems ) {
-        @rules();
-    }
+  @media only all and ( min-width: @ems ) {
+    @rules();
+  }
 }
 
 .respond-to-max( @bp, @rules ) {
-    @ems: unit( ( @bp / @base-font-size-px ), em);
+  @ems: unit( ( @bp / @base-font-size-px ), em);
 
-    @media only all and ( max-width: @ems ) {
-        @rules();
-    }
+  @media only all and ( max-width: @ems ) {
+    @rules();
+  }
 }
 
 .respond-to-range( @bp1, @bp2, @rules ) {
-    @ems1: unit( ( @bp1 / @base-font-size-px ), em );
-    @ems2: unit( ( @bp2 / @base-font-size-px ), em );
+  @ems1: unit( ( @bp1 / @base-font-size-px ), em );
+  @ems2: unit( ( @bp2 / @base-font-size-px ), em );
 
-    @media only all and ( min-width: @ems1 ) and ( max-width: @ems2 ) {
-        @rules();
-    }
+  @media only all and ( min-width: @ems1 ) and ( max-width: @ems2 ) {
+    @rules();
+  }
 }
 
 // TODO: Discuss whether to split this into min and max queries.
 .respond-to-dpi( @ratio, @rules ) {
-    @dpi: ( @ratio * 96dpi );
+  @dpi: ( @ratio * 96dpi );
 
-    // TODO: min-device-pixel-ratio is deprecated, consider removing.
-    /* stylelint-disable-next-line media-feature-name-no-unknown */
-    @media ( min-device-pixel-ratio: @ratio ), ( min-resolution: @dpi ) {
-        @rules();
-    }
+  // TODO: min-device-pixel-ratio is deprecated, consider removing.
+  /* stylelint-disable-next-line media-feature-name-no-unknown */
+  @media ( min-device-pixel-ratio: @ratio ), ( min-resolution: @dpi ) {
+    @rules();
+  }
 }
 
 .respond-to-print( @rules ) {
-    @media print {
-        @rules();
-    }
-    .print & {
-        @rules();
-    }
+  @media print {
+    @rules();
+  }
+  .print & {
+    @rules();
+  }
 }

--- a/packages/cfpb-core/src/utilities.less
+++ b/packages/cfpb-core/src/utilities.less
@@ -8,9 +8,9 @@
 //
 
 .u-js-only {
-    .no-js & {
-        display: none !important;
-    }
+  .no-js & {
+    display: none !important;
+  }
 }
 
 //
@@ -18,11 +18,11 @@
 //
 
 .u-clearfix {
-    &:after {
-        content: '';
-        display: table;
-        clear: both;
-    }
+  &:after {
+    content: '';
+    display: table;
+    clear: both;
+  }
 }
 
 //
@@ -30,23 +30,23 @@
 //
 
 .u-visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    border: 0;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    // `clip` is deprecated, but retained for safety in making sure that this
-    // utility works as expected for screenreaders. Comma-separated syntax is
-    // not used because space-separated is more backward-compatible,
-    // per https://developer.mozilla.org/en-US/docs/Web/CSS/clip
-    clip: rect( 0 0 0 0 );
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  border: 0;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  // `clip` is deprecated, but retained for safety in making sure that this
+  // utility works as expected for screenreaders. Comma-separated syntax is
+  // not used because space-separated is more backward-compatible,
+  // per https://developer.mozilla.org/en-US/docs/Web/CSS/clip
+  clip: rect( 0 0 0 0 );
 }
 
 .u-visually-hidden-on-mobile {
-    .respond-to-max( @bp-xs-max, {
-        .u-visually-hidden();
+  .respond-to-max( @bp-xs-max, {
+    .u-visually-hidden();
     } );
 }
 
@@ -55,16 +55,16 @@
 //
 
 .u-hide-on-mobile {
-    .respond-to-max( @bp-xs-max, {
-        display: none;
+  .respond-to-max( @bp-xs-max, {
+    display: none;
     } );
 }
 
 .u-show-on-mobile {
-    display: none;
+  display: none;
 
-    .respond-to-max( @bp-xs-max, {
-        display: block;
+  .respond-to-max( @bp-xs-max, {
+    display: block;
     } );
 }
 
@@ -73,7 +73,7 @@
 //
 
 .u-hidden {
-    display: none !important;
+  display: none !important;
 }
 
 //
@@ -81,7 +81,7 @@
 //
 
 .u-invisible {
-    visibility: hidden;
+  visibility: hidden;
 }
 
 // TODO: Deprecated. Remove in CFv5.
@@ -90,7 +90,7 @@
 //
 
 .u-inline-block {
-    display: inline-block;
+  display: inline-block;
 }
 
 //
@@ -98,7 +98,7 @@
 //
 
 .u-right {
-    float: right;
+  float: right;
 }
 
 //
@@ -106,7 +106,7 @@
 //
 
 .u-break-word {
-    word-break: break-all;
+  word-break: break-all;
 }
 
 //
@@ -114,7 +114,7 @@
 //
 
 .u-nowrap {
-    white-space: nowrap;
+  white-space: nowrap;
 }
 
 //
@@ -122,9 +122,9 @@
 //
 
 .u-align-with-btn( @font-size: @base-font-size-px ) {
-    display: inline-block;
-    line-height: normal;
-    vertical-align: middle;
+  display: inline-block;
+  line-height: normal;
+  vertical-align: middle;
 }
 
 //
@@ -132,27 +132,27 @@
 //
 
 .u-flexible-container-mixin( @width: 16, @height: 9 ) {
-    @ratio: ( @height / @width ) * 100;
+  @ratio: ( @height / @width ) * 100;
 
-    position: relative;
-    padding-bottom: ~'@{ratio}%';
-    height: 0;
+  position: relative;
+  padding-bottom: ~'@{ratio}%';
+  height: 0;
 }
 
 .u-flexible-container {
-    .u-flexible-container-mixin();
+  .u-flexible-container-mixin();
 
-    &_inner {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-    }
+  &_inner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
 
-    &__4-3 {
-        .u-flexible-container-mixin( 4, 3 );
-    }
+  &__4-3 {
+    .u-flexible-container-mixin( 4, 3 );
+  }
 }
 
 //
@@ -160,33 +160,33 @@
 //
 
 .u-link__colors() {
-    .u-link__colors-base();
+  .u-link__colors-base();
 }
 
 .u-link__colors( @c ) {
-    .u-link__colors-base(
-        @c, @c, @c, @c, @c,
+  .u-link__colors-base(
+    @c, @c, @c, @c, @c,
         @c, @c, @c, @c, @c
     );
 }
 
 .u-link__colors( @c, @h ) {
-    .u-link__colors-base(
-        @c, @c, @h, @h, @c,
+  .u-link__colors-base(
+    @c, @c, @h, @h, @c,
         @c, @c, @h, @h, @c
     );
 }
 
 .u-link__colors( @c, @v, @h, @f, @a ) {
-    .u-link__colors-base(
-        @c, @v, @h, @f, @a,
+  .u-link__colors-base(
+    @c, @v, @h, @f, @a,
         @c, @v, @h, @f, @a
     );
 }
 
 .u-link__colors( @c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba ) {
-    .u-link__colors-base(
-        @c, @v, @h, @f, @a,
+  .u-link__colors-base(
+    @c, @v, @h, @f, @a,
         @bc, @bv, @bh, @bf, @ba
     );
 }
@@ -202,51 +202,51 @@
 @bh: @link-underline-hover,
 @bf: @link-underline,
 @ba: @link-underline-active ) {
-    color: @c;
-    border-color: @bc;
+  color: @c;
+  border-color: @bc;
 
-    &:visited,
-    &.visited {
-        border-color: @bv;
-        color: @v;
-    }
+  &:visited,
+  &.visited {
+    border-color: @bv;
+    color: @v;
+  }
 
-    &:hover,
-    &.hover {
-        border-color: @bh;
-        color: @h;
-    }
+  &:hover,
+  &.hover {
+    border-color: @bh;
+    color: @h;
+  }
 
-    &:focus,
-    &.focus {
-        border-color: @bf;
-        color: @f;
-    }
+  &:focus,
+  &.focus {
+    border-color: @bf;
+    color: @f;
+  }
 
-    &:active,
-    &.active {
-        border-color: @ba;
-        color: @a;
-    }
+  &:active,
+  &.active {
+    border-color: @ba;
+    color: @a;
+  }
 }
 
 .u-link__border() {
-    border-bottom-width: 1px;
+  border-bottom-width: 1px;
 }
 
 .u-link__no-border() {
-    border-bottom-width: 0 !important;
+  border-bottom-width: 0 !important;
 }
 
 .u-link__hover-border() {
-    border-bottom-width: 0 !important;
+  border-bottom-width: 0 !important;
 
-    &:hover,
-    &.hover,
-    &:focus,
-    &.focus {
-        border-bottom-width: 1px !important;
-    }
+  &:hover,
+  &.hover,
+  &:focus,
+  &.focus {
+    border-bottom-width: 1px !important;
+  }
 }
 
 //
@@ -294,10 +294,10 @@
 //
 
 .u-small-text( @context: @base-font-size-px ) {
-    font-size: unit( 14px / @context, em );
+  font-size: unit( 14px / @context, em );
 }
 
 small,
 .u-small-text {
-    .u-small-text();
+  .u-small-text();
 }

--- a/packages/cfpb-expandables/src/cfpb-expandables.less
+++ b/packages/cfpb-expandables/src/cfpb-expandables.less
@@ -41,164 +41,164 @@
 //
 
 .o-expandable {
-    position: relative;
+  position: relative;
 
-    &_target {
-        padding: 0;
-        border: 0;
-        background-color: transparent;
-        cursor: pointer;
+  &_target {
+    padding: 0;
+    border: 0;
+    background-color: transparent;
+    cursor: pointer;
 
-        &:focus {
-            outline: 1px dotted @expandable-focus;
-            outline-offset: 1px;
-        }
-
-        .o-expandable_cue-close,
-        .o-expandable_cue-open {
-            display: none;
-        }
-
-        &__expanded .o-expandable_cue-close {
-            display: block;
-        }
-
-        &__collapsed .o-expandable_cue-open {
-            display: block;
-        }
+    &:focus {
+      outline: 1px dotted @expandable-focus;
+      outline-offset: 1px;
     }
 
-    &_content {
-        // A clearfix prevents twitchy animations from occurring when margins
-        // collapse and extend past the bounds of the expandable.
-        .u-clearfix();
-
-        &__transition {
-            transition: max-height @expandable__transition-speed ease-in-out;
-        }
-
-        &__collapsed {
-            max-height: 0;
-        }
-
-        &__expanded {
-            max-height: 1000px;
-        }
-
-        &.u-is-animating {
-            overflow: hidden;
-        }
+    .o-expandable_cue-close,
+    .o-expandable_cue-open {
+      display: none;
     }
 
-    //
-    // Expandable text elements
-    //
-
-    &_label {
-        // Remove default h4 margin style
-        margin-bottom: 0;
-        color: @expandable_label-text;
-        font-weight: 500;
+    &__expanded .o-expandable_cue-close {
+      display: block;
     }
 
-    &_link {
-        color: @expandable_link-text;
-        font-size: unit( @expandable_link-font-size / @base-font-size-px, em );
-        line-height: unit( @base-line-height-px / @expandable_link-font-size );
+    &__collapsed .o-expandable_cue-open {
+      display: block;
+    }
+  }
+
+  &_content {
+    // A clearfix prevents twitchy animations from occurring when margins
+    // collapse and extend past the bounds of the expandable.
+    .u-clearfix();
+
+    &__transition {
+      transition: max-height @expandable__transition-speed ease-in-out;
     }
 
-    //
-    // Header
-    //
-
-    &_header {
-        display: block;
-        .u-clearfix();
-
-        // Using the button element with .o-expandable_header requires setting
-        // an explicit width.
-        button& {
-            width: 100%;
-            text-align: left;
-        }
-
-        &__spaced {
-            padding-bottom: unit( 15px / @base-font-size-px, em );
-        }
-
-
-        // TODO: Convert float layout to flexbox
-        &-left {
-            float: left;
-            width: 85%;
-        }
-
-        &-right {
-            float: right;
-        }
+    &__collapsed {
+      max-height: 0;
     }
 
-    //
-    // Padded expandable modifier
-    //
+    &__expanded {
+      max-height: 1000px;
+    }
 
-    &__padded {
-        .o-expandable_header {
-            padding:
+    &.u-is-animating {
+      overflow: hidden;
+    }
+  }
+
+  //
+  // Expandable text elements
+  //
+
+  &_label {
+    // Remove default h4 margin style
+    margin-bottom: 0;
+    color: @expandable_label-text;
+    font-weight: 500;
+  }
+
+  &_link {
+    color: @expandable_link-text;
+    font-size: unit( @expandable_link-font-size / @base-font-size-px, em );
+    line-height: unit( @base-line-height-px / @expandable_link-font-size );
+  }
+
+  //
+  // Header
+  //
+
+  &_header {
+    display: block;
+    .u-clearfix();
+
+    // Using the button element with .o-expandable_header requires setting
+    // an explicit width.
+    button& {
+      width: 100%;
+      text-align: left;
+    }
+
+    &__spaced {
+      padding-bottom: unit( 15px / @base-font-size-px, em );
+    }
+
+
+    // TODO: Convert float layout to flexbox
+    &-left {
+      float: left;
+      width: 85%;
+    }
+
+    &-right {
+      float: right;
+    }
+  }
+
+  //
+  // Padded expandable modifier
+  //
+
+  &__padded {
+    .o-expandable_header {
+      padding:
                 unit( 10px / @base-font-size-px, em )
                 unit( 15px / @base-font-size-px, em );
-        }
-
-        .o-expandable_content {
-            padding: 0 unit( 15px / @base-font-size-px, em );
-
-            // The divider between _header and _content.
-            &:before {
-                content: '';
-                display: block;
-                border-top: 1px solid @expandable__border;
-                padding-top: unit( 15px / @base-font-size-px, em );
-            }
-
-            &:after {
-                padding-bottom: unit( 15px / @base-font-size-px, em );
-                width: 100%;
-            }
-        }
     }
 
-    //
-    // Expandable with a background color modifier
-    //
+    .o-expandable_content {
+      padding: 0 unit( 15px / @base-font-size-px, em );
 
-    &__background {
-        background: @expandable__background;
+      // The divider between _header and _content.
+      &:before {
+        content: '';
+        display: block;
+        border-top: 1px solid @expandable__border;
+        padding-top: unit( 15px / @base-font-size-px, em );
+      }
+
+      &:after {
+        padding-bottom: unit( 15px / @base-font-size-px, em );
+        width: 100%;
+      }
     }
+  }
 
-    //
-    // Expandable with a border modifier
-    //
+  //
+  // Expandable with a background color modifier
+  //
 
-    &__border {
-        border: 1px solid @expandable__border;
+  &__background {
+    background: @expandable__background;
+  }
+
+  //
+  // Expandable with a border modifier
+  //
+
+  &__border {
+    border: 1px solid @expandable__border;
+  }
+
+  //
+  // Expandable groups
+  //
+
+  &-group {
+    .o-expandable__padded {
+      border-bottom: 1px solid @expandable__border;
+
+      &:first-child {
+        border-top: 1px solid @expandable__border;
+      }
     }
+  }
 
-    //
-    // Expandable groups
-    //
-
-    &-group {
-        .o-expandable__padded {
-            border-bottom: 1px solid @expandable__border;
-
-            &:first-child {
-                border-top: 1px solid @expandable__border;
-            }
-        }
-    }
-
-    .respond-to-print( {
-        // Hide the interactive expandable cues when printing
+  .respond-to-print( {
+    // Hide the interactive expandable cues when printing
         &_target__expanded &_cue-close,
         &_target__collapsed &_cue-open {
             display: none;

--- a/packages/cfpb-forms/src/atoms/form-alert.less
+++ b/packages/cfpb-forms/src/atoms/form-alert.less
@@ -1,28 +1,28 @@
 .a-form-alert {
-    .cf-icon-svg {
-        color: @input-icon;
-        float: left;
-    }
+  .cf-icon-svg {
+    color: @input-icon;
+    float: left;
+  }
 
-    &_text {
-        display: block;
-        margin-left: unit( 20px / @base-font-size-px, em );
-    }
+  &_text {
+    display: block;
+    margin-left: unit( 20px / @base-font-size-px, em );
+  }
 
-    &__success .cf-icon-svg {
-        color: @input-icon__success;
-    }
+  &__success .cf-icon-svg {
+    color: @input-icon__success;
+  }
 
-    &__error .cf-icon-svg {
-        color: @input-icon__error;
-    }
+  &__error .cf-icon-svg {
+    color: @input-icon__error;
+  }
 
-    &__warning .cf-icon-svg {
-        color: @input-icon__warning;
-    }
+  &__warning .cf-icon-svg {
+    color: @input-icon__warning;
+  }
 }
 
 // TODO: Deprecate a-error-message
 .a-error-message {
-    .a-form-alert();
+  .a-form-alert();
 }

--- a/packages/cfpb-forms/src/atoms/label.less
+++ b/packages/cfpb-forms/src/atoms/label.less
@@ -1,34 +1,34 @@
 .a-label {
-    display: inline-block;
+  display: inline-block;
 
-    &_helper {
-        color: @label-helper;
-        font-size: unit( @size-v / @base-font-size-px, em );
+  &_helper {
+    color: @label-helper;
+    font-size: unit( @size-v / @base-font-size-px, em );
 
-        &__block {
-            display: block;
+    &__block {
+      display: block;
 
-            // Add a gap between the label helper and label.
-            margin-top: unit( 10px / @size-vi, em );
-        }
+      // Add a gap between the label helper and label.
+      margin-top: unit( 10px / @size-vi, em );
     }
+  }
 
-    &__heading {
-        .h4();
+  &__heading {
+    .h4();
 
-        display: block;
+    display: block;
 
-        // Overwrites heading-4 margin.
-        margin-bottom: unit( 10px / @font-size, em );
+    // Overwrites heading-4 margin.
+    margin-bottom: unit( 10px / @font-size, em );
 
-        .a-label_helper {
-            font-size: unit( @base-font-size-px / @font-size, em );
-            font-weight: normal;
+    .a-label_helper {
+      font-size: unit( @base-font-size-px / @font-size, em );
+      font-weight: normal;
 
-            &__block {
-                // Add a gap between the label helper and label.
-                margin-top: unit( 10px / @base-font-size-px, em );
-            }
-        }
+      &__block {
+        // Add a gap between the label helper and label.
+        margin-top: unit( 10px / @base-font-size-px, em );
+      }
     }
+  }
 }

--- a/packages/cfpb-forms/src/atoms/legend.less
+++ b/packages/cfpb-forms/src/atoms/legend.less
@@ -1,10 +1,10 @@
 .a-legend {
-    .h4();
+  .h4();
 
-    // Legends do not wrap in IE.
-    // Different styles are required to ensure wrapping in different versions.
-    box-sizing: border-box; // IE9-11 & Edge 12-13
-    display: table; // IE8-11
-    max-width: 100%; // Patch for IE9-11 & Edge 12-13
-    white-space: normal; // IE8-11
+  // Legends do not wrap in IE.
+  // Different styles are required to ensure wrapping in different versions.
+  box-sizing: border-box; // IE9-11 & Edge 12-13
+  display: table; // IE8-11
+  max-width: 100%; // Patch for IE9-11 & Edge 12-13
+  white-space: normal; // IE8-11
 }

--- a/packages/cfpb-forms/src/atoms/select.less
+++ b/packages/cfpb-forms/src/atoms/select.less
@@ -2,82 +2,82 @@
 @import (reference) '@cfpb/cfpb-icons/src/cfpb-icons.less';
 
 .a-select {
-    position: relative;
-    border: 1px solid @select-border;
+  position: relative;
+  border: 1px solid @select-border;
 
-    select {
-        width: 100%;
-        line-height: @base-line-height;
-        padding:
+  select {
+    width: 100%;
+    line-height: @base-line-height;
+    padding:
             unit( 7px / @base-font-size-px, em )
             unit( 6px / @base-font-size-px, em )
             unit( 6px / @base-font-size-px, em );
-        border: 0;
-        appearance: none;
-        background-color: @input-bg;
-        border-radius: 0;
-        color: @text;
+    border: 0;
+    appearance: none;
+    background-color: @input-bg;
+    border-radius: 0;
+    color: @text;
 
-        &:hover,
-        &.hover {
-            outline: 2px solid @input-border__hover;
-            outline-offset: 0;
-        }
-
-        &:active,
-        &:focus,
-        &.focus {
-            box-shadow: 0 0 0 2px @input-border__focused;
-            outline: 1px dotted @input-border__focused;
-
-            // The outline-offset property is not supported everywhere (e.g. IE)
-            // but it adds a nice touch in browsers where it is.
-            outline-offset: 3px;
-        }
+    &:hover,
+    &.hover {
+      outline: 2px solid @input-border__hover;
+      outline-offset: 0;
     }
 
-    select[disabled] {
-        color: @select-text__disabled;
-        background-color: @input-bg__disabled;
-        cursor: not-allowed;
+    &:active,
+    &:focus,
+    &.focus {
+      box-shadow: 0 0 0 2px @input-border__focused;
+      outline: 1px dotted @input-border__focused;
 
-        &:hover,
-        &.hover,
-        &:focus,
-        &.focus {
-            outline: none;
-        }
+      // The outline-offset property is not supported everywhere (e.g. IE)
+      // but it adds a nice touch in browsers where it is.
+      outline-offset: 3px;
     }
+  }
 
-    select[disabled] option,
-    select[disabled] option:disabled,
-    select option:disabled {
-        color: @select-text__disabled;
+  select[disabled] {
+    color: @select-text__disabled;
+    background-color: @input-bg__disabled;
+    cursor: not-allowed;
+
+    &:hover,
+    &.hover,
+    &:focus,
+    &.focus {
+      outline: none;
     }
+  }
 
-    &:after {
-        // Arrow box width must be odd size to properly center the bg image
-        width: unit( @select-height / @base-font-size-px, em );
-        box-sizing: border-box;
-        border-left: 1px solid @select-border;
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        background-color: @select-icon-bg;
-        .u-svg-inline-bg( 'down' );
+  select[disabled] option,
+  select[disabled] option:disabled,
+  select option:disabled {
+    color: @select-text__disabled;
+  }
 
-        background-size: auto @cf-icon-height;
-        background-repeat: no-repeat;
-        background-position: center center;
-        content: '';
-        pointer-events: none;
-    }
+  &:after {
+    // Arrow box width must be odd size to properly center the bg image
+    width: unit( @select-height / @base-font-size-px, em );
+    box-sizing: border-box;
+    border-left: 1px solid @select-border;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    background-color: @select-icon-bg;
+    .u-svg-inline-bg( 'down' );
 
-    // Correctly lighten the down arrow when a-select__disabled is present.
-    // Unfortunately, we can't target this to apply when only
-    // the select[disabled] is present and need the additional class.
-    &__disabled:after {
-        .u-svg-inline-bg( 'down', @gray );
-    }
+    background-size: auto @cf-icon-height;
+    background-repeat: no-repeat;
+    background-position: center center;
+    content: '';
+    pointer-events: none;
+  }
+
+  // Correctly lighten the down arrow when a-select__disabled is present.
+  // Unfortunately, we can't target this to apply when only
+  // the select[disabled] is present and need the additional class.
+  &__disabled:after {
+    .u-svg-inline-bg( 'down', @gray );
+  }
 }

--- a/packages/cfpb-forms/src/atoms/text-input.less
+++ b/packages/cfpb-forms/src/atoms/text-input.less
@@ -1,86 +1,86 @@
 .a-text-input {
-    // Reset the browser's default styling.
-    appearance: none;
-    display: inline-block;
-    padding: unit( 7px / @base-font-size-px, em );
-    border: 1px solid @input-border;
-    background: @input-bg;
-    color: @input-text;
+  // Reset the browser's default styling.
+  appearance: none;
+  display: inline-block;
+  padding: unit( 7px / @base-font-size-px, em );
+  border: 1px solid @input-border;
+  background: @input-bg;
+  color: @input-text;
 
+  &:hover,
+  &.hover {
+    border-color: @input-border__hover;
+    outline: 1px solid @input-border__hover;
+  }
+
+  &:focus,
+  &.focus {
+    border-color: @input-border__focused;
+    box-shadow: 0 0 0 1px @input-border__focused;
+    outline: 1px dotted @input-border__focused;
+
+    // The outline-offset property is not supported everywhere (e.g. IE)
+    // but it adds a nice touch in browsers where it is.
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+
+    &,
     &:hover,
-    &.hover {
-        border-color: @input-border__hover;
-        outline: 1px solid @input-border__hover;
-    }
-
+    &.hover,
     &:focus,
     &.focus {
-        border-color: @input-border__focused;
-        box-shadow: 0 0 0 1px @input-border__focused;
-        outline: 1px dotted @input-border__focused;
+      color: @input-text__disabled;
+      background-color: @input-bg__disabled;
+      cursor: not-allowed;
 
-        // The outline-offset property is not supported everywhere (e.g. IE)
-        // but it adds a nice touch in browsers where it is.
-        outline-offset: 2px;
+      // Cancel the hover and focus states.
+      border-color: @input-border;
+      outline: none;
     }
+  }
 
-    &:disabled {
-
-        &,
-        &:hover,
-        &.hover,
-        &:focus,
-        &.focus {
-            color: @input-text__disabled;
-            background-color: @input-bg__disabled;
-            cursor: not-allowed;
-
-            // Cancel the hover and focus states.
-            border-color: @input-border;
-            outline: none;
-        }
+  &__error {
+    border-color: @input-border__error;
+    outline: 1px solid @input-border__error;
+    &:focus,
+    &.focus {
+      border-color: @input-border__error;
+      box-shadow: 0 0 0 1px @input-border__error;
+      outline: 1px dotted @input-border__error;
     }
+  }
 
-    &__error {
-        border-color: @input-border__error;
-        outline: 1px solid @input-border__error;
-        &:focus,
-        &.focus {
-            border-color: @input-border__error;
-            box-shadow: 0 0 0 1px @input-border__error;
-            outline: 1px dotted @input-border__error;
-        }
+  &__warning {
+    border-color: @input-border__warning;
+    outline: 1px solid @input-border__warning;
+    &:focus,
+    &.focus {
+      border-color: @input-border__warning;
+      box-shadow: 0 0 0 1px @input-border__warning;
+      outline: 1px dotted @input-border__warning;
     }
+  }
 
-    &__warning {
-        border-color: @input-border__warning;
-        outline: 1px solid @input-border__warning;
-        &:focus,
-        &.focus {
-            border-color: @input-border__warning;
-            box-shadow: 0 0 0 1px @input-border__warning;
-            outline: 1px dotted @input-border__warning;
-        }
+  &__success {
+    border-color: @input-border__success;
+    outline: 1px solid @input-border__success;
+    &:focus,
+    &.focus {
+      border-color: @input-border__success;
+      box-shadow: 0 0 0 1px @input-border__success;
+      outline: 1px dotted @input-border__success;
     }
-
-    &__success {
-        border-color: @input-border__success;
-        outline: 1px solid @input-border__success;
-        &:focus,
-        &.focus {
-            border-color: @input-border__success;
-            box-shadow: 0 0 0 1px @input-border__success;
-            outline: 1px dotted @input-border__success;
-        }
-    }
+  }
 }
 
 // Overrides extra left padding.
 // http://stackoverflow.com/questions/11127891/how-can-i-get-rid-of-horizontal-padding-or-indent-in-html5-search-inputs-in-webk
 ::-webkit-search-decoration {
-    appearance: none;
+  appearance: none;
 }
 
 ::placeholder {
-    color: @input-text__placeholder;
+  color: @input-text__placeholder;
 }

--- a/packages/cfpb-forms/src/molecules/btn-inside-input.less
+++ b/packages/cfpb-forms/src/molecules/btn-inside-input.less
@@ -2,30 +2,30 @@
 // the text as it intersects the button
 
 .m-btn-inside-input {
-    position: relative;
+  position: relative;
 
-    .a-text-input {
-        box-sizing: border-box;
-        // Magic number padding to give the icon clear space
-        padding-right: unit( ( @btn-h-padding * 2 + 11px ) / @btn-font-size, em );
-        width: 100%;
+  .a-text-input {
+    box-sizing: border-box;
+    // Magic number padding to give the icon clear space
+    padding-right: unit( ( @btn-h-padding * 2 + 11px ) / @btn-font-size, em );
+    width: 100%;
+  }
+
+  .a-btn {
+    .u-link__no-border();
+
+    position: absolute;
+    // Set the right and top distances to match typical button padding.
+    right: unit( @btn-h-padding / @btn-font-size, em );
+    top: unit( @btn-v-padding / @btn-font-size, em );
+    color: @gray-80;
+
+    &:hover {
+      color: @black;
     }
 
-    .a-btn {
-        .u-link__no-border();
-
-        position: absolute;
-        // Set the right and top distances to match typical button padding.
-        right: unit( @btn-h-padding / @btn-font-size, em );
-        top: unit( @btn-v-padding / @btn-font-size, em );
-        color: @gray-80;
-
-        &:hover {
-            color: @black;
-        }
-
-        .no-js & {
-            display: none;
-        }
+    .no-js & {
+      display: none;
     }
+  }
 }

--- a/packages/cfpb-forms/src/molecules/form-fields.less
+++ b/packages/cfpb-forms/src/molecules/form-fields.less
@@ -1,233 +1,233 @@
 .m-form-field {
-    .a-text-input__full {
-        box-sizing: border-box;
-        width: 100%;
+  .a-text-input__full {
+    box-sizing: border-box;
+    width: 100%;
+  }
+
+  .a-label + .a-text-input {
+    margin-top: unit( 5px / @base-font-size-px, em );
+  }
+
+  &__checkbox,
+  &__radio {
+    .a-label {
+      // We need to turn off autoprefixing for the inline-grid because
+      // IE does not handle an inline-grid like other browsers,
+      // leading to an extremely narrow column of text for the label
+      // and the checkbox or radio widget covering the first part of it.
+      // The Autoprefixer control comment below ensures that the following
+      // property is only picked up by browsers with standard support.
+      // The exclamation mark is necessary for Less to preserve the
+      // comment so that Autoprefixer will see it.
+
+      /*! autoprefixer: ignore next */
+      display: inline-grid;
+      // 30px is width of checkbox/radio button plus the needed padding.
+      grid-template-columns: unit( 30px / @base-font-size-px, em ) auto;
+      vertical-align: top;
+      cursor: pointer;
+      // Wrap long words in narrow form fields to prevent clipping
+      overflow-wrap: anywhere;
+
+      &:before {
+        display: inline-block;
+        grid-row-start: 1;
+        grid-row-end: 3;
+        border: 1px solid @form-field-input-border;
+        height: unit( 18px / @base-font-size-px, em );
+        width: unit( 18px / @base-font-size-px, em );
+        margin-right: 10px;
+        background-color: @input-bg;
+        content: '';
+        vertical-align: top;
+
+        // Offset so that the checkbox/radio fits within focused area.
+        position: relative;
+        top: 1px;
+        left: 1px;
+      }
+
+      &:hover:before,
+      &.hover:before {
+        border-color: @input-border__hover;
+      }
     }
 
-    .a-label + .a-text-input {
-        margin-top: unit( 5px / @base-font-size-px, em );
+    // Ensure the helper text appears on its own line below the label.
+    .a-label_helper {
+      display: block;
     }
 
-    &__checkbox,
-    &__radio {
-        .a-label {
-            // We need to turn off autoprefixing for the inline-grid because
-            // IE does not handle an inline-grid like other browsers,
-            // leading to an extremely narrow column of text for the label
-            // and the checkbox or radio widget covering the first part of it.
-            // The Autoprefixer control comment below ensures that the following
-            // property is only picked up by browsers with standard support.
-            // The exclamation mark is necessary for Less to preserve the
-            // comment so that Autoprefixer will see it.
+    .a-checkbox,
+    .a-radio {
+      .u-visually-hidden();
 
-            /*! autoprefixer: ignore next */
-            display: inline-grid;
-            // 30px is width of checkbox/radio button plus the needed padding.
-            grid-template-columns: unit( 30px / @base-font-size-px, em ) auto;
-            vertical-align: top;
-            cursor: pointer;
-            // Wrap long words in narrow form fields to prevent clipping
-            overflow-wrap: anywhere;
+      &:focus + .a-label,
+      &.focus + .a-label {
+        outline: 1px dotted @input-border__focused;
+        // The outline-offset property is not supported in IE.
+        outline-offset: 1px;
+      }
 
-            &:before {
-                display: inline-block;
-                grid-row-start: 1;
-                grid-row-end: 3;
-                border: 1px solid @form-field-input-border;
-                height: unit( 18px / @base-font-size-px, em );
-                width: unit( 18px / @base-font-size-px, em );
-                margin-right: 10px;
-                background-color: @input-bg;
-                content: '';
-                vertical-align: top;
+      &:disabled {
 
-                // Offset so that the checkbox/radio fits within focused area.
-                position: relative;
-                top: 1px;
-                left: 1px;
-            }
-
-            &:hover:before,
-            &.hover:before {
-                border-color: @input-border__hover;
-            }
+        &:checked + .a-label:before,
+        &:focus + .a-label:before,
+        &.focus + .a-label:before,
+        &:hover + .a-label:before,
+        &.hover + .a-label:before {
+          border-color: @input-border;
+          outline: none;
+          box-shadow: none; // Applies only to radio buttons.
         }
 
-        // Ensure the helper text appears on its own line below the label.
-        .a-label_helper {
-            display: block;
+        & + .a-label {
+          cursor: not-allowed;
+          color: @input-text__disabled;
+
+          &:before {
+            background: @input-bg__disabled;
+            border-color: @form-field-input-border__disabled;
+          }
         }
-
-        .a-checkbox,
-        .a-radio {
-            .u-visually-hidden();
-
-            &:focus + .a-label,
-            &.focus + .a-label {
-                outline: 1px dotted @input-border__focused;
-                // The outline-offset property is not supported in IE.
-                outline-offset: 1px;
-            }
-
-            &:disabled {
-
-                &:checked + .a-label:before,
-                &:focus + .a-label:before,
-                &.focus + .a-label:before,
-                &:hover + .a-label:before,
-                &.hover + .a-label:before {
-                    border-color: @input-border;
-                    outline: none;
-                    box-shadow: none; // Applies only to radio buttons.
-                }
-
-                & + .a-label {
-                    cursor: not-allowed;
-                    color: @input-text__disabled;
-
-                    &:before {
-                        background: @input-bg__disabled;
-                        border-color: @form-field-input-border__disabled;
-                    }
-                }
-            }
-        }
+      }
     }
+  }
 
-    &__checkbox {
-        .a-checkbox {
-            &:focus + .a-label:before,
-            &.focus + .a-label:before {
-                border-color: @input-border__focused;
-                box-shadow: 0 0 0 1px @input-border__focused;
-            }
+  &__checkbox {
+    .a-checkbox {
+      &:focus + .a-label:before,
+      &.focus + .a-label:before {
+        border-color: @input-border__focused;
+        box-shadow: 0 0 0 1px @input-border__focused;
+      }
 
-            &:hover + .a-label:before,
-            &.hover + .a-label:before {
-                border-color: @input-border__hover;
-                box-shadow: 0 0 0 1px @input-border__hover;
-            }
+      &:hover + .a-label:before,
+      &.hover + .a-label:before {
+        border-color: @input-border__hover;
+        box-shadow: 0 0 0 1px @input-border__hover;
+      }
 
-            &:checked + .a-label:before {
-                .u-svg-inline-bg( 'approved' );
+      &:checked + .a-label:before {
+        .u-svg-inline-bg( 'approved' );
 
-                background-size: auto @cf-icon-height;
-                background-repeat: no-repeat;
-                background-position: center 0;
-            }
-            &:disabled:checked + .a-label:before {
-                // rgb values are CFPB gray-40.
-                // For some reason SVG isn't accepting hex values for the fill.
-                .u-svg-inline-bg( 'approved', @gray );
-            }
-        }
+        background-size: auto @cf-icon-height;
+        background-repeat: no-repeat;
+        background-position: center 0;
+      }
+      &:disabled:checked + .a-label:before {
+        // rgb values are CFPB gray-40.
+        // For some reason SVG isn't accepting hex values for the fill.
+        .u-svg-inline-bg( 'approved', @gray );
+      }
     }
+  }
 
-    &__radio {
-        .a-label {
-            &:before {
-                border-radius: 50%;
+  &__radio {
+    .a-label {
+      &:before {
+        border-radius: 50%;
 
-                /* The rotate is needed to fix a bug in Firefox where radio
+        /* The rotate is needed to fix a bug in Firefox where radio
                    button was not centered. */
-                transform: rotate( 0deg );
-            }
-        }
+        transform: rotate( 0deg );
+      }
+    }
 
-        .a-radio {
-            &:focus + .a-label:before,
-            &.focus + .a-label:before {
-                outline: none;
-                border-color: @input-border__focused;
-                box-shadow: 0 0 0 1px @input-border__focused;
-            }
+    .a-radio {
+      &:focus + .a-label:before,
+      &.focus + .a-label:before {
+        outline: none;
+        border-color: @input-border__focused;
+        box-shadow: 0 0 0 1px @input-border__focused;
+      }
 
-            &:hover + .a-label:before,
-            &.hover + .a-label:before {
-                outline: none;
-                border-color: @input-border__hover;
-                box-shadow: 0 0 0 1px @input-border__hover;
-            }
+      &:hover + .a-label:before,
+      &.hover + .a-label:before {
+        outline: none;
+        border-color: @input-border__hover;
+        box-shadow: 0 0 0 1px @input-border__hover;
+      }
 
-            &:checked + .a-label:before {
-                background-color: @input-bg__selected;
-                box-shadow: inset 0 0 0 2px @form-field-inset;
-            }
+      &:checked + .a-label:before {
+        background-color: @input-bg__selected;
+        box-shadow: inset 0 0 0 2px @form-field-inset;
+      }
 
-            &:checked:disabled + .a-label:before {
-                background-color: @input-bg__disabled-selected;
-                box-shadow: inset 0 0 0 2px @input-bg__disabled;
-            }
+      &:checked:disabled + .a-label:before {
+        background-color: @input-bg__disabled-selected;
+        box-shadow: inset 0 0 0 2px @input-bg__disabled;
+      }
 
-            &:focus:checked + .a-label:before,
-            &.focus:checked + .a-label:before {
-                border-color: @input-border__focused;
-                box-shadow: 0 0 0 1px @input-border__focused,
+      &:focus:checked + .a-label:before,
+      &.focus:checked + .a-label:before {
+        border-color: @input-border__focused;
+        box-shadow: 0 0 0 1px @input-border__focused,
                             inset 0 0 0 2px @form-field-inset;
-            }
+      }
 
-            &:hover:checked + .a-label:before,
-            &.hover:checked + .a-label:before {
-                border-color: @input-border__hover;
-                box-shadow: 0 0 0 1px @input-border__hover,
+      &:hover:checked + .a-label:before,
+      &.hover:checked + .a-label:before {
+        border-color: @input-border__hover;
+        box-shadow: 0 0 0 1px @input-border__hover,
                             inset 0 0 0 2px @form-field-inset;
-            }
-        }
+      }
+    }
+  }
+
+  &__lg-target {
+    display: block;
+
+    .a-label {
+      box-sizing: border-box;
+      width: 100%;
+      padding: 15px;
+      background-color: @form-field-input-lg-target-bg;
     }
 
-    &__lg-target {
-        display: block;
+    .a-checkbox,
+    .a-radio {
 
-        .a-label {
-            box-sizing: border-box;
-            width: 100%;
-            padding: 15px;
-            background-color: @form-field-input-lg-target-bg;
+      &:checked + .a-label {
+        background-color: @form-field-input-lg-target-bg__selected;
+        box-shadow: inset 0 0 0 1px @form-field-input-lg-target-border;
+      }
+
+      &:hover + .a-label,
+      &.hover + .a-label,
+      &:focus + .a-label,
+      &.focus + .a-label {
+        box-shadow: inset 0 0 0 2px @form-field-input-lg-target-border;
+      }
+
+      &:focus + .a-label,
+      &.focus + .a-label,
+      &:checked + .a-label {
+        // The outline-offset property is not supported in IE.
+        outline-offset: 1px;
+      }
+
+      &:disabled + .a-label,
+      &:checked:disabled + .a-label,
+      &:hover:disabled + .a-label {
+        color: @input-text__disabled;
+        box-shadow: none;
+        background-color: @form-field-input-lg-target-bg__disabled;
+      }
+
+      &:checked:disabled + .a-label {
+        &, &:before {
+          border: 1px solid @form-field-input-border__disabled;
         }
-
-        .a-checkbox,
-        .a-radio {
-
-            &:checked + .a-label {
-                background-color: @form-field-input-lg-target-bg__selected;
-                box-shadow: inset 0 0 0 1px @form-field-input-lg-target-border;
-            }
-
-            &:hover + .a-label,
-            &.hover + .a-label,
-            &:focus + .a-label,
-            &.focus + .a-label {
-                box-shadow: inset 0 0 0 2px @form-field-input-lg-target-border;
-            }
-
-            &:focus + .a-label,
-            &.focus + .a-label,
-            &:checked + .a-label {
-                // The outline-offset property is not supported in IE.
-                outline-offset: 1px;
-            }
-
-            &:disabled + .a-label,
-            &:checked:disabled + .a-label,
-            &:hover:disabled + .a-label {
-                color: @input-text__disabled;
-                box-shadow: none;
-                background-color: @form-field-input-lg-target-bg__disabled;
-            }
-
-            &:checked:disabled + .a-label {
-                &, &:before {
-                    border: 1px solid @form-field-input-border__disabled;
-                }
-            }
-        }
+      }
     }
+  }
 
-    // TODO: The same top margin is applied to field-level errors for input-
-    // with-button forms in organisms/form.less; we should find a way to merge
-    // these to be less repetitive.
-    .a-form-alert,
-    .a-error-message {
-        margin-top: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
-    }
+  // TODO: The same top margin is applied to field-level errors for input-
+  // with-button forms in organisms/form.less; we should find a way to merge
+  // these to be less repetitive.
+  .a-form-alert,
+  .a-error-message {
+    margin-top: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
+  }
 }

--- a/packages/cfpb-forms/src/organisms/form.less
+++ b/packages/cfpb-forms/src/organisms/form.less
@@ -1,72 +1,72 @@
 .o-form {
-    &_group {
-        margin-bottom: unit( 30px / @base-font-size-px, em );
+  &_group {
+    margin-bottom: unit( 30px / @base-font-size-px, em );
+  }
+
+  &_fieldset {
+    // Overwrite Normalize.
+    border: none;
+    margin: 0;
+    padding: 0;
+
+    .m-form-field + .m-form-field {
+      margin-top: unit( 10px / @base-font-size-px, em );
     }
+  }
 
-    &_fieldset {
-        // Overwrite Normalize.
-        border: none;
-        margin: 0;
-        padding: 0;
+  //
+  // Input with button
+  //
 
-        .m-form-field + .m-form-field {
-            margin-top: unit( 10px / @base-font-size-px, em );
-        }
-    }
-
-    //
-    // Input with button
-    //
-
-    &__input-w-btn {
-        .respond-to-min( 480px, {
-            .grid_nested-col-group();
+  &__input-w-btn {
+    .respond-to-min( 480px, {
+      .grid_nested-col-group();
         } );
 
-        &_input-container {
-            margin-bottom: unit( 15px / @base-font-size-px, em );
+    &_input-container {
+      margin-bottom: unit( 15px / @base-font-size-px, em );
 
-            .respond-to-min( 480px, {
-                .grid_column( 9 );
-
-                border-right-width: 0;
-            } );
-
-            .respond-to-min( 960px, {
-                .grid_column( 10 );
+      .respond-to-min( 480px, {
+        .grid_column( 9 );
 
                 border-right-width: 0;
             } );
 
-            .a-text-input {
-                box-sizing: border-box;
-                width: 100%;
-            }
+      .respond-to-min( 960px, {
+        .grid_column( 10 );
 
-            // TODO: The same top margin is applied to field-level errors for
-            // regular forms in molecules/form-fields.less; we should find a way
-            // to merge these to be less repetitive.
-            .a-form-alert,
-            .a-error-message {
-                margin-top: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
-            }
-        }
-
-        &_btn-container {
-            margin-bottom: unit( 15px / @base-font-size-px, em );
-
-            .respond-to-min( 480px, {
-                .grid_column( 3 );
+                border-right-width: 0;
             } );
 
-            .respond-to-min( 960px, {
-                .grid_column( 2 );
-            } );
+      .a-text-input {
+        box-sizing: border-box;
+        width: 100%;
+      }
 
-            .a-btn {
-                box-sizing: border-box;
-                width: 100%;
-            }
-        }
+      // TODO: The same top margin is applied to field-level errors for
+      // regular forms in molecules/form-fields.less; we should find a way
+      // to merge these to be less repetitive.
+      .a-form-alert,
+      .a-error-message {
+        margin-top: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
+      }
     }
+
+    &_btn-container {
+      margin-bottom: unit( 15px / @base-font-size-px, em );
+
+      .respond-to-min( 480px, {
+        .grid_column( 3 );
+            } );
+
+      .respond-to-min( 960px, {
+        .grid_column( 2 );
+            } );
+
+      .a-btn {
+        box-sizing: border-box;
+        width: 100%;
+      }
+    }
+  }
 }

--- a/packages/cfpb-forms/src/organisms/multiselect.less
+++ b/packages/cfpb-forms/src/organisms/multiselect.less
@@ -1,211 +1,211 @@
 // Initial and no-js state.
 select.o-multiselect {
-    display: block;
-    box-sizing: border-box;
-    width: 100%;
-    padding: unit( 7px / @base-font-size-px, em );
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  padding: unit( 7px / @base-font-size-px, em );
 
-    // Fixed height breaks the bottom border
-    // mid-character to indicate there's more content.
-    height: 5.5em;
-    padding-top: unit( 4px / @base-font-size-px, em );
-    padding-bottom: unit( 4px / @base-font-size-px, em );
-    border: 1px solid @select-border;
+  // Fixed height breaks the bottom border
+  // mid-character to indicate there's more content.
+  height: 5.5em;
+  padding-top: unit( 4px / @base-font-size-px, em );
+  padding-bottom: unit( 4px / @base-font-size-px, em );
+  border: 1px solid @select-border;
 
-    option {
-        padding:
+  option {
+    padding:
             unit( 2px / @base-font-size-px, em )
             unit( 6px / @base-font-size-px, em );
-    }
+  }
 }
 
 .o-multiselect {
+  position: relative;
+
+  &_header {
     position: relative;
 
-    &_header {
-        position: relative;
+    &:after {
+      // Arrow box width must be odd size to properly center the bg image
+      width: unit( @select-height / @base-font-size-px, em );
+      box-sizing: border-box;
+      border-left: 1px solid @select-border;
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      background-color: @select-icon-bg;
+      .u-svg-inline-bg( 'down' );
+
+      background-size: auto @cf-icon-height;
+      background-repeat: no-repeat;
+      background-position: center center;
+      border: 1px solid @input-border;
+      content: '';
+      pointer-events: none;
+    }
+  }
+
+  // Reverse arrow when search drop-down is open.
+  &.u-active {
+    .o-multiselect_header:after {
+      .u-svg-inline-bg( 'up' );
+    }
+  }
+
+  &_search[type="text"] {
+    display: block;
+
+    box-sizing: border-box;
+    width: 100%;
+  }
+
+  &_fieldset {
+    // Resets
+    border-color: @input-border;
+    border-top: none;
+    margin: 0;
+    padding: 0;
+
+    // Styles
+    box-sizing: border-box;
+    overflow-x: hidden;
+    overflow-y: scroll;
+    position: absolute;
+    z-index: 10;
+
+    max-height: 0;
+    margin-top: -1px;
+    width: 100%;
+
+    transition: max-height 0.25s ease-out;
+
+    // Chrome doesn't properly handle fieldset display properties
+    // See https://bugs.chromium.org/p/chromium/issues/detail?id=375693
+    // and https://codepen.io/contolini/pen/rNLXrvP
+    // and https://codepen.io/pembe180/pen/wCsIk
+    display: -webkit-box;
+  }
+
+  &.u-active {
+    .o-multiselect_fieldset {
+      margin-top: 0;
+      max-height: 140px;
+
+      border-color: @pacific;
+      border-width: 2px;
+      border-top: 0;
+    }
+  }
+
+  &_options {
+    background-color: @white;
+    padding: 0;
+
+    li {
+      margin: 0;
+    }
+
+    li:first-child {
+      .a-label {
+        padding-top: unit( 10px / @base-font-size-px, em );
+      }
+    }
+
+    &.u-filtered li:not( .u-filter-match ) {
+      display: none;
+    }
+
+    &.u-no-results,
+    &.u-max-selections {
+      li {
+        display: none;
+      }
+
+      &:after {
+        display: list-item;
+      }
+    }
+
+    &.u-no-results:after {
+      content: 'No results found';
+    }
+
+    &.u-max-selections {
+      padding: unit( 10px / @base-font-size-px, em );
+      pointer-events: none;
+
+      &:after {
+        content: 'Reached maximum of five selections';
+      }
+    }
+
+    .a-label {
+      box-sizing: border-box;
+      padding-top: unit( 5px / @base-font-size-px, em );
+      padding-right: 0;
+      padding-bottom: unit( 5px / @base-font-size-px, em );
+      padding-left: unit( 10px / @base-font-size-px, em );
+      width: 100%;
+    }
+  }
+
+  &_choices {
+    padding-left: 0;
+    // The following is required to make side-by-side LI
+    // have a space between them.
+    margin-right: unit( -10px / @base-font-size-px, em );
+    margin-bottom: 0;
+
+    li {
+      display: inline-block;
+
+      // The following is required to make side-by-side LI
+      // have a space between them.
+      margin-right: unit( 10px / @base-font-size-px, em );
+    }
+
+    li:last-child {
+      margin-bottom: unit( 10px / @base-font-size-px, em );
+    }
+
+    button {
+      border: none;
+      background: none;
+      padding: 0;
+
+      &:focus {
+        outline: 1px dotted @pacific;
+        outline-offset: 1px;
+      }
+    }
+
+    label {
+      display: inline-block;
+      padding: 2px 5px;
+      padding-right: unit( 25px / @size-v, em );
+
+      background-color: @navy-80;
+      border-radius: unit( 4px / @size-v, em );
+      color: @white;
+      cursor: pointer;
+      font-size: unit( 14px / @base-font-size-px, em );
+      position: relative;
+
+      &:hover {
+        background-color: @navy;
 
         &:after {
-            // Arrow box width must be odd size to properly center the bg image
-            width: unit( @select-height / @base-font-size-px, em );
-            box-sizing: border-box;
-            border-left: 1px solid @select-border;
-            position: absolute;
-            top: 0;
-            right: 0;
-            bottom: 0;
-            background-color: @select-icon-bg;
-            .u-svg-inline-bg( 'down' );
-
-            background-size: auto @cf-icon-height;
-            background-repeat: no-repeat;
-            background-position: center center;
-            border: 1px solid @input-border;
-            content: '';
-            pointer-events: none;
+          color: @white;
         }
-    }
+      }
 
-    // Reverse arrow when search drop-down is open.
-    &.u-active {
-        .o-multiselect_header:after {
-            .u-svg-inline-bg( 'up' );
-        }
-    }
-
-    &_search[type="text"] {
-        display: block;
-
-        box-sizing: border-box;
-        width: 100%;
-    }
-
-    &_fieldset {
-        // Resets
-        border-color: @input-border;
-        border-top: none;
-        margin: 0;
-        padding: 0;
-
-        // Styles
-        box-sizing: border-box;
-        overflow-x: hidden;
-        overflow-y: scroll;
+      .cf-icon-svg {
         position: absolute;
-        z-index: 10;
-
-        max-height: 0;
-        margin-top: -1px;
-        width: 100%;
-
-        transition: max-height 0.25s ease-out;
-
-        // Chrome doesn't properly handle fieldset display properties
-        // See https://bugs.chromium.org/p/chromium/issues/detail?id=375693
-        // and https://codepen.io/contolini/pen/rNLXrvP
-        // and https://codepen.io/pembe180/pen/wCsIk
-        display: -webkit-box;
+        top: 2px;
+        right: 5px;
+        fill: @navy-20;
+      }
     }
-
-    &.u-active {
-        .o-multiselect_fieldset {
-            margin-top: 0;
-            max-height: 140px;
-
-            border-color: @pacific;
-            border-width: 2px;
-            border-top: 0;
-        }
-    }
-
-    &_options {
-        background-color: @white;
-        padding: 0;
-
-        li {
-            margin: 0;
-        }
-
-        li:first-child {
-            .a-label {
-                padding-top: unit( 10px / @base-font-size-px, em );
-            }
-        }
-
-        &.u-filtered li:not( .u-filter-match ) {
-            display: none;
-        }
-
-        &.u-no-results,
-        &.u-max-selections {
-            li {
-                display: none;
-            }
-
-            &:after {
-                display: list-item;
-            }
-        }
-
-        &.u-no-results:after {
-            content: 'No results found';
-        }
-
-        &.u-max-selections {
-            padding: unit( 10px / @base-font-size-px, em );
-            pointer-events: none;
-
-            &:after {
-                content: 'Reached maximum of five selections';
-            }
-        }
-
-        .a-label {
-            box-sizing: border-box;
-            padding-top: unit( 5px / @base-font-size-px, em );
-            padding-right: 0;
-            padding-bottom: unit( 5px / @base-font-size-px, em );
-            padding-left: unit( 10px / @base-font-size-px, em );
-            width: 100%;
-        }
-    }
-
-    &_choices {
-        padding-left: 0;
-        // The following is required to make side-by-side LI
-        // have a space between them.
-        margin-right: unit( -10px / @base-font-size-px, em );
-        margin-bottom: 0;
-
-        li {
-            display: inline-block;
-
-            // The following is required to make side-by-side LI
-            // have a space between them.
-            margin-right: unit( 10px / @base-font-size-px, em );
-        }
-
-        li:last-child {
-            margin-bottom: unit( 10px / @base-font-size-px, em );
-        }
-
-        button {
-            border: none;
-            background: none;
-            padding: 0;
-
-            &:focus {
-                outline: 1px dotted @pacific;
-                outline-offset: 1px;
-            }
-        }
-
-        label {
-            display: inline-block;
-            padding: 2px 5px;
-            padding-right: unit( 25px / @size-v, em );
-
-            background-color: @navy-80;
-            border-radius: unit( 4px / @size-v, em );
-            color: @white;
-            cursor: pointer;
-            font-size: unit( 14px / @base-font-size-px, em );
-            position: relative;
-
-            &:hover {
-                background-color: @navy;
-
-                &:after {
-                    color: @white;
-                }
-            }
-
-            .cf-icon-svg {
-                position: absolute;
-                top: 2px;
-                right: 5px;
-                fill: @navy-20;
-            }
-        }
-    }
+  }
 }

--- a/packages/cfpb-grid/src/cfpb-grid.less
+++ b/packages/cfpb-grid/src/cfpb-grid.less
@@ -21,11 +21,11 @@
 //
 
 .grid_wrapper( @grid_wrapper-width: @grid_wrapper-width ) {
-    max-width: ( @grid_wrapper-width - @grid_gutter-width );
-    padding-right: ( @grid_gutter-width / 2 );
-    padding-left: ( @grid_gutter-width / 2 );
-    margin: 0 auto;
-    clear: both;
+  max-width: ( @grid_wrapper-width - @grid_gutter-width );
+  padding-right: ( @grid_gutter-width / 2 );
+  padding-left: ( @grid_gutter-width / 2 );
+  margin: 0 auto;
+  clear: both;
 }
 
 //
@@ -33,96 +33,96 @@
 //
 
 .grid_column( @columns: 1; @total: @grid_total-columns; @prefix: 0; @suffix: 0 ) {
-    display: inline-block;
-    box-sizing: border-box;
+  display: inline-block;
+  box-sizing: border-box;
 
-    // To calculate the percentage width of the base element, we take the number of
-    // columns it'll span and divide by the total number of columns. As columns are
-    // specified as inline-block elements, standard columns require no further math.
-    //
-    //                      num cols used
-    //  column width in % = -------------
-    //                       total cols
+  // To calculate the percentage width of the base element, we take the number of
+  // columns it'll span and divide by the total number of columns. As columns are
+  // specified as inline-block elements, standard columns require no further math.
+  //
+  //                      num cols used
+  //  column width in % = -------------
+  //                       total cols
 
-    @width: percentage( @columns / @total );
+  @width: percentage( @columns / @total );
 
-    border: solid transparent;
-    border-width: 0 ( @grid_gutter-width / 2 );
+  border: solid transparent;
+  border-width: 0 ( @grid_gutter-width / 2 );
 
-    // Remove whitespace caused by setting display to inline-block
-    margin-right: -0.25em;
-    vertical-align: top;
+  // Remove whitespace caused by setting display to inline-block
+  margin-right: -0.25em;
+  vertical-align: top;
 
-    // Modifying standard width and padding for prefixed/suffixed columns, if necessary:
-    // LESS will now run through four possible child mixins, only one of which will
-    // actually be activated, depending on which one's guard conditions are met.
-    // At some point, consider how to modularize the prefix-suffix functionality and
-    // keep it optional.
+  // Modifying standard width and padding for prefixed/suffixed columns, if necessary:
+  // LESS will now run through four possible child mixins, only one of which will
+  // actually be activated, depending on which one's guard conditions are met.
+  // At some point, consider how to modularize the prefix-suffix functionality and
+  // keep it optional.
 
-    .nonPrefixSuffix( @prefix, @suffix );
-    .prefix( @prefix, @suffix );
-    .suffix( @suffix, @prefix );
-    .prefixSuffix( @prefix, @suffix );
+  .nonPrefixSuffix( @prefix, @suffix );
+  .prefix( @prefix, @suffix );
+  .suffix( @suffix, @prefix );
+  .prefixSuffix( @prefix, @suffix );
 
-    // Child mixins
+  // Child mixins
 
-    // Run this when neither prefix nor suffix are specified
-    .nonPrefixSuffix( @prefix: 0; @suffix: 0 ) when ( @prefix = 0 ) and ( @suffix = 0 ) {
-        width: @width;
-    }
+  // Run this when neither prefix nor suffix are specified
+  .nonPrefixSuffix( @prefix: 0; @suffix: 0 ) when ( @prefix = 0 ) and ( @suffix = 0 ) {
+    width: @width;
+  }
 
-    // Run this when only prefix is specified
-    .prefix( @prefix: 0; @suffix: 0 ) when ( @prefix > 0 ) and ( @suffix = 0 ) {
-        @offset: percentage( @prefix / @total );
+  // Run this when only prefix is specified
+  .prefix( @prefix: 0; @suffix: 0 ) when ( @prefix > 0 ) and ( @suffix = 0 ) {
+    @offset: percentage( @prefix / @total );
 
-        width: @width + @offset;
-        padding-left: @offset;
-    }
+    width: @width + @offset;
+    padding-left: @offset;
+  }
 
-    // Run this when only suffix is specified
-    .suffix( @suffix: 0; @prefix: 0 ) when ( @suffix > 0 ) and ( @prefix = 0 ) {
-        @offset: percentage( @suffix / @total );
+  // Run this when only suffix is specified
+  .suffix( @suffix: 0; @prefix: 0 ) when ( @suffix > 0 ) and ( @prefix = 0 ) {
+    @offset: percentage( @suffix / @total );
 
-        width: @width + @offset;
-        padding-right: @offset;
-    }
+    width: @width + @offset;
+    padding-right: @offset;
+  }
 
-    // Run this when both prefix and suffix are specified
-    .prefixSuffix( @prefix: 0; @suffix: 0 ) when ( @prefix > 0 ) and ( @suffix > 0 ) {
-        @left: percentage( @prefix / @total );
-        @right: percentage( @suffix / @total );
+  // Run this when both prefix and suffix are specified
+  .prefixSuffix( @prefix: 0; @suffix: 0 ) when ( @prefix > 0 ) and ( @suffix > 0 ) {
+    @left: percentage( @prefix / @total );
+    @right: percentage( @suffix / @total );
 
-        width: @width + @left + @right;
-        padding-right: @right;
-        padding-left: @left;
-    }
+    width: @width + @left + @right;
+    padding-right: @right;
+    padding-left: @left;
+  }
 }
 
 .grid_column( @columns; @total: @grid_total-columns; @prefix: 0; @suffix: 0; ) when ( @grid_debug ) {
-    border-left-color: #ffb149;
-    border-left-color: fade( #ff9e1b, 25% );
-    border-right-color: #ffb149;
-    border-right-color: fade( #ff9e1b, 25% );
-    background-color: #f6d9d3;
-    background-color: fade( #d12124, 20% );
+  border-left-color: #ffb149;
+  border-left-color: fade( #ff9e1b, 25% );
+  border-right-color: #ffb149;
+  border-right-color: fade( #ff9e1b, 25% );
+  background-color: #f6d9d3;
+  background-color: fade( #d12124, 20% );
 
-    &:before,
-    &:after {
-        content: '';
-        display: block;
-        width: 100%;
-        height: @grid_gutter-width * 0.25;
-        background-color: #da6750;
-        background-color: fade( #da6750, 75% );
-    }
+  &:before,
+  &:after {
+    content: '';
+    display: block;
+    width: 100%;
+    height: @grid_gutter-width * 0.25;
+    background-color: #da6750;
+    background-color: fade( #da6750, 75% );
+  }
 
-    &:before {
-        margin-bottom: @grid_gutter-width * 0.25;
-    }
+  &:before {
+    margin-bottom: @grid_gutter-width * 0.25;
+  }
 
-    &:after {
-        margin-top: @grid_gutter-width * 0.25;
-    }
+  &:after {
+    margin-top: @grid_gutter-width * 0.25;
+  }
 }
 
 //
@@ -130,17 +130,17 @@
 //
 
 .grid_push( @offset: 1, @grid_total-columns: @grid_total-columns ) {
-    @push: percentage( @offset / @grid_total-columns );
+  @push: percentage( @offset / @grid_total-columns );
 
-    position: relative;
-    left: @push;
+  position: relative;
+  left: @push;
 }
 
 .grid_pull( @offset: 1, @grid_total-columns: @grid_total-columns ) {
-    @pull: percentage( @offset / @grid_total-columns );
+  @pull: percentage( @offset / @grid_total-columns );
 
-    position: relative;
-    right: @pull;
+  position: relative;
+  right: @pull;
 }
 
 //
@@ -148,8 +148,8 @@
 //
 
 .grid_nested-col-group() {
-    display: block;
-    position: relative;
-    margin-left: ( @grid_gutter-width / 2 ) * -1;
-    margin-right: ( @grid_gutter-width / 2 ) * -1;
+  display: block;
+  position: relative;
+  margin-left: ( @grid_gutter-width / 2 ) * -1;
+  margin-right: ( @grid_gutter-width / 2 ) * -1;
 }

--- a/packages/cfpb-icons/src/cfpb-icons.less
+++ b/packages/cfpb-icons/src/cfpb-icons.less
@@ -25,13 +25,13 @@
 @plugin "icons-svg-inline";
 
 .u-svg-inline-bg( @name, @color: @black ) {
-    @red: red( @color );
-    @green: green( @color );
-    @blue: blue( @color );
-    @rgb-color: 'rgb(@{red}, @{green}, @{blue})';
-    @svg: icons-svg-inline( @name, @rgb-color );
+  @red: red( @color );
+  @green: green( @color );
+  @blue: blue( @color );
+  @rgb-color: 'rgb(@{red}, @{green}, @{blue})';
+  @svg: icons-svg-inline( @name, @rgb-color );
 
-    background-image: url( 'data:image/svg+xml;charset=UTF-8,@{svg}' );
+  background-image: url( 'data:image/svg+xml;charset=UTF-8,@{svg}' );
 }
 
 //
@@ -39,24 +39,24 @@
 //
 
 .cf-icon-svg {
-    height: @cf-icon-height;
-    vertical-align: text-top;
-    fill: currentColor;
+  height: @cf-icon-height;
+  vertical-align: text-top;
+  fill: currentColor;
 
-    // IE 10 & 11 require a max-width otherwise the SVG takes up 100%.
-    max-width: 1em;
+  // IE 10 & 11 require a max-width otherwise the SVG takes up 100%.
+  max-width: 1em;
 
-    &__updating {
-        animation: updating-animation 1.25s infinite linear;
-        transform-origin: 50% 50%;
-    }
+  &__updating {
+    animation: updating-animation 1.25s infinite linear;
+    transform-origin: 50% 50%;
+  }
 }
 
 @keyframes updating-animation {
-    0% {
-        transform: rotate( 0deg );
-    }
-    100% {
-        transform: rotate( 359deg );
-    }
+  0% {
+    transform: rotate( 0deg );
+  }
+  100% {
+    transform: rotate( 359deg );
+  }
 }

--- a/packages/cfpb-layout/src/cfpb-layout.less
+++ b/packages/cfpb-layout/src/cfpb-layout.less
@@ -57,46 +57,46 @@
 //
 
 .content-l {
-    // Used to position __divider modifiers
-    position: relative;
+  // Used to position __divider modifiers
+  position: relative;
 
-    .respond-to-min( @bp-sm-min, {
-        .grid_nested-col-group();
+  .respond-to-min( @bp-sm-min, {
+    .grid_nested-col-group();
     } );
 
-    &__full {
-        .respond-to-range( @bp-sm-min, 767px, {
-            .stack-col-thirds();
+  &__full {
+    .respond-to-range( @bp-sm-min, 767px, {
+      .stack-col-thirds();
             .stack-col-eighths();
             .stack-col-quarters();
         } );
-    }
+  }
 
-    &__main {
-        .respond-to-range( @bp-med-min, @bp-med-max, {
-            .stack-col( content-l_col-1-2 );
+  &__main {
+    .respond-to-range( @bp-med-min, @bp-med-max, {
+      .stack-col( content-l_col-1-2 );
         } );
 
-        .respond-to-range( @bp-sm-min, @bp-sm-max, {
-            .stack-col-thirds();
+    .respond-to-range( @bp-sm-min, @bp-sm-max, {
+      .stack-col-thirds();
             .stack-col-eighths();
             .stack-col-quarters();
         } );
-    }
+  }
 
-    &__sidebar {
-        .stack-col-thirds();
-        .stack-col-eighths();
-        .stack-col-quarters();
+  &__sidebar {
+    .stack-col-thirds();
+    .stack-col-eighths();
+    .stack-col-quarters();
 
-        .respond-to-min( @bp-med-min, {
-            .stack-col( content-l_col-1-2 );
+    .respond-to-min( @bp-med-min, {
+      .stack-col( content-l_col-1-2 );
         } );
-    }
+  }
 
-    &__large-gutters {
-        .respond-to-min( @bp-sm-min, {
-            margin-left: -@grid_gutter-width;
+  &__large-gutters {
+    .respond-to-min( @bp-sm-min, {
+      margin-left: -@grid_gutter-width;
             margin-right: -@grid_gutter-width;
 
             > .content-l_col {
@@ -104,19 +104,19 @@
                 border-right-width: @grid_gutter-width;
             }
         } );
-    }
+  }
 }
 
 .content-l_col {
-    .respond-to-max( @bp-xs-max, {
-        & + & {
+  .respond-to-max( @bp-xs-max, {
+    & + & {
             margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
         }
     } );
 }
 
 .respond-to-min( @bp-sm-min, {
-    .content-l_col-1 {
+  .content-l_col-1 {
         .grid_column( 12 );
     }
 
@@ -154,60 +154,60 @@
 //
 
 .content-l_col__before-divider.content-l_col-1-2 {
-    .respond-to-max( @bp-xs-max, {
-        .grid_column__top-divider();
+  .respond-to-max( @bp-xs-max, {
+    .grid_column__top-divider();
     } );
 
-    .respond-to-min( @bp-sm-min, {
-        .grid_column__left-divider();
+  .respond-to-min( @bp-sm-min, {
+    .grid_column__left-divider();
     } );
 }
 
 .content-l_col__before-divider.content-l_col-1-3 {
-    .respond-to-max( @bp-xs-max, {
-        .grid_column__top-divider();
+  .respond-to-max( @bp-xs-max, {
+    .grid_column__top-divider();
     } );
 
-    .respond-to-min( @bp-sm-min, {
-        .grid_column__left-divider();
+  .respond-to-min( @bp-sm-min, {
+    .grid_column__left-divider();
     } );
 }
 
 
 .stack-col( @col ) {
-    .content-l_col.@{col} {
-        display: block;
-        width: 100%;
+  .content-l_col.@{col} {
+    display: block;
+    width: 100%;
 
-        &.content-l_col__before-divider {
-            .grid_column__top-divider();
-        }
+    &.content-l_col__before-divider {
+      .grid_column__top-divider();
     }
+  }
 
-    &.content-l__large-gutters {
-        .content-l_col.@{col}.content-l_col__before-divider {
-            border-left-width: @grid_gutter-width;
-        }
+  &.content-l__large-gutters {
+    .content-l_col.@{col}.content-l_col__before-divider {
+      border-left-width: @grid_gutter-width;
     }
+  }
 
-    .content-l_col + .@{col} {
-        margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
-    }
+  .content-l_col + .@{col} {
+    margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
+  }
 }
 
 .stack-col-thirds() {
-    .stack-col( content-l_col-1-3 );
-    .stack-col( content-l_col-2-3 );
+  .stack-col( content-l_col-1-3 );
+  .stack-col( content-l_col-2-3 );
 }
 
 .stack-col-eighths() {
-    .stack-col( content-l_col-3-8 );
-    .stack-col( content-l_col-5-8 );
+  .stack-col( content-l_col-3-8 );
+  .stack-col( content-l_col-5-8 );
 }
 
 .stack-col-quarters() {
-    .stack-col( content-l_col-1-4 );
-    .stack-col( content-l_col-3-4 );
+  .stack-col( content-l_col-1-4 );
+  .stack-col( content-l_col-3-4 );
 }
 
 //
@@ -215,8 +215,8 @@
 //
 
 .content_line {
-    height: 1px;
-    background: @content_line;
+  height: 1px;
+  background: @content_line;
 }
 
 //
@@ -224,55 +224,55 @@
 //
 
 .content_wrapper {
-    &:extend( .wrapper all );
+  &:extend( .wrapper all );
 }
 
 .content_main,
 .content_intro {
-    dd,
-    dt,
-    h3,
-    h4,
-    h5,
-    h6,
-    li,
-    p,
-    label {
-        max-width: 41.875rem;
-    }
+  dd,
+  dt,
+  h3,
+  h4,
+  h5,
+  h6,
+  li,
+  p,
+  label {
+    max-width: 41.875rem;
+  }
 }
 
 .content_intro,
 .content_main,
 .content_sidebar {
-    padding:
+  padding:
         unit( @grid_gutter-width / @base-font-size-px, em )
         unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
 
-    .respond-to-min( @bp-sm-min, {
-        .grid_column( 12 );
+  .respond-to-min( @bp-sm-min, {
+    .grid_column( 12 );
 
         padding:
         unit( ( @grid_gutter-width * 1.5 ) / @base-font-size-px, em )
         unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
     } );
 
-    .respond-to-min( @bp-med-min, {
-        padding:
+  .respond-to-min( @bp-med-min, {
+    padding:
         unit( ( @grid_gutter-width * 1.5 ) / @base-font-size-px, em )
         0;
     } );
 }
 
 .respond-to-min( @bp-med-min, {
-    .content_intro {
+  .content_intro {
         .grid_column( 12 );
     }
 } );
 
 // Set up standard multi-column content area layouts
 .respond-to-min( @bp-med-min, {
-    .content {
+  .content {
         &__1-3 {
             .content_sidebar {
                 .grid_column( 3 );
@@ -314,24 +314,24 @@
 }); // END min-width 801 block
 
 .respond-to-min( @bp-lg-min, {
-    .content__2-1 .content_main__narrow {
+  .content__2-1 .content_main__narrow {
         .grid_column( 7, @grid_total-columns, 0, 1 );
     }
 } );
 
 .content__flush-bottom {
-    padding-bottom: 0;
+  padding-bottom: 0;
 }
 
 .content__flush-top-on-small {
-    .respond-to-max( @bp-sm-max, {
-        padding-top: 0;
+  .respond-to-max( @bp-sm-max, {
+    padding-top: 0;
     } );
 }
 
 .content__flush-all-on-small {
-    .respond-to-max( @bp-sm-max, {
-        padding: 0;
+  .respond-to-max( @bp-sm-max, {
+    padding: 0;
         border: none;
     } );
 }
@@ -341,53 +341,53 @@
 //
 
 .block {
-    margin-top: unit( ( @grid_gutter-width * 2 ) / @base-font-size-px, em );
-    margin-bottom: unit( ( @grid_gutter-width * 2 ) / @base-font-size-px, em );
+  margin-top: unit( ( @grid_gutter-width * 2 ) / @base-font-size-px, em );
+  margin-bottom: unit( ( @grid_gutter-width * 2 ) / @base-font-size-px, em );
 
-    &__border-top {
-        border-top: 1px solid @block__border-top;
+  &__border-top {
+    border-top: 1px solid @block__border-top;
+  }
+
+  &__border-right {
+    border-right: 1px solid @block__border-right;
+  }
+
+  &__border-bottom {
+    border-bottom: 1px solid @block__border-bottom;
+  }
+
+  &__border-left {
+    border-left: 1px solid @block__border-left;
+  }
+
+  &__border {
+    border: 1px solid @block__border;
+  }
+
+  &__flush-top {
+    margin-top: 0 !important;
+
+    &.block__border,
+    &.block__border-top {
+      border-top: none;
     }
+  }
 
-    &__border-right {
-        border-right: 1px solid @block__border-right;
+  &__flush-bottom {
+    margin-bottom: 0 !important;
+
+    &.block__border,
+    &.block__border-bottom {
+      border-bottom: none;
     }
+  }
 
-    &__border-bottom {
-        border-bottom: 1px solid @block__border-bottom;
-    }
+  &__flush-sides {
+    margin-right: -( @grid_gutter-width / 2 );
+    margin-left: -( @grid_gutter-width / 2 );
 
-    &__border-left {
-        border-left: 1px solid @block__border-left;
-    }
-
-    &__border {
-        border: 1px solid @block__border;
-    }
-
-    &__flush-top {
-        margin-top: 0 !important;
-
-        &.block__border,
-        &.block__border-top {
-            border-top: none;
-        }
-    }
-
-    &__flush-bottom {
-        margin-bottom: 0 !important;
-
-        &.block__border,
-        &.block__border-bottom {
-            border-bottom: none;
-        }
-    }
-
-    &__flush-sides {
-        margin-right: -( @grid_gutter-width / 2 );
-        margin-left: -( @grid_gutter-width / 2 );
-
-        .respond-to-max( @bp-xs-max, {
-            &.block__border,
+    .respond-to-max( @bp-xs-max, {
+      &.block__border,
             &.block__border-right,
             &.block__border-left {
                 border-right: none;
@@ -395,27 +395,27 @@
             }
         } );
 
-        .respond-to-min( @bp-sm-min, {
-            margin-right: -@grid_gutter-width;
+    .respond-to-min( @bp-sm-min, {
+      margin-right: -@grid_gutter-width;
             margin-left: -@grid_gutter-width;
         } );
+  }
+
+  &__flush {
+    margin-top: 0 !important;
+    margin-right: -( @grid_gutter-width / 2 );
+    margin-bottom: 0 !important;
+    margin-left: -( @grid_gutter-width / 2 );
+
+    &.block__border,
+    &.block__border-top,
+    &.block__border-bottom {
+      border-top: none;
+      border-bottom: none;
     }
 
-    &__flush {
-        margin-top: 0 !important;
-        margin-right: -( @grid_gutter-width / 2 );
-        margin-bottom: 0 !important;
-        margin-left: -( @grid_gutter-width / 2 );
-
-        &.block__border,
-        &.block__border-top,
-        &.block__border-bottom {
-            border-top: none;
-            border-bottom: none;
-        }
-
-        .respond-to-max( @bp-xs-max, {
-            &.block__border,
+    .respond-to-max( @bp-xs-max, {
+      &.block__border,
             &.block__border-right,
             &.block__border-left {
                 border-right: none;
@@ -423,47 +423,47 @@
             }
         } );
 
-        .respond-to-min( @bp-sm-min, {
-            margin-right: -@grid_gutter-width;
+    .respond-to-min( @bp-sm-min, {
+      margin-right: -@grid_gutter-width;
             margin-left: -@grid_gutter-width;
         } );
-    }
+  }
 
-    &__bg {
-        padding:
+  &__bg {
+    padding:
             unit( @grid_gutter-width / @base-font-size-px, em )
             unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
-        padding-bottom: unit( ( @grid_gutter-width * 2 ) / @base-font-size-px, em );
-        background: @block__bg;
+    padding-bottom: unit( ( @grid_gutter-width * 2 ) / @base-font-size-px, em );
+    background: @block__bg;
 
-        .respond-to-min( @bp-sm-min, {
-            padding: unit( ( @grid_gutter-width * 1.5 ) / @base-font-size-px, em )
+    .respond-to-min( @bp-sm-min, {
+      padding: unit( ( @grid_gutter-width * 1.5 ) / @base-font-size-px, em )
             unit( @grid_gutter-width / @base-font-size-px, em );
         } );
-    }
+  }
 
-    &__padded-top {
-        padding-top: unit( @grid_gutter-width / @base-font-size-px, em );
-        margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
-    }
+  &__padded-top {
+    padding-top: unit( @grid_gutter-width / @base-font-size-px, em );
+    margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
+  }
 
-    &__padded-bottom {
-        padding-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
-        margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
-    }
+  &__padded-bottom {
+    padding-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+    margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+  }
 
-    &__sub {
-        margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
-        margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
-    }
+  &__sub {
+    margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
+    margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+  }
 
-    // Overrides for when .block is also a column
-    .content-l_col&,
-    .content-l_col&__sub {
-        .respond-to-min( @bp-sm-min, {
-            margin-top: 0;
+  // Overrides for when .block is also a column
+  .content-l_col&,
+  .content-l_col&__sub {
+    .respond-to-min( @bp-sm-min, {
+      margin-top: 0;
         } );
-    }
+  }
 }
 
 //
@@ -471,20 +471,20 @@
 //
 
 .content__bleedbar {
-    // Overrides the border between main and sidebar, because bleedbar makes its own.
-    .content_main:after {
-        content: none;
-    }
+  // Overrides the border between main and sidebar, because bleedbar makes its own.
+  .content_main:after {
+    content: none;
+  }
 
-    .content_sidebar {
-        padding:
+  .content_sidebar {
+    padding:
             unit( @grid_gutter-width / @base-font-size-px, em )
             unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
-        background: @content_sidebar-bg;
-    }
+    background: @content_sidebar-bg;
+  }
 
-    .respond-to-min( @bp-med-min, {
-        // Prevent pseudo element background from creating horizontal scrollbar.
+  .respond-to-min( @bp-med-min, {
+    // Prevent pseudo element background from creating horizontal scrollbar.
         overflow: hidden;
 
         .content_sidebar {
@@ -536,49 +536,49 @@
 //
 
 .wrapper {
-    .respond-to-min( @bp-med-min, {
-        .grid_wrapper();
+  .respond-to-min( @bp-med-min, {
+    .grid_wrapper();
     } );
 
-    &__match-content {
-        padding-left: @grid_gutter-width / 2;
-        padding-right: @grid_gutter-width / 2;
+  &__match-content {
+    padding-left: @grid_gutter-width / 2;
+    padding-right: @grid_gutter-width / 2;
 
-        .respond-to-min( @bp-sm-min, {
-            padding-left: @grid_gutter-width;
+    .respond-to-min( @bp-sm-min, {
+      padding-left: @grid_gutter-width;
             padding-right: @grid_gutter-width;
             max-width: @grid_wrapper-width - @grid_gutter-width;
         } );
-    }
+  }
 }
 
 .grid_column__top-divider {
-    margin-top: unit( ( @grid_gutter-width * 2 ) / @base-font-size-px, em );
-    border-left-width: @grid_gutter-width / 2;
+  margin-top: unit( ( @grid_gutter-width * 2 ) / @base-font-size-px, em );
+  border-left-width: @grid_gutter-width / 2;
 
-    &:before {
-        display: block;
-        height: 1px;
-        width: 100%;
-        margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
-        margin-left: auto !important;
-        position: static;
-        background-color: @grid_column__top-divider;
-        content: '';
-    }
+  &:before {
+    display: block;
+    height: 1px;
+    width: 100%;
+    margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+    margin-left: auto !important;
+    position: static;
+    background-color: @grid_column__top-divider;
+    content: '';
+  }
 }
 
 .grid_column__left-divider {
-    border-left-width: @grid_gutter-width;
+  border-left-width: @grid_gutter-width;
 
-    &:before {
-        display: block;
-        width: 1px;
-        margin-left: -@grid_gutter-width;
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        background-color: @grid_column__left-divider;
-        content: '';
-    }
+  &:before {
+    display: block;
+    width: 1px;
+    margin-left: -@grid_gutter-width;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    background-color: @grid_column__left-divider;
+    content: '';
+  }
 }

--- a/packages/cfpb-layout/src/molecules/card.less
+++ b/packages/cfpb-layout/src/molecules/card.less
@@ -4,304 +4,304 @@
 // @f = `:focus` state.
 // @a = `:active` state.
 .u-link-card__colors( @c, @v, @h, @f, @a ) {
-    .m-card_footer > span {
-        display: inline;
-        border-width: 0;
-        border-bottom-width: 1px;
-        border-color: @c;
-        border-style: dotted;
-        font-weight: 500;
-        color: @c;
-        text-decoration: none;
-    }
+  .m-card_footer > span {
+    display: inline;
+    border-width: 0;
+    border-bottom-width: 1px;
+    border-color: @c;
+    border-style: dotted;
+    font-weight: 500;
+    color: @c;
+    text-decoration: none;
+  }
 
-    & > a:visited .m-card_footer > span {
-        border-color: @v;
-        color: @v;
-    }
+  & > a:visited .m-card_footer > span {
+    border-color: @v;
+    color: @v;
+  }
 
-    // Border changes on the regular cards happen on the top-level `article`
-    // element, so for consistency we trigger the hover styles on the parent
-    // instead of on the link. This differs from the visited, focus,
-    // and active states, which add styles onto the link.
-    &:hover .m-card_footer > span {
-        border-style: solid;
-        border-color: @h;
-        color: @h;
-    }
+  // Border changes on the regular cards happen on the top-level `article`
+  // element, so for consistency we trigger the hover styles on the parent
+  // instead of on the link. This differs from the visited, focus,
+  // and active states, which add styles onto the link.
+  &:hover .m-card_footer > span {
+    border-style: solid;
+    border-color: @h;
+    color: @h;
+  }
 
-    & > a:focus .m-card_footer > span {
-        border-color: @f;
-        color: @f;
-    }
+  & > a:focus .m-card_footer > span {
+    border-color: @f;
+    color: @f;
+  }
 
-    & > a:active .m-card_footer > span {
-        border-color: @a;
-        border-style: solid;
-        color: @a;
-    }
+  & > a:active .m-card_footer > span {
+    border-color: @a;
+    border-style: solid;
+    color: @a;
+  }
 }
 
 .u-card-bottom-bar() {
-    // Bottom green hover bar.
-    &:after {
-        content: '';
-        position: absolute;
-        left: 0;
-        bottom: 1px;
-        height: 5px;
-        width: 100%;
-        background: @green;
-    }
+  // Bottom green hover bar.
+  &:after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 1px;
+    height: 5px;
+    width: 100%;
+    background: @green;
+  }
 }
 
 .m-card {
-    position: relative;
+  position: relative;
 
-    &:not( .m-card__breakout ) {
-        & > a {
-            padding: unit( @grid_gutter-width / @base-font-size-px, em );
-        }
-    }
-
-    &:not( .m-card__breakout ):not( .m-card__highlight ):not( .m-card__topic ) {
-        background: @white;
-        border: 1px solid @gray-20;
-        border-bottom-width: 3px;
-    }
-
-    &:not( .m-card__featured ):not( .m-card__breakout ):not( .m-card__topic ):not( .m-card__highlight ) {
-        padding: unit( @grid_gutter-width / @base-font-size-px, em );
-    }
-
-    &:not( .m-card__featured ):not( .m-card__breakout ):not( .m-card__topic ):not( .m-card__highlight ),
+  &:not( .m-card__breakout ) {
     & > a {
-        display: flex;
-        flex-direction: column;
-        flex-grow: 1;
-        flex-basis: 0;
-        box-sizing: border-box;
-        height: 100%;
+      padding: unit( @grid_gutter-width / @base-font-size-px, em );
     }
+  }
 
-    & a:focus {
-        outline-offset: 2px;
+  &:not( .m-card__breakout ):not( .m-card__highlight ):not( .m-card__topic ) {
+    background: @white;
+    border: 1px solid @gray-20;
+    border-bottom-width: 3px;
+  }
+
+  &:not( .m-card__featured ):not( .m-card__breakout ):not( .m-card__topic ):not( .m-card__highlight ) {
+    padding: unit( @grid_gutter-width / @base-font-size-px, em );
+  }
+
+  &:not( .m-card__featured ):not( .m-card__breakout ):not( .m-card__topic ):not( .m-card__highlight ),
+  & > a {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    flex-basis: 0;
+    box-sizing: border-box;
+    height: 100%;
+  }
+
+  & a:focus {
+    outline-offset: 2px;
+  }
+
+  &:not( .m-card__highlight ) {
+    &_footer {
+      margin-top: auto;
     }
+  }
 
-    &:not( .m-card__highlight ) {
-        &_footer {
-            margin-top: auto;
-        }
-    }
+  &_footer > a {
+    font-weight: 500;
+    border-bottom-width: 1px;
+  }
 
-    &_footer > a {
-        font-weight: 500;
-        border-bottom-width: 1px;
-    }
-
-    // Shrink heading at smaller screen sizes.
-    &_heading {
-        .respond-to-max( @bp-med-min, {
-            .h3();
+  // Shrink heading at smaller screen sizes.
+  &_heading {
+    .respond-to-max( @bp-med-min, {
+      .h3();
         } );
+  }
+
+  // Regular cards.
+  &_heading > a {
+    color: @black;
+
+    &:hover {
+      color: @pacific;
     }
 
-    // Regular cards.
-    &_heading > a {
-        color: @black;
-
-        &:hover {
-            color: @pacific;
-        }
-
-        & .m-card_icon {
-            font-size: 1em;
-            margin-bottom: 0;
-            padding-right: unit( 7.5px / @base-font-size-px, em );
-        }
-
-        & .m-card_icon,
-        & span {
-            display: table-cell;
-        }
+    & .m-card_icon {
+      font-size: 1em;
+      margin-bottom: 0;
+      padding-right: unit( 7.5px / @base-font-size-px, em );
     }
 
-    & > .m-list {
-        margin-top: 10px;
-        margin-bottom: 30px;
+    & .m-card_icon,
+    & span {
+      display: table-cell;
+    }
+  }
+
+  & > .m-list {
+    margin-top: 10px;
+    margin-bottom: 30px;
+  }
+
+  // Featured cards.
+  &__featured {
+
+    .m-card_heading {
+      margin: 0;
     }
 
-    // Featured cards.
-    &__featured {
+    .m-card_icon {
+      font-size: unit( 30px / @base-font-size-px, em );
+      margin-bottom: unit( 5px / @base-font-size-px, em );
+    }
 
-        .m-card_heading {
-            margin: 0;
-        }
+    .m-card_icon,
+    p {
+      color: @black;
+    }
 
-        .m-card_icon {
-            font-size: unit( 30px / @base-font-size-px, em );
-            margin-bottom: unit( 5px / @base-font-size-px, em );
-        }
-
-        .m-card_icon,
-        p {
-            color: @black;
-        }
-
-        &:hover {
-            box-shadow: 0 8px 0 0 inset @green,
+    &:hover {
+      box-shadow: 0 8px 0 0 inset @green,
                         2px 0 0 0 inset @gray-20,
                         -2px 0 0 0 inset @gray-20;
-        }
-
-        &:hover .m-card_footer > span {
-            border-style: solid;
-            color: @pacific-dark;
-        }
-
-        .m-card_footer > span {
-            display: inline;
-            border-width: 0;
-            border-bottom-width: 1px;
-            border-color: @pacific;
-            border-style: dotted;
-            font-weight: 500;
-            color: @pacific;
-            text-decoration: none;
-        }
-
-        & > a:visited .m-card_footer > span {
-            color: @teal;
-            border-color: @teal !important;
-        }
-
-        & > a:link,
-        & > a:visited {
-            border: 1px solid @gray-20;
-            border-bottom-width: 3px;
-        }
     }
 
-    // Topic cards.
-    &__topic {
-        text-align: center;
-        width: 170px;
-        background: @white;
+    &:hover .m-card_footer > span {
+      border-style: solid;
+      color: @pacific-dark;
+    }
 
-        & > a {
-            border: 1px solid @gray-20;
-            border-bottom-width: 3px;
-        }
+    .m-card_footer > span {
+      display: inline;
+      border-width: 0;
+      border-bottom-width: 1px;
+      border-color: @pacific;
+      border-style: dotted;
+      font-weight: 500;
+      color: @pacific;
+      text-decoration: none;
+    }
 
-        .m-card_icon {
-            font-size: unit( 30px / @base-font-size-px, em );
-            color: @green;
-            margin-bottom: unit( 5px / @base-font-size-px, em );
-        }
+    & > a:visited .m-card_footer > span {
+      color: @teal;
+      border-color: @teal !important;
+    }
 
-        &:hover {
-            > a {
-                box-shadow: 0 2px 0 0 inset @gray-20,
+    & > a:link,
+    & > a:visited {
+      border: 1px solid @gray-20;
+      border-bottom-width: 3px;
+    }
+  }
+
+  // Topic cards.
+  &__topic {
+    text-align: center;
+    width: 170px;
+    background: @white;
+
+    & > a {
+      border: 1px solid @gray-20;
+      border-bottom-width: 3px;
+    }
+
+    .m-card_icon {
+      font-size: unit( 30px / @base-font-size-px, em );
+      color: @green;
+      margin-bottom: unit( 5px / @base-font-size-px, em );
+    }
+
+    &:hover {
+      > a {
+        box-shadow: 0 2px 0 0 inset @gray-20,
                             2px 0 0 0 inset @gray-20,
                            -2px 0 0 0 inset @gray-20;
-            }
+      }
 
-            .u-card-bottom-bar();
-        }
-
-        // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.
-        .u-link-card__colors( @pacific, @teal, @pacific-dark, @pacific-dark, @pacific-dark );
+      .u-card-bottom-bar();
     }
 
-    &__topic-action {
-        .m-card_icon {
-            color: @pacific;
-        }
+    // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.
+    .u-link-card__colors( @pacific, @teal, @pacific-dark, @pacific-dark, @pacific-dark );
+  }
+
+  &__topic-action {
+    .m-card_icon {
+      color: @pacific;
+    }
+  }
+
+  // Breakout cards.
+  @card_img_width: 210px;
+  @card_img_height: 120px;
+  &__breakout {
+    min-width: 210px;
+    text-align: center;
+
+    // Provide padding offset set to half the image height.
+    > a {
+      padding-top: @card_img_height / 2;
     }
 
-    // Breakout cards.
-    @card_img_width: 210px;
-    @card_img_height: 120px;
-    &__breakout {
-        min-width: 210px;
-        text-align: center;
+    .m-card_inner-wrapper {
+      position: relative;
+      z-index: 0;
+      min-height: @card_img_height + ( @grid_gutter-width / 2 );
 
-        // Provide padding offset set to half the image height.
-        > a {
-            padding-top: @card_img_height / 2;
-        }
+      background: @gray-5;
+      border: 1px solid @gray-20;
+      border-bottom-width: 3px;
+    }
 
-        .m-card_inner-wrapper {
-            position: relative;
-            z-index: 0;
-            min-height: @card_img_height + ( @grid_gutter-width / 2 );
+    .m-card_img {
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      left: 50%;
+      width: @card_img_width;
+      height: @card_img_height;
 
-            background: @gray-5;
-            border: 1px solid @gray-20;
-            border-bottom-width: 3px;
-        }
+      // Match half of image width.
+      margin-left: -( @card_img_width / 2 );
+    }
 
-        .m-card_img {
-            position: absolute;
-            z-index: 1;
-            top: 0;
-            left: 50%;
-            width: @card_img_width;
-            height: @card_img_height;
+    .m-card_footer {
+      // Subtract 6px to accommodate heading-3 size.
+      margin-top: ( @card_img_height / 2 ) + @grid_gutter-width - 6px;
+    }
 
-            // Match half of image width.
-            margin-left: -( @card_img_width / 2 );
-        }
-
-        .m-card_footer {
-            // Subtract 6px to accommodate heading-3 size.
-            margin-top: ( @card_img_height / 2 ) + @grid_gutter-width - 6px;
-        }
-
-        &:hover {
-            .m-card_inner-wrapper {
-                box-shadow: 0 2px 0 0 inset @gray-20,
+    &:hover {
+      .m-card_inner-wrapper {
+        box-shadow: 0 2px 0 0 inset @gray-20,
                             2px 0 0 0 inset @gray-20,
                            -2px 0 0 0 inset @gray-20;
-            }
+      }
 
-            .u-card-bottom-bar();
-        }
-
-        // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.
-        .u-link-card__colors( @pacific, @teal, @pacific-dark, @pacific, @navy );
-
-        // Breakout cards have larger links.
-        .m-card_footer > span {
-            .heading-3();
-        }
+      .u-card-bottom-bar();
     }
 
-    // Highlight cards.
-    &__highlight {
-        background: @green-20;
+    // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.
+    .u-link-card__colors( @pacific, @teal, @pacific-dark, @pacific, @navy );
 
-        & > a {
-            border: 1px solid @green-40;
-            border-bottom-width: 3px;
-        }
+    // Breakout cards have larger links.
+    .m-card_footer > span {
+      .heading-3();
+    }
+  }
 
-        h3,
-        p {
-            color: @black;
-        }
+  // Highlight cards.
+  &__highlight {
+    background: @green-20;
 
-        &:hover {
-            > a {
-                box-shadow: 0 2px 0 0 inset @green-40,
+    & > a {
+      border: 1px solid @green-40;
+      border-bottom-width: 3px;
+    }
+
+    h3,
+    p {
+      color: @black;
+    }
+
+    &:hover {
+      > a {
+        box-shadow: 0 2px 0 0 inset @green-40,
                             2px 0 0 0 inset @green-40,
                            -2px 0 0 0 inset @green-40;
-            }
+      }
 
-            .u-card-bottom-bar();
-        }
-
-        // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.
-        .u-link-card__colors( @pacific-mid-dark, @teal-mid-dark, @pacific-dark, @pacific-mid-dark, @navy );
+      .u-card-bottom-bar();
     }
+
+    // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.
+    .u-link-card__colors( @pacific-mid-dark, @teal-mid-dark, @pacific-dark, @pacific-mid-dark, @navy );
+  }
 }

--- a/packages/cfpb-layout/src/molecules/heroes.less
+++ b/packages/cfpb-layout/src/molecules/heroes.less
@@ -5,21 +5,21 @@
 // Hero molecule
 
 .m-hero {
-    background-color: @gray-5;
+  background-color: @gray-5;
 
-    &_wrapper {
-        // Manually enable CSS grid for IE. IE's grid implementation differs
-        // slightly from the spec so we manually enable it per component
-        // instead of using autoprefixer to enable it for the entire site.
-        display: -ms-grid;
-        display: grid;
-        max-width: ( @grid_wrapper-width - @grid_gutter-width );
-        margin: 0 auto;
-        padding-top: @grid_gutter-width;
-        padding-bottom: @grid_gutter-width;
+  &_wrapper {
+    // Manually enable CSS grid for IE. IE's grid implementation differs
+    // slightly from the spec so we manually enable it per component
+    // instead of using autoprefixer to enable it for the entire site.
+    display: -ms-grid;
+    display: grid;
+    max-width: ( @grid_wrapper-width - @grid_gutter-width );
+    margin: 0 auto;
+    padding-top: @grid_gutter-width;
+    padding-bottom: @grid_gutter-width;
 
-        .respond-to-min( @bp-sm-min, {
-            -ms-grid-columns: 7fr 5fr;
+    .respond-to-min( @bp-sm-min, {
+      -ms-grid-columns: 7fr 5fr;
             grid-template-columns: 7fr 5fr;
             padding-right: ( @grid_gutter-width / 2);
             padding-left: ( @grid_gutter-width / 2);
@@ -27,47 +27,47 @@
             min-height: @hero-desktop-height - ( @grid_gutter-width * 2 );
         } );
 
-        .respond-to-min( @bp-lg-min, {
-            padding-top: unit( ( @grid_gutter-width * 1.5 ) / @base-font-size-px, em );
+    .respond-to-min( @bp-lg-min, {
+      padding-top: unit( ( @grid_gutter-width * 1.5 ) / @base-font-size-px, em );
             padding-bottom: unit( ( @grid_gutter-width * 1.5 ) / @base-font-size-px, em );
             min-height: @hero-desktop-height - ( ( @grid_gutter-width * 1.5 ) * 2 );
         } );
-    }
+  }
 
-    &_text {
-        padding-right: ( @grid_gutter-width / 2 );
-        padding-left: ( @grid_gutter-width / 2 );
+  &_text {
+    padding-right: ( @grid_gutter-width / 2 );
+    padding-left: ( @grid_gutter-width / 2 );
 
-        .respond-to-min( @bp-sm-min, {
-            margin: auto;
+    .respond-to-min( @bp-sm-min, {
+      margin: auto;
         } );
-    }
+  }
 
-    &_heading {
-        .heading-1();
+  &_heading {
+    .heading-1();
 
-        .respond-to-max( @bp-sm-max, {
-            .heading-2();
+    .respond-to-max( @bp-sm-max, {
+      .heading-2();
         } );
-    }
+  }
 
-    &_subhead {
-        // Not using the `.heading-3()` mixin here because we want the weight
-        // to remain Regular on smaller screens.
-        font-size: @size-iii;
-        line-height: 1.25;
+  &_subhead {
+    // Not using the `.heading-3()` mixin here because we want the weight
+    // to remain Regular on smaller screens.
+    font-size: @size-iii;
+    line-height: 1.25;
 
-        .respond-to-max( @bp-sm-max, {
-            font-size: @size-iv;
+    .respond-to-max( @bp-sm-max, {
+      font-size: @size-iv;
         } );
-    }
+  }
 
-    &_image-wrapper {
-        box-sizing: border-box;
-        overflow: hidden;
+  &_image-wrapper {
+    box-sizing: border-box;
+    overflow: hidden;
 
-        .respond-to-min( @bp-sm-min, {
-            padding-right: ( @grid_gutter-width / 2 );
+    .respond-to-min( @bp-sm-min, {
+      padding-right: ( @grid_gutter-width / 2 );
             padding-left: ( @grid_gutter-width / 2 );
 
             // Vertically center hero images
@@ -75,37 +75,37 @@
             align-items: center;
         } );
 
-        .respond-to-max( @bp-xs-max, {
-            margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
+    .respond-to-max( @bp-xs-max, {
+      margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
         } );
+  }
+
+  &_image {
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+
+    width: 100%;
+
+    // Progressive enhancement for legacy browsers.
+    // Instead of writing fallbacks for the behavior of each type of
+    // hero image, we hide the hero image in legacy browsers.
+    display: none;
+
+    @supports ( display: grid ) {
+      display: block;
     }
+  }
 
-    &_image {
-        background-position: center;
-        background-repeat: no-repeat;
-        background-size: contain;
+  &__knockout {
+    background-color: @gray;
+    color: @white;
+  }
 
-        width: 100%;
+  &__bleeding {
+    .respond-to-min( @bp-sm-min, {
 
-        // Progressive enhancement for legacy browsers.
-        // Instead of writing fallbacks for the behavior of each type of
-        // hero image, we hide the hero image in legacy browsers.
-        display: none;
-
-        @supports ( display: grid ) {
-            display: block;
-        }
-    }
-
-    &__knockout {
-        background-color: @gray;
-        color: @white;
-    }
-
-    &__bleeding {
-        .respond-to-min( @bp-sm-min, {
-
-            .m-hero_image-wrapper {
+      .m-hero_image-wrapper {
                 width: 100%;
                 margin-top: unit( @grid_gutter-width / @base-font-size-px, em ) * -1;
                 margin-bottom: unit( @grid_gutter-width / @base-font-size-px, em ) * -1;
@@ -120,43 +120,43 @@
             }
         } );
 
-        .respond-to-min( @bp-lg-min, {
-            .m-hero_image-wrapper {
+    .respond-to-min( @bp-lg-min, {
+      .m-hero_image-wrapper {
                 margin-top: unit( ( @grid_gutter-width * 1.5 ) / @base-font-size-px, em ) * -1;
                 margin-bottom: unit( ( @grid_gutter-width * 1.5 ) / @base-font-size-px, em ) * -1;
             }
         } );
+  }
+
+  &__overlay {
+    .m-hero_wrapper {
+      background-position: center;
+      background-repeat: no-repeat;
+      background-size: cover;
     }
 
-    &__overlay {
-        .m-hero_wrapper {
-            background-position: center;
-            background-repeat: no-repeat;
-            background-size: cover;
-        }
-
-        .respond-to-max( @bp-xs-max, {
-            .m-hero_wrapper {
+    .respond-to-max( @bp-xs-max, {
+      .m-hero_wrapper {
                 // Overwrite the image that is set in the markup because
                 // we are showing the image container below instead.
                 background-image: none !important;
             }
         } );
 
-        .respond-to-min( @bp-sm-min, {
-            .m-hero_image {
+    .respond-to-min( @bp-sm-min, {
+      .m-hero_image {
                 display: none;
             }
         } );
-    }
+  }
 
-    &__jumbo {
-        background-color: @white;
+  &__jumbo {
+    background-color: @white;
 
-        .u-jumbo-text();
+    .u-jumbo-text();
 
-        .respond-to-min( @bp-sm-min, {
-            .m-hero_wrapper {
+    .respond-to-min( @bp-sm-min, {
+      .m-hero_wrapper {
                 background-position: 50%;
                 background-repeat: no-repeat;
                 background-size: cover;
@@ -167,21 +167,21 @@
             }
         } );
 
-        .respond-to-max( @bp-xs-max, {
-            .m-hero_wrapper {
+    .respond-to-max( @bp-xs-max, {
+      .m-hero_wrapper {
                 // Keep hero image flush with container on mobile
                 padding-bottom: 0;
             }
         } );
-    }
+  }
 
-    &__50-50 {
-        background-color: @white;
+  &__50-50 {
+    background-color: @white;
 
-        .u-jumbo-text();
+    .u-jumbo-text();
 
-        .respond-to-min( @bp-sm-min, {
-            .m-hero_wrapper {
+    .respond-to-min( @bp-sm-min, {
+      .m-hero_wrapper {
                 -ms-grid-columns: 1fr 1fr;
                 grid-template-columns: 1fr 1fr;
 
@@ -198,31 +198,30 @@
             }
         } );
 
-        .respond-to-min( @bp-lg-min, {
-            .m-hero_wrapper {
+    .respond-to-min( @bp-lg-min, {
+      .m-hero_wrapper {
                 // Enlarge the 50/50 height on large screens to maximize the image size
                 min-height: @hero-desktop-height + ( @grid_gutter-width * 2 );
             }
         } );
-    }
-
+  }
 }
 
 // Jumbo hero text mixin
 
 .u-jumbo-text() {
-    .m-hero_subhead {
-        .lead-paragraph();
-    }
+  .m-hero_subhead {
+    .lead-paragraph();
+  }
 
-    .respond-to-min( @bp-sm-min, {
-        .m-hero_subhead {
+  .respond-to-min( @bp-sm-min, {
+    .m-hero_subhead {
             .heading-3();
         }
     } );
 
-    .respond-to-min( @bp-lg-min, {
-        .m-hero_wrapper {
+  .respond-to-min( @bp-lg-min, {
+    .m-hero_wrapper {
             min-height: @hero-desktop-height;
         }
         .m-hero_heading {

--- a/packages/cfpb-layout/src/organisms/card-group.less
+++ b/packages/cfpb-layout/src/organisms/card-group.less
@@ -1,38 +1,38 @@
 // Grid-based "column" card group layouts.
 .o-card-group {
 
-    > h2 {
-        margin-bottom: unit( 30px / @base-font-size-px, rem );
-    }
+  > h2 {
+    margin-bottom: unit( 30px / @base-font-size-px, rem );
+  }
 
-    &__column-2 &_cards {
-        grid-template-columns: 1fr 1fr;
-    }
+  &__column-2 &_cards {
+    grid-template-columns: 1fr 1fr;
+  }
 
-    &__column-3 &_cards {
-        grid-template-columns: repeat( 3, minmax( 0, 1fr ) );
+  &__column-3 &_cards {
+    grid-template-columns: repeat( 3, minmax( 0, 1fr ) );
 
-        // Convert to 2-column layout at small screen sizes;
-        .respond-to-max( @bp-lg-min, {
-            grid-template-columns: 1fr 1fr;
+    // Convert to 2-column layout at small screen sizes;
+    .respond-to-max( @bp-lg-min, {
+      grid-template-columns: 1fr 1fr;
         } );
-    }
+  }
 
-    &_cards {
-        display: grid;
-        grid-column-gap: unit( 20px / @base-font-size-px, em );
-        grid-row-gap: unit( 20px / @base-font-size-px, em );
+  &_cards {
+    display: grid;
+    grid-column-gap: unit( 20px / @base-font-size-px, em );
+    grid-row-gap: unit( 20px / @base-font-size-px, em );
 
-        .respond-to-max( @bp-xs-max, {
-            // Make sure cards are stacked at mobile size.
+    .respond-to-max( @bp-xs-max, {
+      // Make sure cards are stacked at mobile size.
             grid-template-columns: 100% !important;
         } );
-    }
+  }
 
-    &__bg-green {
-        padding: unit( 30px / @base-font-size-px, em );
-        background: @green-20;
-    }
+  &__bg-green {
+    padding: unit( 30px / @base-font-size-px, em );
+    background: @green-20;
+  }
 }
 
 // Hack for Edge/IE to convert grid to a floated block layout.
@@ -41,111 +41,111 @@
 
 /* stylelint-disable selector-type-no-unknown */
 _:-ms-lang( x ),.o-card-group_cards {
-    display: block;
+  display: block;
 
-    .m-card {
-        display: block;
-        float: left;
-        margin-bottom: 10px;
-    }
+  .m-card {
+    display: block;
+    float: left;
+    margin-bottom: 10px;
+  }
 }
 
 _:-ms-lang( x ),.o-card-group__column-2 {
-    .o-card-group_cards .m-card {
-        width: 48%;
-        margin-right: 2%;
-    }
-    .o-card-group_cards .m-card:last-child {
-        margin-right: 0;
-    }
+  .o-card-group_cards .m-card {
+    width: 48%;
+    margin-right: 2%;
+  }
+  .o-card-group_cards .m-card:last-child {
+    margin-right: 0;
+  }
 }
 
 _:-ms-lang( x ),.o-card-group__column-3 {
-    .o-card-group_cards .m-card {
-        width: 32%;
-        margin-right: 1%;
-    }
-    .o-card-group_cards .m-card:last-child {
-        margin-right: 0;
-    }
+  .o-card-group_cards .m-card {
+    width: 32%;
+    margin-right: 1%;
+  }
+  .o-card-group_cards .m-card:last-child {
+    margin-right: 0;
+  }
 }
 
 _:-ms-lang( x ),.o-card-group:after {
-    content: '';
-    display: table;
-    clear: both;
+  content: '';
+  display: table;
+  clear: both;
 }
 /* stylelint-enable selector-type-no-unknown */
 
 /* stylelint-disable no-duplicate-selectors */
 // Grid-based "count" card group layouts.
 .o-card-group {
-    /* stylelint-enable no-duplicate-selectors */
-    // Name the card grid areas.
-    &__count-2,
-    &__count-3,
-    &__count-4 {
+  /* stylelint-enable no-duplicate-selectors */
+  // Name the card grid areas.
+  &__count-2,
+  &__count-3,
+  &__count-4 {
 
-        .m-card:nth-of-type( 1 ) {
-            grid-area: card1;
-        }
-
-        .m-card:nth-of-type( 2 ) {
-            grid-area: card2;
-        }
-
-        .m-card:nth-of-type( 3 ) {
-            grid-area: card3;
-        }
-
-        .m-card:nth-of-type( 4 ) {
-            grid-area: card4;
-        }
+    .m-card:nth-of-type( 1 ) {
+      grid-area: card1;
     }
 
-    &__count-2 &_cards {
-        grid-template-columns: 1fr 1fr;
-        grid-template-areas: "card1 card2";
+    .m-card:nth-of-type( 2 ) {
+      grid-area: card2;
     }
 
-    &__count-3 &_cards {
-        grid-template-columns: 1fr 1fr;
-        grid-template-areas:
+    .m-card:nth-of-type( 3 ) {
+      grid-area: card3;
+    }
+
+    .m-card:nth-of-type( 4 ) {
+      grid-area: card4;
+    }
+  }
+
+  &__count-2 &_cards {
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas: "card1 card2";
+  }
+
+  &__count-3 &_cards {
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
             "card1 card2"
             "card1 card3";
 
-        // We have to reach inside the m-card here unfortunately to
-        // center the content of the first card and increase the heading.
-        .m-card:nth-of-type( 1 ) {
-            h3 {
-                .h2();
-            }
+    // We have to reach inside the m-card here unfortunately to
+    // center the content of the first card and increase the heading.
+    .m-card:nth-of-type( 1 ) {
+      h3 {
+        .h2();
+      }
 
-            > a {
-                justify-content: center;
-            }
-        }
+      > a {
+        justify-content: center;
+      }
     }
+  }
 
-    &__count-4 &_cards {
-        grid-template-columns: 1fr 1fr;
-        grid-template-areas:
+  &__count-4 &_cards {
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
             "card1 card2"
             "card3 card4";
-    }
+  }
 
-    // Flexbox-based "flow" card group layout.
-    &__flow {
-        .o-card-group_cards {
-            display: flex;
-            flex-wrap: wrap;
-        }
+  // Flexbox-based "flow" card group layout.
+  &__flow {
+    .o-card-group_cards {
+      display: flex;
+      flex-wrap: wrap;
     }
+  }
 }
 
 // Tablet size.
 .respond-to-range( @bp-sm-min, @bp-sm-max, {
-    .o-card-group {
+  .o-card-group {
         &__count-3 &_cards {
             grid-template-columns: 1fr 1fr;
             grid-template-areas:
@@ -157,7 +157,7 @@ _:-ms-lang( x ),.o-card-group:after {
 
 // Mobile size.
 .respond-to-max( @bp-xs-max, {
-    .o-card-group {
+  .o-card-group {
         &__count-2 &_cards {
             grid-template-columns: 1fr;
             grid-template-areas:

--- a/packages/cfpb-layout/src/organisms/email-signup.less
+++ b/packages/cfpb-layout/src/organisms/email-signup.less
@@ -1,36 +1,36 @@
 .o-email-signup {
-    .m-notification {
-        margin-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-    }
+  .m-notification {
+    margin-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+  }
 
-    .a-text-input {
-        // Keep inputs in a wider layout to a reasonable width.
-        // 370 = 4 columns at max grid width
-        max-width: unit( 370px / @base-font-size-px, rem );
-    }
+  .a-text-input {
+    // Keep inputs in a wider layout to a reasonable width.
+    // 370 = 4 columns at max grid width
+    max-width: unit( 370px / @base-font-size-px, rem );
+  }
 
-    .m-btn-group {
-        display: flex;
-        margin-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-        align-items: flex-start;
-        flex-wrap: wrap-reverse;
-    }
+  .m-btn-group {
+    display: flex;
+    margin-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+    align-items: flex-start;
+    flex-wrap: wrap-reverse;
+  }
 
-    button {
-        margin-right: unit( @grid_gutter-width / 3 / @base-font-size-px, em );
-    }
+  button {
+    margin-right: unit( @grid_gutter-width / 3 / @base-font-size-px, em );
+  }
 
-    // Extra class in selector needed to override default .m-btn-group margin
-    .a-btn.a-btn__secondary {
-        // Magic number below is to align its baseline with the button
-        // label to its left when they are side-by-side.
-        margin-bottom: unit( 8px / @base-font-size-px, em );
-        margin-left: 0;
-        order: 1;
-    }
+  // Extra class in selector needed to override default .m-btn-group margin
+  .a-btn.a-btn__secondary {
+    // Magic number below is to align its baseline with the button
+    // label to its left when they are side-by-side.
+    margin-bottom: unit( 8px / @base-font-size-px, em );
+    margin-left: 0;
+    order: 1;
+  }
 
-    .respond-to-max( @bp-xs-max, {
-        .a-label__heading {
+  .respond-to-max( @bp-xs-max, {
+    .a-label__heading {
             font-size: 1em;
         }
     } );

--- a/packages/cfpb-layout/src/organisms/featured-content-module.less
+++ b/packages/cfpb-layout/src/organisms/featured-content-module.less
@@ -3,22 +3,22 @@
 @fcm-min-height: 220px;
 
 .o-featured-content-module {
-    min-height: @fcm-min-height;
-    position: relative;
-    border: 1px solid @gray-40;
-    background-color: @gray-5;
+  min-height: @fcm-min-height;
+  position: relative;
+  border: 1px solid @gray-40;
+  background-color: @gray-5;
 
+  &_text {
+    padding-top: unit( @grid_gutter-width / @base-font-size-px, em );
+    padding-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
+  }
+
+  &_img {
+    display: block;
+  }
+
+  .respond-to-max( @bp-xs-max, {
     &_text {
-        padding-top: unit( @grid_gutter-width / @base-font-size-px, em );
-        padding-bottom: unit( @grid_gutter-width / @base-font-size-px, em );
-    }
-
-    &_img {
-        display: block;
-    }
-
-    .respond-to-max( @bp-xs-max, {
-        &_text {
             padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
             padding-left: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
         }
@@ -36,8 +36,8 @@
 
     } );
 
-    .respond-to-min( @bp-sm-min, {
-        &_text {
+  .respond-to-min( @bp-sm-min, {
+    &_text {
             padding-right: @fcm-visual-width + @grid_gutter-width;
             padding-left: unit( @grid_gutter-width / @base-font-size-px, em );
         }
@@ -64,24 +64,24 @@
 
     } );
 
-    // Modifiers
-    &__left {
-        /* Left modifier doesn't have a border/background. If in the future we
+  // Modifiers
+  &__left {
+    /* Left modifier doesn't have a border/background. If in the future we
            have a left arranged FCM we'll want to make the border/background
            its own modifer */
-        border: initial;
-        background-color: initial;
+    border: initial;
+    background-color: initial;
 
-        .o-featured-content-module_visual {
-            left: 0;
-            right: initial;
-        }
+    .o-featured-content-module_visual {
+      left: 0;
+      right: initial;
+    }
 
-        .o-featured-content-module_text {
-            .respond-to-min( @bp-sm-min, {
-                padding-left: @fcm-visual-width + @grid_gutter-width;
+    .o-featured-content-module_text {
+      .respond-to-min( @bp-sm-min, {
+        padding-left: @fcm-visual-width + @grid_gutter-width;
                 padding-right: unit( @grid_gutter-width / @base-font-size-px, em );
             } );
-        }
     }
+  }
 }

--- a/packages/cfpb-layout/src/organisms/wells.less
+++ b/packages/cfpb-layout/src/organisms/wells.less
@@ -1,31 +1,31 @@
 .o-well {
-    box-sizing: border-box;
+  box-sizing: border-box;
 
-    padding:
+  padding:
         unit( @grid_gutter-width / @base-font-size-px, em )
         unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
-    border: 1px solid @gray-40;
-    background-color: @gray-5;
+  border: 1px solid @gray-40;
+  background-color: @gray-5;
 
-    .respond-to-min( @bp-sm-min, {
-        padding-left: unit( @grid_gutter-width / @base-font-size-px, em );
+  .respond-to-min( @bp-sm-min, {
+    padding-left: unit( @grid_gutter-width / @base-font-size-px, em );
         padding-right: unit( @grid_gutter-width / @base-font-size-px, em );
     } );
 
-    &__inkwell {
-        background-color: @gray-dark;
-        color: @white;
-        border: none;
+  &__inkwell {
+    background-color: @gray-dark;
+    color: @white;
+    border: none;
 
-        a {
-            // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.
-            .u-link__colors( @pacific-40, @teal-40, @pacific-50, @pacific-40, @navy-40 );
-        }
-
-        // If an inkwell contains a tagline, properly lay it out.
-        .a-tagline {
-            margin-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-            max-width: 41.875rem;
-        }
+    a {
+      // Arguments: default, `:visited`, `:hover`, `:focus`, and `:active` states.
+      .u-link__colors( @pacific-40, @teal-40, @pacific-50, @pacific-40, @navy-40 );
     }
+
+    // If an inkwell contains a tagline, properly lay it out.
+    .a-tagline {
+      margin-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+      max-width: 41.875rem;
+    }
+  }
 }

--- a/packages/cfpb-notifications/src/molecules/notification.less
+++ b/packages/cfpb-notifications/src/molecules/notification.less
@@ -3,71 +3,71 @@
 //
 
 .m-notification {
-    display: none;
-    position: relative;
-    padding: @notification-padding__px;
-    background: @notification-bg;
-    border: 1px solid @notification-border;
+  display: none;
+  position: relative;
+  padding: @notification-padding__px;
+  background: @notification-bg;
+  border: 1px solid @notification-border;
 
-    & > .cf-icon-svg {
-        position: absolute;
-        fill: @notification-icon;
+  & > .cf-icon-svg {
+    position: absolute;
+    fill: @notification-icon;
+  }
+
+  &__success {
+    background: @notification-bg-success;
+    border-color: @notification-border-success;
+
+    .cf-icon-svg {
+      fill: @notification-icon-success;
     }
+  }
 
-    &__success {
-        background: @notification-bg-success;
-        border-color: @notification-border-success;
+  &__warning {
+    background: @notification-bg-warning;
+    border-color: @notification-border-warning;
 
-        .cf-icon-svg {
-            fill: @notification-icon-success;
-        }
+    .cf-icon-svg {
+      fill: @notification-icon-warning;
     }
+  }
 
-    &__warning {
-        background: @notification-bg-warning;
-        border-color: @notification-border-warning;
+  &__error {
+    background: @notification-bg-error;
+    border-color: @notification-border-error;
 
-        .cf-icon-svg {
-            fill: @notification-icon-warning;
-        }
+    .cf-icon-svg {
+      fill: @notification-icon-error;
     }
+  }
 
-    &__error {
-        background: @notification-bg-error;
-        border-color: @notification-border-error;
+  &__visible {
+    display: block;
+  }
 
-        .cf-icon-svg {
-            fill: @notification-icon-error;
-        }
-    }
+  // Only adding left padding if an icon is present.
+  .cf-icon-svg + &_content {
+    padding-left: unit( 25px / @base-font-size-px, em );
+  }
 
-    &__visible {
-        display: block;
-    }
+  &_message {
+    margin-bottom: 0;
+  }
 
-    // Only adding left padding if an icon is present.
-    .cf-icon-svg + &_content {
-        padding-left: unit( 25px / @base-font-size-px, em );
-    }
+  &_explanation {
+    margin-top: unit( 5px / @base-font-size-px, em );
+    margin-bottom: unit( 15px / @base-font-size-px, em );
+  }
 
-    &_message {
-        margin-bottom: 0;
-    }
+  // We need to provide a margin for links if an explanation is absent.
+  &_message + .m-list {
+    margin-top: unit( 15px / @base-font-size-px, em );
+  }
 
-    &_explanation {
-        margin-top: unit( 5px / @base-font-size-px, em );
-        margin-bottom: unit( 15px / @base-font-size-px, em );
-    }
+  // Make adjustments to the icon, explanation, and links if at non-mobile.
+  .respond-to-min( @bp-sm-min, {
 
-    // We need to provide a margin for links if an explanation is absent.
-    &_message + .m-list {
-        margin-top: unit( 15px / @base-font-size-px, em );
-    }
-
-    // Make adjustments to the icon, explanation, and links if at non-mobile.
-    .respond-to-min( @bp-sm-min, {
-
-        // Increase the icon size.
+    // Increase the icon size.
         .cf-icon-svg {
             font-size: unit( @size-iv / @base-font-size-px, em );
         }

--- a/packages/cfpb-notifications/src/organisms/banner.less
+++ b/packages/cfpb-notifications/src/organisms/banner.less
@@ -7,23 +7,23 @@
 //
 
 .o-banner {
-    padding: unit( @grid_gutter-width / 2 / @base-font-size-px, em ) 0;
-    background: @gold-10;
-    border-bottom: 1px solid @gray-40;
-    font-size: 0.875em;
+  padding: unit( @grid_gutter-width / 2 / @base-font-size-px, em ) 0;
+  background: @gold-10;
+  border-bottom: 1px solid @gray-40;
+  font-size: 0.875em;
 
-    // Override notification box styling to align notification in header.
-    .m-notification {
-        border: none;
-        padding: 0;
+  // Override notification box styling to align notification in header.
+  .m-notification {
+    border: none;
+    padding: 0;
 
-        &_icon {
-            left: 0;
-            top: 0;
-        }
+    &_icon {
+      left: 0;
+      top: 0;
     }
+  }
 
-    .respond-to-min( @bp-sm-min, {
-        font-size: 1em;
+  .respond-to-min( @bp-sm-min, {
+    font-size: 1em;
     } );
 }

--- a/packages/cfpb-pagination/src/molecules/pagination.less
+++ b/packages/cfpb-pagination/src/molecules/pagination.less
@@ -3,70 +3,70 @@
 //
 
 .m-pagination {
-    position: relative;
+  position: relative;
 
-    &_form {
-        padding: unit( 5px / @base-font-size-px, em );
-        border-radius: unit( 4px / @base-font-size-px, em );
-        background: @pagination-bg;
-        color: @pagination-text;
-        text-align: center;
+  &_form {
+    padding: unit( 5px / @base-font-size-px, em );
+    border-radius: unit( 4px / @base-font-size-px, em );
+    background: @pagination-bg;
+    color: @pagination-text;
+    text-align: center;
+  }
+
+  &_current-page {
+    // 45px is a magic number to provide enough room for three digits
+    // and the number spinners for type="number" inputs on desktop
+    width: unit( 45px / @base-font-size-px, em );
+
+    // 10px + a normal inline single space ~= spec'ed value of 15px
+    margin-right: unit( 10px / @base-font-size-px, em );
+    margin-left: unit( 10px / @base-font-size-px, em );
+    font-weight: 500;
+    text-align: right;
+  }
+
+  &_label {
+    display: inline-block;
+
+    // 10px + a normal inline single space ~= spec'ed value of 15px
+    margin-right: unit( 10px / @base-font-size-px, em );
+    vertical-align: middle;
+  }
+
+  &_btn-submit {
+    margin: 0;
+    vertical-align: middle;
+  }
+
+  &_btn-prev,
+  &_btn-next {
+    min-width: @pagination-btn-min-width-px;
+
+    // 22px is a magic number to vertically center the type in the button
+    // TODO: Consider refactoring with flexbox for vertical centering
+    line-height: 22px;
+    text-align: center;
+
+    &.a-btn__disabled {
+      background-color: @pagination-bg;
+      border-color: transparent;
     }
+  }
 
-    &_current-page {
-        // 45px is a magic number to provide enough room for three digits
-        // and the number spinners for type="number" inputs on desktop
-        width: unit( 45px / @base-font-size-px, em );
+  &_btn-next {
+    position: absolute;
+    right: 0;
+  }
 
-        // 10px + a normal inline single space ~= spec'ed value of 15px
-        margin-right: unit( 10px / @base-font-size-px, em );
-        margin-left: unit( 10px / @base-font-size-px, em );
-        font-weight: 500;
-        text-align: right;
-    }
-
-    &_label {
-        display: inline-block;
-
-        // 10px + a normal inline single space ~= spec'ed value of 15px
-        margin-right: unit( 10px / @base-font-size-px, em );
-        vertical-align: middle;
-    }
-
-    &_btn-submit {
-        margin: 0;
-        vertical-align: middle;
-    }
-
+  .respond-to-max( @bp-xs-max, {
     &_btn-prev,
-    &_btn-next {
-        min-width: @pagination-btn-min-width-px;
-
-        // 22px is a magic number to vertically center the type in the button
-        // TODO: Consider refactoring with flexbox for vertical centering
-        line-height: 22px;
-        text-align: center;
-
-        &.a-btn__disabled {
-            background-color: @pagination-bg;
-            border-color: transparent;
-        }
-    }
-
-    &_btn-next {
-        position: absolute;
-        right: 0;
-    }
-
-    .respond-to-max( @bp-xs-max, {
-        &_btn-prev,
         &_btn-next {
             margin-bottom: unit( 15px / @base-font-size-px, em );
         }
     } );
 
-    .respond-to-min( @bp-sm-min, {
-        &_btn-prev,
+  .respond-to-min( @bp-sm-min, {
+    &_btn-prev,
         &_btn-next {
             height: 100%;
         }

--- a/packages/cfpb-tables/src/cfpb-tables.less
+++ b/packages/cfpb-tables/src/cfpb-tables.less
@@ -22,21 +22,21 @@
 
 // Mixins
 .striped-table() {
-    & > tbody > tr:nth-child( even ) {
-        & > th,
-        & > td {
-            background: @table-cell-bg_alt;
-        }
+  & > tbody > tr:nth-child( even ) {
+    & > th,
+    & > td {
+      background: @table-cell-bg_alt;
     }
+  }
 }
 
 .o-table_cell__right-align {
-    text-align: right;
+  text-align: right;
 }
 
 .o-table__row-links {
-    .respond-to-min( @bp-med-min, {
-        tr:hover {
+  .respond-to-min( @bp-med-min, {
+    tr:hover {
             td {
                 background: @table-row-link-bg-hover;
                 color: @table-row-link-hover-color;
@@ -50,72 +50,72 @@
 }
 
 .o-table-wrapper__scrolling {
-    box-sizing: border-box;
-    overflow-y: hidden;
-    table {
-        border: 1px solid @table-scrolling-border;
-        .striped-table();
-    }
+  box-sizing: border-box;
+  overflow-y: hidden;
+  table {
+    border: 1px solid @table-scrolling-border;
+    .striped-table();
+  }
 }
 
 .o-table__sortable {
-    button.sortable {
-        width: 100%;
-        height: 100%;
-        padding: 0;
-        margin: 0;
-        border: none;
-        background: none;
-        font-family: inherit;
-        font-weight: inherit;
-        line-height: inherit;
-        outline: none;
-        text-align: left;
-        text-transform: inherit;
+  button.sortable {
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    margin: 0;
+    border: none;
+    background: none;
+    font-family: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    outline: none;
+    text-align: left;
+    text-transform: inherit;
 
-        &:after {
-            .u-svg-inline-bg( 'down' );
+    &:after {
+      .u-svg-inline-bg( 'down' );
 
-            display: inline-block;
-            position: relative;
-            vertical-align: bottom;
-            content: '';
-            visibility: hidden;
-            background-size: auto @cf-icon-height;
-            background-repeat: no-repeat;
-            background-position: center center;
-            height: @cf-icon-height;
-            width: 1em;
-        }
+      display: inline-block;
+      position: relative;
+      vertical-align: bottom;
+      content: '';
+      visibility: hidden;
+      background-size: auto @cf-icon-height;
+      background-repeat: no-repeat;
+      background-position: center center;
+      height: @cf-icon-height;
+      width: 1em;
     }
+  }
 
-    .sortable:hover:after,
-    .sortable.sorted-up:after,
-    .sortable.sorted-down:after {
-        visibility: visible;
-    }
+  .sortable:hover:after,
+  .sortable.sorted-up:after,
+  .sortable.sorted-down:after {
+    visibility: visible;
+  }
 
-    .sortable.sorted-down:after,
-    .sortable.sorted-up:hover:after {
-        top: 1px;
-        transform: rotate( 180deg );
-    }
+  .sortable.sorted-down:after,
+  .sortable.sorted-up:hover:after {
+    top: 1px;
+    transform: rotate( 180deg );
+  }
 
-    .sortable.sorted-up:after,
-    .sortable.sorted-down:hover:after {
-        top: -1px;
-        transform: rotate( 0deg );
-    }
+  .sortable.sorted-up:after,
+  .sortable.sorted-down:hover:after {
+    top: -1px;
+    transform: rotate( 0deg );
+  }
 }
 
 .respond-to-min( @bp-sm-min, {
-    .o-table__striped {
+  .o-table__striped {
         .striped-table();
     }
 } );
 
 .respond-to-max( @bp-xs-max, {
-    .o-table {
+  .o-table {
         width: 100%;
     }
 

--- a/packages/cfpb-typography/src/atoms/date.less
+++ b/packages/cfpb-typography/src/atoms/date.less
@@ -1,6 +1,6 @@
 .a-date {
-    .heading-5( @text-shadow: @date );
+  .heading-5( @text-shadow: @date );
 
-    color: @date;
-    white-space: nowrap;
+  color: @date;
+  white-space: nowrap;
 }

--- a/packages/cfpb-typography/src/atoms/headings.less
+++ b/packages/cfpb-typography/src/atoms/headings.less
@@ -1,15 +1,15 @@
 .a-heading__icon {
-    .heading-4();
+  .heading-4();
 
-    color: @heading__icon;
+  color: @heading__icon;
 
-    a& {
-        .u-link__colors( @heading__icon, @heading__icon__hover );
+  a& {
+    .u-link__colors( @heading__icon, @heading__icon__hover );
 
-        border-width: 0;
-    }
+    border-width: 0;
+  }
 
-    .cf-icon {
-        margin-right: unit( 2px / @font-size, em );
-    }
+  .cf-icon {
+    margin-right: unit( 2px / @font-size, em );
+  }
 }

--- a/packages/cfpb-typography/src/atoms/links.less
+++ b/packages/cfpb-typography/src/atoms/links.less
@@ -5,16 +5,16 @@
 
 .a-link__icon,
 .a-link__jump {
-    border-bottom-width: 0;
+  border-bottom-width: 0;
 
-    .a-link_text {
-        border-bottom-width: 1px;
-        border-bottom-style: inherit;
-    }
+  .a-link_text {
+    border-bottom-width: 1px;
+    border-bottom-style: inherit;
+  }
 
-    &.a-link__no-wrap {
-        white-space: nowrap;
-    }
+  &.a-link__no-wrap {
+    white-space: nowrap;
+  }
 }
 
 //
@@ -22,14 +22,14 @@
 //
 
 .a-link__jump {
-    font-weight: 500;
+  font-weight: 500;
 
-    &.a-link__large {
-        font-size: unit( @size-iv / @base-font-size-px, em );
-    }
+  &.a-link__large {
+    font-size: unit( @size-iv / @base-font-size-px, em );
+  }
 
-    .respond-to-max( @bp-xs-max, {
-        .u-block-link();
+  .respond-to-max( @bp-xs-max, {
+    .u-block-link();
 
         position: relative;
 
@@ -92,17 +92,17 @@
  */
 
 .u-block-link {
-    box-sizing: border-box;
-    display: block;
-    padding-top: unit( 10px / @base-font-size-px, em );
-    padding-bottom: unit( 10px / @base-font-size-px, em );
-    border-top-width: 1px;
-    border-bottom-width: 1px;
-    // 100% width is needed when block or jump link are applied to a <button>
-    width: 100%;
-    text-align: left;
+  box-sizing: border-box;
+  display: block;
+  padding-top: unit( 10px / @base-font-size-px, em );
+  padding-bottom: unit( 10px / @base-font-size-px, em );
+  border-top-width: 1px;
+  border-bottom-width: 1px;
+  // 100% width is needed when block or jump link are applied to a <button>
+  width: 100%;
+  text-align: left;
 
-    .a-link_text {
-        border-bottom-width: 0;
-    }
+  .a-link_text {
+    border-bottom-width: 0;
+  }
 }

--- a/packages/cfpb-typography/src/atoms/micro-copy.less
+++ b/packages/cfpb-typography/src/atoms/micro-copy.less
@@ -1,4 +1,4 @@
 .a-micro-copy {
-    color: @micro-copy;
-    font-size: unit( @size-v / @base-font-size-px, em );
+  color: @micro-copy;
+  font-size: unit( @size-v / @base-font-size-px, em );
 }

--- a/packages/cfpb-typography/src/atoms/tagline.less
+++ b/packages/cfpb-typography/src/atoms/tagline.less
@@ -1,62 +1,62 @@
 .a-tagline {
 
-    font-size: unit( 12px / @base-font-size-px, rem );
+  font-size: unit( 12px / @base-font-size-px, rem );
 
-    display: grid;
-    grid-template-columns: 22px 1fr;
-    grid-column-gap: 10px;
+  display: grid;
+  grid-template-columns: 22px 1fr;
+  grid-column-gap: 10px;
 
-    &_text {
-        // Needed for browsers with legacy/no grid support (e.g. IE11).
-        display: inline-block;
-    }
+  &_text {
+    // Needed for browsers with legacy/no grid support (e.g. IE11).
+    display: inline-block;
+  }
+
+  & .u-usa-flag {
+    margin-top: 1px;
+  }
+
+  &__large {
 
     & .u-usa-flag {
-        margin-top: 1px;
+      margin-top: 4px;
     }
 
-    &__large {
+    font-size: unit( 16px / @base-font-size-px, rem );
+  }
 
-        & .u-usa-flag {
-            margin-top: 4px;
-        }
+  &__xlarge {
 
-        font-size: unit( 16px / @base-font-size-px, rem );
+    & .u-usa-flag {
+      margin-top: 6px;
+
+      // Should not be greater than the source image size of 80x50.
+      width: 40px;
+      height: 21px;
+      // 80px x 42px USA flag image.
+      background-image: url( 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAAqCAMAAAATdiw4AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAADlQTFRF////sxlC2YyhCjFhKUt1R2WJGT5rhZiwOFh/Zn6co7LEdYum0djhV3GS8PL1wszYsr/O4OXrlKW6gKQKnwAAAUhJREFUeNrslM2OwzAIhN2OHf/HSd//YXfYqGroZWWUS9XlgPgOGRmY4IAFjOXIr/Qsb5PhkEbglzHy4zAS3tkg6CIFWqNAdCKoeV7Qp4SIEJhS8iFohpsNGVVxGciuAH7f/ZlhEUzo0TNiZ1mrZoNgXuVlrcnLVnmZ5vtkcIYj0x6lMOXhl0WzYSmM2DrQG7frS/Fnhk2wrlTxa2U5hmZDy6kE9lkruw0lea/ZsJTkHjTyvtPIj8PYiucF6WVk9M7062rNNmNvjuOqbpPByfhebFpKQj6MnFnGqNkgWNftaeRNFvvGhuMwKj28bUz1MPaZbTOMTX65s7GfDKOgEyPLHURrmi2CD7DR3tmslF6z4U8JcvcOIxfH6//GhqV0qiBzaghdWtU8LRj+iOmWvzBuF8cHCH5h3C+OD9jy5S3/H4cvOA4/AgwAabgYexE/bU4AAAAASUVORK5CYII=' );
     }
 
-    &__xlarge {
+    font-size: unit( 26px / @base-font-size-px, rem );
+    grid-template-columns: 40px 1fr;
+    grid-column-gap: 30px;
 
-        & .u-usa-flag {
-            margin-top: 6px;
-
-            // Should not be greater than the source image size of 80x50.
-            width: 40px;
-            height: 21px;
-            // 80px x 42px USA flag image.
-            background-image: url( 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAAqCAMAAAATdiw4AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAADlQTFRF////sxlC2YyhCjFhKUt1R2WJGT5rhZiwOFh/Zn6co7LEdYum0djhV3GS8PL1wszYsr/O4OXrlKW6gKQKnwAAAUhJREFUeNrslM2OwzAIhN2OHf/HSd//YXfYqGroZWWUS9XlgPgOGRmY4IAFjOXIr/Qsb5PhkEbglzHy4zAS3tkg6CIFWqNAdCKoeV7Qp4SIEJhS8iFohpsNGVVxGciuAH7f/ZlhEUzo0TNiZ1mrZoNgXuVlrcnLVnmZ5vtkcIYj0x6lMOXhl0WzYSmM2DrQG7frS/Fnhk2wrlTxa2U5hmZDy6kE9lkruw0lea/ZsJTkHjTyvtPIj8PYiucF6WVk9M7062rNNmNvjuOqbpPByfhebFpKQj6MnFnGqNkgWNftaeRNFvvGhuMwKj28bUz1MPaZbTOMTX65s7GfDKOgEyPLHURrmi2CD7DR3tmslF6z4U8JcvcOIxfH6//GhqV0qiBzaghdWtU8LRj+iOmWvzBuF8cHCH5h3C+OD9jy5S3/H4cvOA4/AgwAabgYexE/bU4AAAAASUVORK5CYII=' );
-        }
-
-        font-size: unit( 26px / @base-font-size-px, rem );
-        grid-template-columns: 40px 1fr;
-        grid-column-gap: 30px;
-
-        // Mobile size.
-        .respond-to-max( @bp-xs-max, {
-            font-size: unit( 22px / @base-font-size-px, rem );
+    // Mobile size.
+    .respond-to-max( @bp-xs-max, {
+      font-size: unit( 22px / @base-font-size-px, rem );
             grid-template-columns: initial;
             grid-template-rows: 22px 1fr;
             grid-row-gap: 30px;
         } );
-    }
+  }
 }
 
 // Standard flag size. Gets overwritten in the xlarge tagline.
 .u-usa-flag {
-    display: inline-block;
-    width: 24px;
-    height: 13px;
-    // 48px x 25px USA flag image.
-    background-image: url( 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAZCAMAAABAf11LAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAE5QTFRF////sxlC7MbQ2YyhxlNxCjFhR2WJV3GSKUt1dYumOFh/GT5rhZiwwszYsr/OlKW6Zn6c0djh8PL1iR9Ko7LE4OXrl0pttKC0pXWRtYKbSuJhRQAAANFJREFUeNrkkctuwyAUREnSuW/ApHYf//+jBVdZVcJi3aORgAXcMyLBAAJEzsVG3m8TkifyI3zfPQ6nJJLo421CArSBmkgjNEWtQE4zXJmClXuCWIlU5hdQxCqbqnE1KdIz79CVDvBwZxyKfQfmHTyzl01UZSvOWSTbhZLSWeDMufWLC/1ls3amT4qQq394EjIjApxBT+/nr8eEBNuKcB9SWMpmEXalNOylmlUZNTr4vE/4VdKhpC+leQf6y/e0wzL3RdJtkfUJyzwW+ZcdfgQYAJmJD3zerW6OAAAAAElFTkSuQmCC' );
-    background-size: contain;
-    background-repeat: no-repeat;
+  display: inline-block;
+  width: 24px;
+  height: 13px;
+  // 48px x 25px USA flag image.
+  background-image: url( 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAZCAMAAABAf11LAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAE5QTFRF////sxlC7MbQ2YyhxlNxCjFhR2WJV3GSKUt1dYumOFh/GT5rhZiwwszYsr/OlKW6Zn6c0djh8PL1iR9Ko7LE4OXrl0pttKC0pXWRtYKbSuJhRQAAANFJREFUeNrkkctuwyAUREnSuW/ApHYf//+jBVdZVcJi3aORgAXcMyLBAAJEzsVG3m8TkifyI3zfPQ6nJJLo421CArSBmkgjNEWtQE4zXJmClXuCWIlU5hdQxCqbqnE1KdIz79CVDvBwZxyKfQfmHTyzl01UZSvOWSTbhZLSWeDMufWLC/1ls3amT4qQq394EjIjApxBT+/nr8eEBNuKcB9SWMpmEXalNOylmlUZNTr4vE/4VdKhpC+leQf6y/e0wzL3RdJtkfUJyzwW+ZcdfgQYAJmJD3zerW6OAAAAAElFTkSuQmCC' );
+  background-size: contain;
+  background-repeat: no-repeat;
 }

--- a/packages/cfpb-typography/src/licensed-fonts.less
+++ b/packages/cfpb-typography/src/licensed-fonts.less
@@ -4,87 +4,87 @@
    ========================================================================== */
 
 .generate-font-face-rules( @use-font-cdn ) when ( @use-font-cdn = 'true' ) {
-    @font-face {
-        font-family: 'AvenirNextLTW01-Regular';
-        src:
+  @font-face {
+    font-family: 'AvenirNextLTW01-Regular';
+    src:
             url( '//fast.fonts.net/dv2/14/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff2' ),
             url( '//fast.fonts.net/dv2/3/1e9892c0-6927-4412-9874-1b82801ba47a.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
-        font-style: normal;
-        font-weight: normal;
-        font-display: fallback;
-    }
+    font-style: normal;
+    font-weight: normal;
+    font-display: fallback;
+  }
 
-    @font-face {
-        font-family: 'AvenirNextLTW01-Medium';
-        src:
+  @font-face {
+    font-family: 'AvenirNextLTW01-Medium';
+    src:
             url( '//fast.fonts.net/dv2/14/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff2' ),
             url( '//fast.fonts.net/dv2/3/f26faddb-86cc-4477-a253-1e1287684336.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
-        font-style: normal;
-        font-weight: 500;
-        font-display: fallback;
-    }
+    font-style: normal;
+    font-weight: 500;
+    font-display: fallback;
+  }
 
-    @font-face {
-        font-family: 'Avenir Next';
-        src:
+  @font-face {
+    font-family: 'Avenir Next';
+    src:
             url( '//fast.fonts.net/dv2/14/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff2' ),
             url( '//fast.fonts.net/dv2/3/1e9892c0-6927-4412-9874-1b82801ba47a.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
-        font-style: normal;
-        font-weight: normal;
-        font-display: fallback;
-    }
+    font-style: normal;
+    font-weight: normal;
+    font-display: fallback;
+  }
 
-    @font-face {
-        font-family: 'Avenir Next';
-        src:
+  @font-face {
+    font-family: 'Avenir Next';
+    src:
             url( '//fast.fonts.net/dv2/14/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff2' ),
             url( '//fast.fonts.net/dv2/3/f26faddb-86cc-4477-a253-1e1287684336.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
-        font-style: normal;
-        font-weight: 500;
-        font-display: fallback;
-    }
+    font-style: normal;
+    font-weight: 500;
+    font-display: fallback;
+  }
 }
 
 .generate-font-face-rules( @use-font-cdn ) when ( @use-font-cdn = 'false' ) {
-    @font-face {
-        font-family: 'AvenirNextLTW01-Regular';
-        src:
+  @font-face {
+    font-family: 'AvenirNextLTW01-Regular';
+    src:
             url( '@{cf-fonts-path}/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2' ) format( 'woff2' ),
             url( '@{cf-fonts-path}/1e9892c0-6927-4412-9874-1b82801ba47a.woff' ) format( 'woff' );
-        font-style: normal;
-        font-weight: normal;
-        font-display: fallback;
-    }
+    font-style: normal;
+    font-weight: normal;
+    font-display: fallback;
+  }
 
-    @font-face {
-        font-family: 'AvenirNextLTW01-Medium';
-        src:
+  @font-face {
+    font-family: 'AvenirNextLTW01-Medium';
+    src:
             url( '@{cf-fonts-path}/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2' ) format( 'woff2' ),
             url( '@{cf-fonts-path}/f26faddb-86cc-4477-a253-1e1287684336.woff' ) format( 'woff' );
-        font-style: normal;
-        font-weight: 500;
-        font-display: fallback;
-    }
+    font-style: normal;
+    font-weight: 500;
+    font-display: fallback;
+  }
 
-    @font-face {
-        font-family: 'Avenir Next';
-        src:
+  @font-face {
+    font-family: 'Avenir Next';
+    src:
             url( '@{cf-fonts-path}/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2' ) format( 'woff2' ),
             url( '@{cf-fonts-path}/1e9892c0-6927-4412-9874-1b82801ba47a.woff' ) format( 'woff' );
-        font-style: normal;
-        font-weight: normal;
-        font-display: fallback;
-    }
+    font-style: normal;
+    font-weight: normal;
+    font-display: fallback;
+  }
 
-    @font-face {
-        font-family: 'Avenir Next';
-        src:
+  @font-face {
+    font-family: 'Avenir Next';
+    src:
             url( '@{cf-fonts-path}/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2' ) format( 'woff2' ),
             url( '@{cf-fonts-path}/f26faddb-86cc-4477-a253-1e1287684336.woff' ) format( 'woff' );
-        font-style: normal;
-        font-weight: 500;
-        font-display: fallback;
-    }
+    font-style: normal;
+    font-weight: 500;
+    font-display: fallback;
+  }
 }
 
 // Mixin either local self-hosted font URLs or URLs from fonts.net.

--- a/packages/cfpb-typography/src/molecules/list.less
+++ b/packages/cfpb-typography/src/molecules/list.less
@@ -6,13 +6,13 @@
 .m-list__unstyled,
 .m-list__horizontal,
 .m-list__links {
-    padding-left: 0;
-    list-style-type: none;
+  padding-left: 0;
+  list-style-type: none;
 
-    // This is needed for dd elements.
-    .m-list_item {
-        margin-left: 0;
-    }
+  // This is needed for dd elements.
+  .m-list_item {
+    margin-left: 0;
+  }
 }
 
 //
@@ -20,10 +20,10 @@
 //
 
 .m-list__spaced {
-    .m-list__spaced,
-    .m-list_item + .m-list_item {
-        margin-top: unit( 24px / @base-font-size-px, em );
-    }
+  .m-list__spaced,
+  .m-list_item + .m-list_item {
+    margin-top: unit( 24px / @base-font-size-px, em );
+  }
 }
 
 //
@@ -31,14 +31,14 @@
 //
 
 .m-list__horizontal {
-    .m-list_item {
-        display: inline-block;
+  .m-list_item {
+    display: inline-block;
 
-        // Assuming a natural space of 4px between inline block items
-        // then the space between would be 8px (4px natural + 4px added).
-        margin-right: unit( 4px / @base-font-size-px, em );
-        margin-bottom: 0;
-    }
+    // Assuming a natural space of 4px between inline block items
+    // then the space between would be 8px (4px natural + 4px added).
+    margin-right: unit( 4px / @base-font-size-px, em );
+    margin-bottom: 0;
+  }
 }
 
 //
@@ -46,21 +46,21 @@
 //
 
 .m-list__links {
-    .m-list_item {
-        .respond-to-max( @bp-xs-max, {
-            margin-bottom: 0;
+  .m-list_item {
+    .respond-to-max( @bp-xs-max, {
+      margin-bottom: 0;
 
             &:nth-child( n+2 ) .m-list_link {
                 border-top-width: 0;
             }
         } );
-    }
+  }
 
-    .m-list_link {
-        font-weight: 500;
+  .m-list_link {
+    font-weight: 500;
 
-        .respond-to-max( @bp-xs-max, {
-            .u-block-link();
+    .respond-to-max( @bp-xs-max, {
+      .u-block-link();
         } );
-    }
+  }
 }

--- a/packages/cfpb-typography/src/molecules/meta-header.less
+++ b/packages/cfpb-typography/src/molecules/meta-header.less
@@ -1,10 +1,10 @@
 .m-meta-header {
-    padding-bottom: unit( 10px / @base-font-size-px, em );
-    border-bottom: 1px solid @meta-header_border;
-    overflow: auto;
+  padding-bottom: unit( 10px / @base-font-size-px, em );
+  border-bottom: 1px solid @meta-header_border;
+  overflow: auto;
 
-    .respond-to-min( @bp-sm-min, {
-        .u-clearfix();
+  .respond-to-min( @bp-sm-min, {
+    .u-clearfix();
 
         &_left {
             float: left;
@@ -15,7 +15,7 @@
         }
     } );
 
-    .a-heading {
-        margin-bottom: 0;
-    }
+  .a-heading {
+    margin-bottom: 0;
+  }
 }

--- a/packages/cfpb-typography/src/molecules/pull-quote.less
+++ b/packages/cfpb-typography/src/molecules/pull-quote.less
@@ -1,31 +1,31 @@
 .m-pull-quote {
 
-    &_body {
-        .heading-3();
+  &_body {
+    .heading-3();
 
-        color: @pull-quote_body;
+    color: @pull-quote_body;
 
-        .respond-to-max( @bp-xs-max, {
-            .heading-4();
+    .respond-to-max( @bp-xs-max, {
+      .heading-4();
         } );
+  }
+
+  &_citation {
+    .heading-5( @text-shadow: @pull-quote_citation );
+
+    color: @pull-quote_citation;
+
+    &:before {
+      // An em dash before the cited author name.
+      content: '\2014 ';
     }
+  }
 
-    &_citation {
-        .heading-5( @text-shadow: @pull-quote_citation );
+  &__large .m-pull-quote_body {
+    .heading-2();
 
-        color: @pull-quote_citation;
-
-        &:before {
-            // An em dash before the cited author name.
-            content: '\2014 ';
-        }
-    }
-
-    &__large .m-pull-quote_body {
-        .heading-2();
-
-        .respond-to-max( @bp-xs-max, {
-            .heading-3();
+    .respond-to-max( @bp-xs-max, {
+      .heading-3();
         } );
-    }
+  }
 }

--- a/packages/cfpb-typography/src/molecules/slug-header.less
+++ b/packages/cfpb-typography/src/molecules/slug-header.less
@@ -1,12 +1,12 @@
 .m-slug-header {
-    border-top: 1px solid @slug-header_border__thin;
+  border-top: 1px solid @slug-header_border__thin;
 
-    .a-heading {
-        .heading-5();
+  .a-heading {
+    .heading-5();
 
-        display: inline-block;
-        padding-top: unit( 4px / @font-size, em );
-        border-top: 5px solid @slug-header_border__thick;
-        margin-top: -3px;
-    }
+    display: inline-block;
+    padding-top: unit( 4px / @font-size, em );
+    border-top: 5px solid @slug-header_border__thick;
+    margin-top: -3px;
+  }
 }

--- a/scripts/gulp/lint.js
+++ b/scripts/gulp/lint.js
@@ -74,10 +74,7 @@ function lintStyles() {
   // Pass all command line flags to Stylelint.
   const options = minimist( process.argv.slice( 2 ) );
   const willFix = options.fix || false;
-  return gulp.src( [
-    'packages/**/*.less',
-    '!packages/**/node_modules/**/*.less'
-  ] )
+  return gulp.src( [ 'packages/**/*.less' ] )
     .pipe( gulpStylelint( {
       failAfterError: true,
       fix: willFix,

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -2,41 +2,32 @@
 at-rule-no-unknown -
   This rule enforces only @ rules that appear in the CSS spec,
   however, @plugin appears in Less, so should be ignored.
-
 declaration-colon-newline-after -
   Turned off because it messes with our format for multi-line declarations.
-
 function-parentheses-space-inside -
   Custom setting that differs from stylelint-config-standard.
-
 rule-empty-line-before -
   Custom setting that differs from stylelint-config-standard.
-
 max-empty-lines -
   Set to 2 since we have existing two line breaks in place. Could be removed.
-
 no-descending-specificity -
   Turned off, but probably shouldn't be.
   TODO: Turn on this rule and see if issues can be fixed.
-
 selector-list-comma-newline-after -
   Turned off because it wraps arguments in Less mixin declarations.
-
 selector-pseudo-element-colon-notation -
   Set to 'single' to support IE8.
   Remove this rule after dropping IE8 CSS support.
 */
 module.exports = {
   'extends': 'stylelint-config-standard',
+  'ignoreFiles': [ 'packages/**/node_modules/**/*.less' ],
   'syntax': 'less',
   'rules': {
     'at-rule-no-unknown': [ true, { ignoreAtRules: 'plugin' } ],
     'declaration-colon-newline-after': null,
     'declaration-empty-line-before': null,
-    'function-name-case': [
-      'lower',
-      { ignoreFunctions: [ 'filter' ]}
-    ],
+    'function-name-case': [ 'lower', { ignoreFunctions: [ 'filter' ]} ],
     'function-parentheses-space-inside': 'always',
     'rule-empty-line-before': [
       'always-multi-line',
@@ -46,7 +37,7 @@ module.exports = {
       }
     ],
     'indentation': [
-      4,
+      2,
       {
         ignore: 'value'
       }


### PR DESCRIPTION
## Changes

- Change stylelint default to 2 spaces from 4 spaces to align it with JavaScript standard.
- Move ignored file path to styelint config file (prep for probable removal of gulp-stylelint in the future).

## Testing

1. PR checks should pass.

## Notes

- We might want to update this in cfgov too before merging this.
