### PR TITLE
Add variation group name to Banners page

### DIFF
--- a/docs/pages/banners.md
+++ b/docs/pages/banners.md
@@ -70,6 +70,6 @@ variation_groups:
               </div>
           </div>
         variation_name: Dark banner
-    variation_group_name: ""
+    variation_group_name: Types
 last_updated: 2020-01-28T15:55:47.394Z
 ---


### PR DESCRIPTION
This fixes an accessibility error that Lighthouse discovered.
Without this change, the heading order goes h1, h3.
This adds the missing h2.