### PR TITLE
Centralize text input with a button pattern in the design system

### DIFF
--- a/packages/cfpb-forms/src/organisms/form.less
+++ b/packages/cfpb-forms/src/organisms/form.less
@@ -32,12 +32,6 @@
         border-right-width: 0;
       } );
 
-      .respond-to-min( 960px, {
-        .grid_column( 10 );
-
-        border-right-width: 0;
-      } );
-
       .a-text-input {
         box-sizing: border-box;
         width: 100%;
@@ -55,18 +49,18 @@
     &_btn-container {
       margin-bottom: unit( ( 15px / @base-font-size-px ), em );
 
-      .respond-to-min( 480px, {
-        .grid_column( 3 );
-      } );
-
-      .respond-to-min( 960px, {
-        .grid_column( 2 );
-      } );
-
       .a-btn {
-        box-sizing: border-box;
         width: 100%;
       }
+
+      .respond-to-min( 480px, {
+        .grid_column( 3 );
+        border-left: 0;
+        .a-btn {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+        }
+      } );
     }
   }
 }


### PR DESCRIPTION
Currently our "text input with a button" pattern looks as follows:
<img width="831" alt="Screen Shot 2022-05-18 at 12 55 09 PM" src="https://user-images.githubusercontent.com/1558033/169099379-823c4957-af79-4a23-8ddf-a0edbb9c08f7.png">

However, everywhere this is used in cf.gov, we specifically add styles that make the button flush with the input, like this:
<img width="798" alt="Screen Shot 2022-05-18 at 12 51 52 PM" src="https://user-images.githubusercontent.com/1558033/169099698-c57779d3-9064-49d5-97f6-be571b60fadd.png">

This brings that behavior into the design-system. After merge and release, a follow-on PR to cf.gov will remove all that soon-to-be unneeded customization.