### PR TITLE
Stylelint: Ignore less/color-no-invalid-hex and less/no-duplicate-variables rules

### DIFF
--- a/packages/cfpb-core/src/media-queries.less
+++ b/packages/cfpb-core/src/media-queries.less
@@ -6,8 +6,6 @@
 //
 // Media query mixins
 //
-// TODO: Latest stylelint does not handle the @rules parameter. Refactor.
-/* stylelint-disable less/color-no-invalid-hex */
 .respond-to-min( @bp, @rules ) {
   @ems: unit( ( @bp / @base-font-size-px ), em );
 
@@ -49,8 +47,6 @@
     @rules();
   }
   .print & {
-    /* stylelint-disable-next-line less/no-duplicate-variables */
     @rules();
   }
 }
-/* stylelint-enable less/color-no-invalid-hex */

--- a/packages/cfpb-forms/src/organisms/form.less
+++ b/packages/cfpb-forms/src/organisms/form.less
@@ -32,13 +32,11 @@
         border-right-width: 0;
       } );
 
-      /* stylelint-disable less/no-duplicate-variables */
       .respond-to-min( 960px, {
         .grid_column( 10 );
 
         border-right-width: 0;
       } );
-      /* stylelint-enable less/no-duplicate-variables */
 
       .a-text-input {
         box-sizing: border-box;
@@ -61,11 +59,9 @@
         .grid_column( 3 );
       } );
 
-      /* stylelint-disable less/no-duplicate-variables */
       .respond-to-min( 960px, {
         .grid_column( 2 );
       } );
-      /* stylelint-enable less/no-duplicate-variables */
 
       .a-btn {
         box-sizing: border-box;

--- a/packages/cfpb-layout/src/cfpb-layout.less
+++ b/packages/cfpb-layout/src/cfpb-layout.less
@@ -77,13 +77,11 @@
       .stack-col( content-l_col-1-2 );
     } );
 
-    /* stylelint-disable less/no-duplicate-variables */
     .respond-to-range( @bp-sm-min, @bp-sm-max, {
       .stack-col-thirds();
       .stack-col-eighths();
       .stack-col-quarters();
     } );
-    /* stylelint-enable less/no-duplicate-variables */
   }
 
   &__sidebar {
@@ -197,7 +195,6 @@
   }
 }
 
-/* stylelint-disable less/no-duplicate-variables */
 .stack-col-thirds() {
   .stack-col( content-l_col-1-3 );
   .stack-col( content-l_col-2-3 );
@@ -212,7 +209,6 @@
   .stack-col( content-l_col-1-4 );
   .stack-col( content-l_col-3-4 );
 }
-/* stylelint-enable less/no-duplicate-variables */
 
 //
 // Content line
@@ -253,7 +249,6 @@
     unit( @grid_gutter-width / @base-font-size-px, em )
     unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
 
-  /* stylelint-disable less/no-duplicate-variables */
   .respond-to-min( @bp-sm-min, {
     .grid_column( 12 );
 
@@ -323,7 +318,6 @@
     .grid_column( 7, @grid_total-columns, 0, 1 );
   }
 } );
-/* stylelint-enable less/no-duplicate-variables */
 
 .content__flush-bottom {
   padding-bottom: 0;

--- a/packages/cfpb-layout/src/molecules/heroes.less
+++ b/packages/cfpb-layout/src/molecules/heroes.less
@@ -27,13 +27,11 @@
       min-height: @hero-desktop-height - ( @grid_gutter-width * 2 );
     } );
 
-    /* stylelint-disable less/no-duplicate-variables */
     .respond-to-min( @bp-lg-min, {
       padding-top: unit( ( @grid_gutter-width * 1.5 ) / @base-font-size-px, em );
       padding-bottom: unit( ( @grid_gutter-width * 1.5 ) / @base-font-size-px, em );
       min-height: @hero-desktop-height - ( ( @grid_gutter-width * 1.5 ) * 2 );
     } );
-    /* stylelint-enable less/no-duplicate-variables */
   }
 
   &_text {
@@ -122,14 +120,12 @@
       }
     } );
 
-    /* stylelint-disable less/no-duplicate-variables */
     .respond-to-min( @bp-lg-min, {
       .m-hero_image-wrapper {
         margin-top: unit( ( @grid_gutter-width * 1.5 ) / @base-font-size-px, em ) * -1;
         margin-bottom: unit( ( @grid_gutter-width * 1.5 ) / @base-font-size-px, em ) * -1;
       }
     } );
-    /* stylelint-enable less/no-duplicate-variables */
   }
 
   &__overlay {
@@ -202,14 +198,12 @@
       }
     } );
 
-    /* stylelint-disable less/no-duplicate-variables */
     .respond-to-min( @bp-lg-min, {
       .m-hero_wrapper {
         // Enlarge the 50/50 height on large screens to maximize the image size
         min-height: @hero-desktop-height + ( @grid_gutter-width * 2 );
       }
     } );
-    /* stylelint-enable less/no-duplicate-variables */
   }
 }
 
@@ -220,7 +214,6 @@
     .lead-paragraph();
   }
 
-  /* stylelint-disable less/no-duplicate-variables */
   .respond-to-min( @bp-sm-min, {
     .m-hero_subhead {
       .heading-3();
@@ -238,5 +231,4 @@
       .heading-2();
     }
   } );
-  /* stylelint-enable less/no-duplicate-variables */
 }

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -18,6 +18,10 @@ selector-list-comma-newline-after -
 selector-pseudo-element-colon-notation -
   Set to 'single' to support IE8.
   Remove this rule after dropping IE8 CSS support.
+less/color-no-invalid-hex
+less/no-duplicate-variables
+  Both of the above settings are turned off till
+  https://github.com/ssivanatarajan/stylelint-less/issues/6 is addressed.
 */
 module.exports = {
   'extends': 'stylelint-config-recommended-less',
@@ -47,6 +51,8 @@ module.exports = {
     'no-descending-specificity': null,
     'selector-list-comma-newline-after': null,
     'selector-pseudo-class-parentheses-space-inside': 'always',
-    'selector-pseudo-element-colon-notation': 'single'
+    'selector-pseudo-element-colon-notation': 'single',
+    'less/color-no-invalid-hex': null,
+    'less/no-duplicate-variables': null
   }
 };


### PR DESCRIPTION
## Changes

- Stylelint: Ignore less/color-no-invalid-hex and less/no-duplicate-variables rules and remove ignore comments.

## Testing

1. `yarn run gulp lint:styles` should have no errors.
