### PR TITLE
Hierarchy changes

### DIFF
--- a/docs/pages/heading-hierarchy.md
+++ b/docs/pages/heading-hierarchy.md
@@ -68,9 +68,9 @@ variation_groups:
           <h1 style="font-size:60pt; font-weight:500; line-height:66pt">Display
           heading</h1>
 
-          <h1 style="font-size:38pt; font-weight:400; line-height:40pt">Heading level 1</h1>
+          <h1 style="font-size:38pt; font-weight:600; line-height:40pt">Heading level 1</h1>
 
-          <h2 style="font-size:26pt; font-weight:400; line-height:28pt">Heading level 2</h2>
+          <h2 style="font-size:26pt; font-weight:600; line-height:28pt">Heading level 2</h2>
 
           <h3 style="font-size: 16pt; font-weight:600; line-height: 18pt">Heading level 3</h3>
 

--- a/packages/cfpb-core/src/base.less
+++ b/packages/cfpb-core/src/base.less
@@ -33,7 +33,7 @@ b {
 
   margin-bottom: unit( ( 15px / @font-size ), em );
   font-size: unit( ( @font-size / @base-font-size-px ), em );
-  font-weight: normal;
+  font-weight: 600;
   letter-spacing: inherit;
   line-height: 1.25;
   text-transform: inherit;
@@ -44,7 +44,7 @@ b {
 
   margin-bottom: unit( ( 15px / @font-size ), em );
   font-size: unit( ( @font-size / @base-font-size-px ), em );
-  font-weight: normal;
+  font-weight: 600;
   letter-spacing: inherit;
   line-height: 1.25;
   text-transform: inherit;

--- a/packages/cfpb-layout/src/molecules/heroes.less
+++ b/packages/cfpb-layout/src/molecules/heroes.less
@@ -229,6 +229,7 @@
     }
     .m-hero_subhead {
       .heading-2();
+      font-weight: 500;
     }
   } );
 }

--- a/packages/cfpb-layout/src/molecules/heroes.less
+++ b/packages/cfpb-layout/src/molecules/heroes.less
@@ -229,7 +229,7 @@
     }
     .m-hero_subhead {
       .heading-2();
-      font-weight: 500;
+      font-weight:400;
     }
   } );
 }


### PR DESCRIPTION
This PR institutes changes to our type hierarchy, specifically the weight of our H1 and H2.

@ajbush has been running point on the design part of this change, so he can field design-related questions. I can handle any technical requests!

## Changes

- Change H1, H2 weight to 600

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
