### PR TITLE
Remove @use-font-cdn variable and logic

### DIFF
--- a/docs/assets/css/main.less
+++ b/docs/assets/css/main.less
@@ -25,8 +25,6 @@
 // Webfont variables
 // This is the path for self-hosted fonts.
 @cf-fonts-path: '/static/fonts';
-// Whether or not to override the local path and retrieve fonts from fonts.net.
-@use-font-cdn: true;
 
 // Documentation specific stlyes
 html, body {

--- a/docs/pages/variables.md
+++ b/docs/pages/variables.md
@@ -442,12 +442,4 @@ variation_groups:
 
           ```
 
-
-          If you want to load fonts from a Fonts.com Web Fonts project, set the following variable to true, otherwise set it to false to use the self-hosted font path:
-
-          ```
-
-          @use-font-cdn: true;
-
-          ```
 ---

--- a/packages/cfpb-typography/src/cfpb-typography.less
+++ b/packages/cfpb-typography/src/cfpb-typography.less
@@ -20,8 +20,6 @@
 // Webfont variables
 // This is the path for self-hosted fonts.
 @cf-fonts-path: '/static/fonts';
-// Whether or not to override the local path and retrieve fonts from fonts.net.
-@use-font-cdn: false;
 
 // Color variables
 

--- a/packages/cfpb-typography/src/licensed-fonts.less
+++ b/packages/cfpb-typography/src/licensed-fonts.less
@@ -3,89 +3,43 @@
    Licensed font URLs – for CFPB use only.
    ========================================================================== */
 
-.generate-font-face-rules( @use-font-cdn ) when ( @use-font-cdn = 'true' ) {
-  @font-face {
-    font-family: 'AvenirNextLTW01-Regular';
-    src:
-            url( '//fast.fonts.net/dv2/14/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff2' ),
-            url( '//fast.fonts.net/dv2/3/1e9892c0-6927-4412-9874-1b82801ba47a.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
-    font-style: normal;
-    font-weight: normal;
-    font-display: fallback;
-  }
 
-  @font-face {
-    font-family: 'AvenirNextLTW01-Medium';
-    src:
-            url( '//fast.fonts.net/dv2/14/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff2' ),
-            url( '//fast.fonts.net/dv2/3/f26faddb-86cc-4477-a253-1e1287684336.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
-    font-style: normal;
-    font-weight: 500;
-    font-display: fallback;
-  }
-
-  @font-face {
-    font-family: 'Avenir Next';
-    src:
-            url( '//fast.fonts.net/dv2/14/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff2' ),
-            url( '//fast.fonts.net/dv2/3/1e9892c0-6927-4412-9874-1b82801ba47a.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
-    font-style: normal;
-    font-weight: normal;
-    font-display: fallback;
-  }
-
-  @font-face {
-    font-family: 'Avenir Next';
-    src:
-            url( '//fast.fonts.net/dv2/14/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff2' ),
-            url( '//fast.fonts.net/dv2/3/f26faddb-86cc-4477-a253-1e1287684336.woff?d44f19a684109620e4841679af90e818b934c450213fb296d217dd76fbd8133e8104ffce1b8d7381e92baf075aac747ded01b441045f936c159eb0f46c11e1f99e958a3e0d6904164b21814766132f7cb38b46df85fb387875d6907338f619856e049c29c288424547a2ca329b1d0251faf8c505bae9c3ec3d5a1e4327f5fdf46ffb088d97582c65a45857e1e0662c2d545166a03c7b024ca17ac3839d703086c5f9fd694b6f5493360c3bcd9d5d427b599ea7651d27005ca2f4c1d0312515f51a323f79b7f5cf1afa2ab67a3ddbfee1&projectId=44e8c964-4684-44c6-a6e3-3f3da8787b50' ) format( 'woff' );
-    font-style: normal;
-    font-weight: 500;
-    font-display: fallback;
-  }
+@font-face {
+  font-family: 'AvenirNextLTW01-Regular';
+  src:
+          url( '@{cf-fonts-path}/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2' ) format( 'woff2' ),
+          url( '@{cf-fonts-path}/1e9892c0-6927-4412-9874-1b82801ba47a.woff' ) format( 'woff' );
+  font-style: normal;
+  font-weight: normal;
+  font-display: fallback;
 }
 
-.generate-font-face-rules( @use-font-cdn ) when ( @use-font-cdn = 'false' ) {
-  @font-face {
-    font-family: 'AvenirNextLTW01-Regular';
-    src:
-            url( '@{cf-fonts-path}/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2' ) format( 'woff2' ),
-            url( '@{cf-fonts-path}/1e9892c0-6927-4412-9874-1b82801ba47a.woff' ) format( 'woff' );
-    font-style: normal;
-    font-weight: normal;
-    font-display: fallback;
-  }
-
-  @font-face {
-    font-family: 'AvenirNextLTW01-Medium';
-    src:
-            url( '@{cf-fonts-path}/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2' ) format( 'woff2' ),
-            url( '@{cf-fonts-path}/f26faddb-86cc-4477-a253-1e1287684336.woff' ) format( 'woff' );
-    font-style: normal;
-    font-weight: 500;
-    font-display: fallback;
-  }
-
-  @font-face {
-    font-family: 'Avenir Next';
-    src:
-            url( '@{cf-fonts-path}/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2' ) format( 'woff2' ),
-            url( '@{cf-fonts-path}/1e9892c0-6927-4412-9874-1b82801ba47a.woff' ) format( 'woff' );
-    font-style: normal;
-    font-weight: normal;
-    font-display: fallback;
-  }
-
-  @font-face {
-    font-family: 'Avenir Next';
-    src:
-            url( '@{cf-fonts-path}/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2' ) format( 'woff2' ),
-            url( '@{cf-fonts-path}/f26faddb-86cc-4477-a253-1e1287684336.woff' ) format( 'woff' );
-    font-style: normal;
-    font-weight: 500;
-    font-display: fallback;
-  }
+@font-face {
+  font-family: 'AvenirNextLTW01-Medium';
+  src:
+          url( '@{cf-fonts-path}/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2' ) format( 'woff2' ),
+          url( '@{cf-fonts-path}/f26faddb-86cc-4477-a253-1e1287684336.woff' ) format( 'woff' );
+  font-style: normal;
+  font-weight: 500;
+  font-display: fallback;
 }
 
-// Mixin either local self-hosted font URLs or URLs from fonts.net.
-.generate-font-face-rules( '@{use-font-cdn}' );
+@font-face {
+  font-family: 'Avenir Next';
+  src:
+          url( '@{cf-fonts-path}/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2' ) format( 'woff2' ),
+          url( '@{cf-fonts-path}/1e9892c0-6927-4412-9874-1b82801ba47a.woff' ) format( 'woff' );
+  font-style: normal;
+  font-weight: normal;
+  font-display: fallback;
+}
+
+@font-face {
+  font-family: 'Avenir Next';
+  src:
+          url( '@{cf-fonts-path}/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2' ) format( 'woff2' ),
+          url( '@{cf-fonts-path}/f26faddb-86cc-4477-a253-1e1287684336.woff' ) format( 'woff' );
+  font-style: normal;
+  font-weight: 500;
+  font-display: fallback;
+}

--- a/packages/cfpb-typography/usage.md
+++ b/packages/cfpb-typography/usage.md
@@ -111,14 +111,6 @@ Can be either a relative or absolute path.
 @cf-fonts-path: '/fonts'
 ```
 
-If you want to load fonts from a Fonts.com Web Fonts project,
-set the following variable to `true`,
-otherwise set it to `false` to use the self-hosted font path:
-
-```
-@use-font-cdn: true;
-```
-
 
 ### Heading with icon
 


### PR DESCRIPTION
With fonts being shipped in cf.gov, we no longer need this variable or the associated logic.