### PR TITLE
add data-cy attribute to multiselect options

### DIFF
--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -184,6 +184,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
       isChecked = _model.getOption( i ).checked;
       const optionsItemDom = MultiselectUtils.create( 'li', {
         'data-option': option.value,
+        'data-cy': 'multiselect-option'
         'class': 'm-form-field m-form-field__checkbox'
       } );
 

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -184,7 +184,7 @@ function Multiselect( element ) { // eslint-disable-line max-statements
       isChecked = _model.getOption( i ).checked;
       const optionsItemDom = MultiselectUtils.create( 'li', {
         'data-option': option.value,
-        'data-cy': 'multiselect-option'
+        'data-cy': 'multiselect-option',
         'class': 'm-form-field m-form-field__checkbox'
       } );
 


### PR DESCRIPTION
Our Cypress functional tests currently get elements by id or classname. By adding data-cy attributes, we can easily retrieve elements, and be sure that what we are searching those elements out by will not change.

## Additions

- Added a data-cy attribute to multiselect options

## Testing

1. Ensure data-cy element is added to multiselect options

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)