### PR TITLE
Add new dark banner variation

### DIFF
--- a/docs/pages/banners.md
+++ b/docs/pages/banners.md
@@ -22,12 +22,12 @@ variation_groups:
                           </p>
                           <ul class="m-list m-list__links">
                               <li class="m-list_item">
-                                  <a class="m-list_link" href="/">
+                                  <a class="m-list_link" href="#">
                                       A link can be added
                                   </a>
                               </li>
                               <li class="m-list_item">
-                                  <a class="m-list_link" href="/">
+                                  <a class="m-list_link" href="#">
                                       Multiple links are supported
                                   </a>
                               </li>
@@ -53,6 +53,18 @@ variation_groups:
                           <p class="m-notification_explanation">
                               An optional paragraph of text can be added to explain the purpose of the banner.
                           </p>
+                          <ul class="m-list m-list__links">
+                              <li class="m-list_item">
+                                  <a class="m-list_link" href="#test-link">
+                                      Links can be added
+                                  </a>
+                              </li>
+                              <li class="m-list_item">
+                                  <a class="m-list_link" href="#">
+                                      Visited links appear gray instead of white
+                                  </a>
+                              </li>
+                          </ul>
                       </div>
                   </div>
               </div>

--- a/docs/pages/banners.md
+++ b/docs/pages/banners.md
@@ -8,8 +8,39 @@ description: This component provides banner boxes at the top of a page's
   content. This is similar to a notification, but is intended to be full width.
 variation_groups:
   - variations:
-      - variation_code_snippet: |-
+      - variation_code_snippet: >-
           <div class="o-banner">
+              <div class="wrapper wrapper__match-content">
+                  <div class="m-notification
+                              m-notification__visible
+                              m-notification__warning">
+                      {% include icons/information-round.svg %}
+                      <div class="m-notification_content">
+                          <div class="h4 m-notification_message">A default banner with a notification</div>
+                          <p class="m-notification_explanation">
+                              An optional paragraph of text can be added to explain the purpose of the banner.
+                          </p>
+                          <ul class="m-list m-list__links">
+                              <li class="m-list_item">
+                                  <a class="m-list_link" href="/">
+                                      A link can be added
+                                  </a>
+                              </li>
+                              <li class="m-list_item">
+                                  <a class="m-list_link" href="/">
+                                      Multiple links are supported
+                                  </a>
+                              </li>
+                          </ul>
+                      </div>
+                  </div>
+              </div>
+          </div>
+        variation_description: ""
+        variation_name: Default banner
+      - variation_is_deprecated: false
+        variation_code_snippet: >-
+          <div class="o-banner o-banner__dark">
               <div class="wrapper wrapper__match-content">
                   <div class="m-notification
                               m-notification__warning
@@ -17,14 +48,16 @@ variation_groups:
                       {% include icons/information-round.svg %}
                       <div class="m-notification_content">
                           <div class="h4 m-notification_message">
-                              A default banner
+                              A dark-themed banner with a notification
                           </div>
+                          <p class="m-notification_explanation">
+                              An optional paragraph of text can be added to explain the purpose of the banner.
+                          </p>
                       </div>
                   </div>
               </div>
           </div>
-        variation_description: ""
-        variation_name: ""
-    variation_group_name: Default banner
+        variation_name: Dark banner
+    variation_group_name: ""
 last_updated: 2020-01-28T15:55:47.394Z
 ---

--- a/packages/cfpb-notifications/src/organisms/banner.less
+++ b/packages/cfpb-notifications/src/organisms/banner.less
@@ -23,6 +23,25 @@
     }
   }
 
+  &__dark {
+    background: @teal-mid-dark;
+    border-color: @teal-mid-dark;
+    color: @white;
+
+    a {
+      border-color: @white;
+      color: @white;
+    }
+
+    .m-notification {
+      background: @teal-mid-dark;
+
+      .cf-icon-svg {
+        fill: @white;
+      }
+    }
+  }
+
   .respond-to-min( @bp-sm-min, {
     font-size: 1em;
   } );

--- a/packages/cfpb-notifications/src/organisms/banner.less
+++ b/packages/cfpb-notifications/src/organisms/banner.less
@@ -32,8 +32,7 @@
       border-color: @white;
       color: @white;
 
-      &:hover,
-      &:visited {
+      &:hover {
         border-color: @gray-15;
         color: @gray-15;
       }

--- a/packages/cfpb-notifications/src/organisms/banner.less
+++ b/packages/cfpb-notifications/src/organisms/banner.less
@@ -31,6 +31,12 @@
     a {
       border-color: @white;
       color: @white;
+
+      &:hover,
+      &:visited {
+        border-color: @gray-15;
+        color: @gray-15;
+      }
     }
 
     .m-notification {


### PR DESCRIPTION
As part of our 1071 work, we'll be using banners to indicate the status of our online filing guide. Our default gold banner will be used to flag outdated versions of the guide, while a more eye-catching dark teal banner will highlight super old archived versions.

## Additions

- Dark banner variation

## Testing

1. Check it out at https://deploy-preview-1387--cfpb-design-system.netlify.app/design-system/components/banners

## Screenshots

<img width="826" alt="image" src="https://user-images.githubusercontent.com/1060248/183755569-247c1c70-1af0-46cb-a8ba-32d6b284e2b8.png">

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
