### PR TITLE
Add a subsection eyebrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,3 @@
-Must provide GITHUB_AUTH
-
-
-Must provide GITHUB_AUTH
-
-
-Must provide GITHUB_AUTH
-
-
-Must provide GITHUB_AUTH
-
-
-Must provide GITHUB_AUTH
-
-
-Must provide GITHUB_AUTH
-
-
-Must provide GITHUB_AUTH
-
-
-Must provide GITHUB_AUTH
-
-
-Must provide GITHUB_AUTH
-
-
-
 ## v0.17.0 (2022-08-10)
 
 #### Enhancement

--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -1,4 +1,9 @@
 <section>
+    {%- if page.eyebrow %}
+      <div class="h5">
+        {{ page.eyebrow }}
+      </div>
+    {% endif %}
 
     <h1 class="component-header u-mb30">
         {{ page.title }}

--- a/docs/pages/accessibility.md
+++ b/docs/pages/accessibility.md
@@ -305,7 +305,7 @@ accessibility: >-
    - With VoiceOver enabled, optionally enable the "rotor" by pressing _control +option+U_.
 last_updated: 2019-12-10T22:50:48.793Z
 behavior: ""
-secondary_section: null
+eyebrow: Accessibility
 
 redirect_from:
   - /accessibility

--- a/docs/pages/animation.md
+++ b/docs/pages/animation.md
@@ -2,7 +2,7 @@
 title: Animation
 layout: variation
 section: foundation
-secondary_section: Brand guidelines
+eyebrow: Multimedia
 status: Released
 description: Animation should be used to bring on-brand illustrations to life.
   Animation can also be used enhance the display of information, such as drawing

--- a/docs/pages/atomic-components.md
+++ b/docs/pages/atomic-components.md
@@ -86,6 +86,6 @@ guidelines: ""
 behavior: ""
 accessibility: ""
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Core development
+eyebrow: Atomic
 research: ""
 ---

--- a/docs/pages/banners.md
+++ b/docs/pages/banners.md
@@ -2,7 +2,7 @@
 title: Banners
 layout: variation
 section: components
-secondary_section: Alerts
+eyebrow: Alerts
 status: Beta
 description: This component provides banner boxes at the top of a page's
   content. This is similar to a notification, but is intended to be full width.

--- a/docs/pages/bar-charts.md
+++ b/docs/pages/bar-charts.md
@@ -51,5 +51,5 @@ accessibility: ""
 research: ""
 related_items: ""
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Data visualization
+eyebrow: Data visualization
 ---

--- a/docs/pages/base-images.md
+++ b/docs/pages/base-images.md
@@ -22,6 +22,6 @@ guidelines: ""
 behavior: ""
 accessibility: ""
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Core development
+eyebrow: Layout
 research: ""
 ---

--- a/docs/pages/beam-pattern.md
+++ b/docs/pages/beam-pattern.md
@@ -2,7 +2,6 @@
 title: Beam pattern
 layout: variation
 section: foundation
-secondary_section: Brand guidelines
 description: >-
   - [Stylistic guidelines](#stylistic-guidelines)
 

--- a/docs/pages/blocks.md
+++ b/docs/pages/blocks.md
@@ -216,5 +216,5 @@ related_items: "* [Layout
   variables](https://cfpb.github.io/design-system/development/variables#color-4\
   )"
 last_updated: 2020-01-06T20:29:09.912Z
-secondary_section: Core development
+eyebrow: Layout
 ---

--- a/docs/pages/browse-pages.md
+++ b/docs/pages/browse-pages.md
@@ -117,5 +117,4 @@ related_items: >-
 
   * [Email signup form](https://cfpb.github.io/design-system/patterns/e-mail-signup-forms)
 last_updated: 2020-01-13T23:25:20.183Z
-secondary_section: Web templates
 ---

--- a/docs/pages/buttons.md
+++ b/docs/pages/buttons.md
@@ -341,5 +341,5 @@ related_items: "* [Button
   variables](https://cfpb.github.io/design-system/development/variables#buttons\
   )"
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Forms
+eyebrow: Form elements
 ---

--- a/docs/pages/cards.md
+++ b/docs/pages/cards.md
@@ -815,6 +815,6 @@ guidelines: ""
 behavior: ""
 accessibility: ""
 last_updated: 2019-10-21T20:38:39.851Z
-secondary_section: Layout options
+eyebrow: Featured content
 research: ""
 ---

--- a/docs/pages/carousel.md
+++ b/docs/pages/carousel.md
@@ -80,5 +80,4 @@ related_items: >-
 
   * [Featured content module](https://cfpb.github.io/design-system/patterns/featured-content-module)
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Layout options
 ---

--- a/docs/pages/checkboxes.md
+++ b/docs/pages/checkboxes.md
@@ -272,6 +272,6 @@ behavior: >-
 accessibility: To optimize screen reader accessibility, lay out checkboxes
   vertically rather than horizontally.
 last_updated: 2019-09-17T14:30:15.293Z
-secondary_section: Forms
+eyebrow: Form elements
 research: ""
 ---

--- a/docs/pages/color.md
+++ b/docs/pages/color.md
@@ -1692,5 +1692,5 @@ accessibility: >-
     * For large text, a contrast ratio of only 3 : 1 is necessary. Large regular text is at least 18pt/24px, while large bold text is 14pt/18px.
     * Text or images of text that are either pure decoration or not visible, or are part of a logo, picture that contains significant other visual content, or inactive UI components (like disabled form controls) do not have a color contrast requirement.
 last_updated: 2019-08-30T18:31:00.000Z
-secondary_section: Brand guidelines
+eyebrow: Basics
 ---

--- a/docs/pages/column-dividers.md
+++ b/docs/pages/column-dividers.md
@@ -86,6 +86,6 @@ guidelines: ""
 behavior: ""
 accessibility: ""
 last_updated: 2019-09-13T19:34:43.025Z
-secondary_section: Core development
+eyebrow: Layout
 research: ""
 ---

--- a/docs/pages/data-visualization-1.md
+++ b/docs/pages/data-visualization-1.md
@@ -3,6 +3,7 @@ title: Data visualization guidelines
 collection_name: pages
 layout: variation
 section: guidelines
+eyebrow: Data visualization
 description: "Data visualization can be an excellent way to increase
   understanding of information and make comparisons of data. Using visuals to
   convey meaning and tell stories can engage the user and create a memorable

--- a/docs/pages/document-detail-pages.md
+++ b/docs/pages/document-detail-pages.md
@@ -147,5 +147,4 @@ related_items: >-
 
   * [Email sign-up form](https://cfpb.github.io/design-system/patterns/e-mail-signup-forms)
 last_updated: 2020-01-13T23:29:43.319Z
-secondary_section: Web templates
 ---

--- a/docs/pages/dropdowns.md
+++ b/docs/pages/dropdowns.md
@@ -168,5 +168,5 @@ related_items: "* [Forms
   variables](https://cfpb.github.io/design-system/development/variables#forms-1\
   )"
 last_updated: 2020-01-06T20:31:06.632Z
-secondary_section: Forms
+eyebrow: Form elements
 ---

--- a/docs/pages/e-mail-signup-forms.md
+++ b/docs/pages/e-mail-signup-forms.md
@@ -2,6 +2,7 @@
 title: E-mail signup forms
 layout: variation
 section: patterns
+eyebrow: Forms
 status: Released
 description: Email sign-ups allow users to stay engaged on a specific topic or
   content type produced by the Bureau. They are used to add individual email

--- a/docs/pages/expandables.md
+++ b/docs/pages/expandables.md
@@ -613,5 +613,5 @@ related_items: "* [Expandables
   variables](https://cfpb.github.io/design-system/development/variables#expanda\
   bles) "
 last_updated: 2019-12-16T18:43:19.784Z
-secondary_section: Layout options
+eyebrow: Behavior
 ---

--- a/docs/pages/featured-content-modules.md
+++ b/docs/pages/featured-content-modules.md
@@ -196,5 +196,5 @@ related_items: "* [Variables for featured content
   modules](https://cfpb.github.io/design-system/development/variables#heroes-an\
   d-featured-content-modules)"
 last_updated: 2019-10-17T14:52:11.082Z
-secondary_section: Layout options
+eyebrow: Featured content
 ---

--- a/docs/pages/fieldsets.md
+++ b/docs/pages/fieldsets.md
@@ -136,6 +136,6 @@ guidelines: ""
 behavior: ""
 accessibility: ""
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Forms
+eyebrow: Form elements
 research: ""
 ---

--- a/docs/pages/filterable-list-control-panels.md
+++ b/docs/pages/filterable-list-control-panels.md
@@ -216,5 +216,5 @@ related_items: >-
 
   * [Filterable list pages](https://cfpb.github.io/design-system/pages/filterable-list-pages)
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Layout options
+eyebrow: Navigation
 ---

--- a/docs/pages/filterable-list-pages.md
+++ b/docs/pages/filterable-list-pages.md
@@ -107,5 +107,4 @@ related_items: >-
 
   * [Email sign-up form](https://cfpb.github.io/design-system/patterns/e-mail-signup-forms)
 last_updated: 2020-01-13T23:28:26.904Z
-secondary_section: Web templates
 ---

--- a/docs/pages/forms.md
+++ b/docs/pages/forms.md
@@ -2,6 +2,7 @@
 title: Designing forms
 layout: variation
 section: patterns
+eyebrow: Forms
 status: Legacy
 description: >
   Web forms provide an incredible advantage over paper forms in their potential

--- a/docs/pages/general-principles.md
+++ b/docs/pages/general-principles.md
@@ -2,7 +2,6 @@
 title: General principles
 layout: variation
 section: null
-secondary_section: null
 description: >-
   These are the strategic underpinnings for the CFPB’s design and development
   standards. They should serve as the backbone for the user experience, ensuring

--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -476,5 +476,5 @@ research: ""
 related_items: "* [Grid
   variables](https://cfpb.github.io/design-system/development/variables#grid-1)"
 last_updated: 2019-09-10T15:02:08.752Z
-secondary_section: Core development
+eyebrow: Basics
 ---

--- a/docs/pages/heading-hierarchy.md
+++ b/docs/pages/heading-hierarchy.md
@@ -211,5 +211,5 @@ related_items: "* [Typography
   variables](https://cfpb.github.io/design-system/development/variables#typogra\
   phy)"
 last_updated: 2019-10-21T21:54:52.744Z
-secondary_section: Text
+eyebrow: Typography
 ---

--- a/docs/pages/helper-classes-mixins.md
+++ b/docs/pages/helper-classes-mixins.md
@@ -430,6 +430,6 @@ guidelines: ""
 behavior: ""
 accessibility: ""
 last_updated: 2019-09-13T18:46:32.716Z
-secondary_section: Core development
+eyebrow: Utilities
 research: ""
 ---

--- a/docs/pages/helper-text.md
+++ b/docs/pages/helper-text.md
@@ -102,5 +102,5 @@ related_items: >-
 
   * [Designing forms](https://cfpb.github.io/design-system/patterns/designing-forms)
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Text
+eyebrow: Form elements
 ---

--- a/docs/pages/heroes.md
+++ b/docs/pages/heroes.md
@@ -802,5 +802,5 @@ related_items: >-
 
   - [Item introductions](https://cfpb.github.io/design-system/patterns/item-introductions)
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Layout options
+eyebrow: Introductions
 ---

--- a/docs/pages/iconography.md
+++ b/docs/pages/iconography.md
@@ -639,5 +639,5 @@ behavior: >-
 
   In some cases we embed an SVG as a background image. To accomplish this, a custom Less plugin is used to inject the SVG icon source file inline into the CSS `background-image` property. This is exposed via a mixin, `.u-svg-inline-bg( @name, @color: @black )`, where `@name` is the SVG icon canonical name and `@color` is the SVG fill color (which defaults to black).
 related_items: ""
-secondary_section: Brand guidelines
+eyebrow: Graphics
 ---

--- a/docs/pages/illustration.md
+++ b/docs/pages/illustration.md
@@ -131,5 +131,5 @@ accessibility: >-
   * Use the `<title>` and `<desc>` elements in SVG drawings.
 
   * Include descriptive text near images (for example, a pie chart legend with percentages of each item).
-secondary_section: Brand guidelines
+eyebrow: Graphics
 ---

--- a/docs/pages/info-unit-groups-link-blobs.md
+++ b/docs/pages/info-unit-groups-link-blobs.md
@@ -309,5 +309,5 @@ related_items: |-
   * [Links](https://cfpb.github.io/design-system/components/links)
   * [Typography](https://cfpb.github.io/design-system/foundation/typography)
 last_updated: 2019-08-30T16:07:00.000Z
-secondary_section: Layout options
+eyebrow: Main content
 ---

--- a/docs/pages/interactive-chart.md
+++ b/docs/pages/interactive-chart.md
@@ -3,6 +3,7 @@ title: Interactive charts
 collection_name: pages
 layout: variation
 section: patterns
+eyebrow: Main content
 status: Released
 description: Interactive charts, in contrast to static data visualizations, are
   intended to let users explore a set of data, focus in on the details that

--- a/docs/pages/introductions.md
+++ b/docs/pages/introductions.md
@@ -143,5 +143,5 @@ related_items: >-
 
   * [Item introductions](https://cfpb.github.io/design-system/patterns/item-introductions)
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Layout options
+eyebrow: Introductions
 ---

--- a/docs/pages/item-introductions.md
+++ b/docs/pages/item-introductions.md
@@ -75,5 +75,5 @@ related_items: >-
   * [Heroes](https://cfpb.github.io/design-system/patterns/heroes)
 
   * [Text introductions](https://cfpb.github.io/design-system/patterns/text-introductions)
-secondary_section: Layout options
+eyebrow: Introductions
 ---

--- a/docs/pages/labels.md
+++ b/docs/pages/labels.md
@@ -69,5 +69,5 @@ related_items: >-
 
   * [Designing forms](https://cfpb.github.io/design-system/patterns/designing-forms)
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Text
+eyebrow: Form elements
 ---

--- a/docs/pages/landing-pages.md
+++ b/docs/pages/landing-pages.md
@@ -104,5 +104,4 @@ related_items: >-
 
   * [Email signup form](https://cfpb.github.io/design-system/patterns/e-mail-signup-forms)
 last_updated: 2019-10-24T20:28:47.366Z
-secondary_section: Web templates
 ---

--- a/docs/pages/learn-pages.md
+++ b/docs/pages/learn-pages.md
@@ -112,5 +112,4 @@ related_items: >-
 
   * [Email signup form](https://cfpb.github.io/design-system/patterns/e-mail-signup-forms)
 last_updated: 2020-01-13T23:26:34.507Z
-secondary_section: Web templates
 ---

--- a/docs/pages/line-charts.md
+++ b/docs/pages/line-charts.md
@@ -30,6 +30,6 @@ guidelines: >-
 behavior: ""
 accessibility: ""
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Data visualization
+eyebrow: Data visualization
 research: ""
 ---

--- a/docs/pages/links.md
+++ b/docs/pages/links.md
@@ -285,5 +285,5 @@ related_items: >-
 
   * [Iconography](https://cfpb.github.io/design-system/foundation/iconography)
 last_updated: 2019-09-17T14:52:22.684Z
-secondary_section: Text
+eyebrow: Form elements
 ---

--- a/docs/pages/lists.md
+++ b/docs/pages/lists.md
@@ -194,5 +194,5 @@ accessibility: ""
 research: ""
 related_items: ""
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Layout options
+eyebrow: Lists and tables
 ---

--- a/docs/pages/logo.md
+++ b/docs/pages/logo.md
@@ -2,7 +2,7 @@
 title: Logo
 layout: variation
 section: foundation
-secondary_section: Brand guidelines
+eyebrow: Brand symbols
 description: >-
   
   The CFPB logo was designed to symbolize vigilance, transparency, and a consumer focus. Consumers are the foundation and focus of our mission and our logo reflects that. A soft beam of light symbolizes our efforts to illuminate the financial landscape and foster transparency in the marketplace.

--- a/docs/pages/manual-accessibility-audit.md
+++ b/docs/pages/manual-accessibility-audit.md
@@ -3,6 +3,7 @@ title: Accessibility audit tools
 collection_name: pages
 layout: variation
 section: guidelines
+eyebrow: Accessibility
 description: This page contains web accessibility testing tools developed by the
   Design & Development team at the CFPB. They help us check for our desired
   level of conformance to federal regulations around accessibility. More plainly

--- a/docs/pages/media-queries.md
+++ b/docs/pages/media-queries.md
@@ -2,7 +2,7 @@
 title: Media queries
 layout: variation
 section: development
-secondary_section: Core development
+eyebrow: Utilities
 status: Released
 description: Mixins for consistent media queries that take `px` values and
   convert them to ems.

--- a/docs/pages/motion-graphics-and-animation.md
+++ b/docs/pages/motion-graphics-and-animation.md
@@ -3,6 +3,7 @@ title: Motion
 collection_name: pages
 layout: variation
 section: foundation
+eyebrow: Multimedia
 status: Released
 description: >-
   Motion graphics are the combination of graphic design, animation, and visual

--- a/docs/pages/notifications.md
+++ b/docs/pages/notifications.md
@@ -256,5 +256,5 @@ related_items: "* [Notifications
   variables](https://cfpb.github.io/design-system/development/variables#notific\
   ations)"
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Alerts
+eyebrow: Alerts
 ---

--- a/docs/pages/pagination.md
+++ b/docs/pages/pagination.md
@@ -127,5 +127,5 @@ related_items: "* [Pagination
   variables](https://cfpb.github.io/design-system/development/variables#paginat\
   ion-1)"
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Navigation
+eyebrow: Navigation
 ---

--- a/docs/pages/paragraphs.md
+++ b/docs/pages/paragraphs.md
@@ -115,5 +115,5 @@ related_items: "* [Typography
   variables](https://cfpb.github.io/design-system/development/variables#typogra\
   phy)"
 last_updated: 2020-01-06T20:28:04.952Z
-secondary_section: Text
+eyebrow: Typography
 ---

--- a/docs/pages/photography.md
+++ b/docs/pages/photography.md
@@ -139,5 +139,5 @@ accessibility: >-
   * **Facebook:** Add a photo to your post. Before publishing, hover on the photo and an “Edit” button will appear in the upper left corner. Click the “Edit” button and editing options will appear on the left side of the photo. Click “Alternative Text.” Enter a description in the “Custom alt text” field and click the “Save” button.  
 
   * **Twitter:** Add a photo to your post. Before publishing, click “Add description.” Enter a description in the “Description” field and click the “Save” button.
-secondary_section: Brand guidelines
+eyebrow: Graphics
 ---

--- a/docs/pages/pie-charts.md
+++ b/docs/pages/pie-charts.md
@@ -31,6 +31,6 @@ guidelines: >-
 behavior: ""
 accessibility: ""
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Data visualization
+eyebrow: Data visualization
 research: ""
 ---

--- a/docs/pages/print-styles.md
+++ b/docs/pages/print-styles.md
@@ -3,6 +3,7 @@ title: Print styles
 collection_name: pages
 layout: variation
 section: guidelines
+eyebrow: Print
 status: Proposed
 description: >-
   As some [consumerfinance.gov](https://www.consumerfinance.gov/) users may want

--- a/docs/pages/radio-buttons.md
+++ b/docs/pages/radio-buttons.md
@@ -271,5 +271,5 @@ accessibility: There are some issues with Voiceover reading radio buttons. To
 research: ""
 related_items: ""
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Forms
+eyebrow: Form elements
 ---

--- a/docs/pages/range-sliders.md
+++ b/docs/pages/range-sliders.md
@@ -54,6 +54,6 @@ guidelines: ""
 behavior: ""
 accessibility: Make sure that sliders are accessible by keyboard using the arrow keys.
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Forms
+eyebrow: Form elements
 research: ""
 ---

--- a/docs/pages/sample-component-page.md
+++ b/docs/pages/sample-component-page.md
@@ -178,5 +178,4 @@ behavior: >-
 restrictions:
   - restrictions_do: Words or photos
     restrictions_do_not: Words or photos
-secondary_section: Alerts
 ---

--- a/docs/pages/seal.md
+++ b/docs/pages/seal.md
@@ -321,5 +321,5 @@ behavior: ""
 restrictions: []
 related_items: ""
 last_updated: 2020-02-27T16:56:46.952Z
-secondary_section: Brand guidelines
+eyebrow: Brand symbols
 ---

--- a/docs/pages/sidebars-prefooters.md
+++ b/docs/pages/sidebars-prefooters.md
@@ -374,5 +374,5 @@ related_items: >-
 
   * [Grid](https://cfpb.github.io/design-system/foundation/grid)
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Core development
+eyebrow: Layout
 ---

--- a/docs/pages/sublanding-pages.md
+++ b/docs/pages/sublanding-pages.md
@@ -112,5 +112,4 @@ related_items: >-
 
   * [Email signup form](https://cfpb.github.io/design-system/patterns/e-mail-signup-forms)
 last_updated: 2020-03-30T16:36:53.821Z
-secondary_section: Web templates
 ---

--- a/docs/pages/tables.md
+++ b/docs/pages/tables.md
@@ -766,5 +766,5 @@ related_items: "* [Tables
   variables](https://cfpb.github.io/design-system/development/variables#tables-\
   1)"
 last_updated: 2019-08-30T15:18:28.960Z
-secondary_section: Layout options
+eyebrow: Lists and tables
 ---

--- a/docs/pages/taglines.md
+++ b/docs/pages/taglines.md
@@ -52,5 +52,5 @@ accessibility: ""
 research: ""
 related_items: ""
 last_updated: 2019-10-21T20:38:39.851Z
-secondary_section: Layout options
+eyebrow: Featured content
 ---

--- a/docs/pages/text-inputs.md
+++ b/docs/pages/text-inputs.md
@@ -226,5 +226,5 @@ related_items: "* [Text input
   variables](https://cfpb.github.io/design-system/development/variables#forms-1\
   )"
 last_updated: 2020-01-28T15:55:47.394Z
-secondary_section: Forms
+eyebrow: Form elements
 ---

--- a/docs/pages/transition-patterns.md
+++ b/docs/pages/transition-patterns.md
@@ -2,6 +2,7 @@
 title: Transition patterns
 layout: variation
 section: patterns
+eyebrow: Transitions
 status: Released
 description: Transition patterns are animations that happen when a user
   interacts with an element on the page. They are CSS transition styles that are

--- a/docs/pages/typography.md
+++ b/docs/pages/typography.md
@@ -167,5 +167,5 @@ accessibility: >-
 related_items: "* [Typography
   variables](https://cfpb.github.io/design-system/development/variables#typogra\
   phy)"
-secondary_section: Brand guidelines
+eyebrow: Typography
 ---

--- a/docs/pages/variables.md
+++ b/docs/pages/variables.md
@@ -2,7 +2,7 @@
 title: Variables
 layout: variation
 section: development
-secondary_section: Core development
+eyebrow: Utilities
 status: Proposed
 description: >
   Component variables are used to theme a component. They likely will be left as

--- a/docs/pages/video.md
+++ b/docs/pages/video.md
@@ -921,5 +921,5 @@ accessibility: >-
 
 
   * Nothing on the page should flash more than 3 times in 1 second.
-secondary_section: Brand guidelines
+eyebrow: Multimedia
 ---

--- a/docs/pages/wells.md
+++ b/docs/pages/wells.md
@@ -90,5 +90,5 @@ accessibility: ""
 research: ""
 related_items: "* [Featured content module](/design-system/patterns/featured-content-module)"
 last_updated: 2019-10-21T20:38:39.851Z
-secondary_section: Layout options
+eyebrow: Featured content
 ---


### PR DESCRIPTION
This adds a subsection eyebrow as shown below to support desired design of the equity-centered design section
<img width="940" alt="Screen Shot 2022-09-30 at 9 48 38 AM" src="https://user-images.githubusercontent.com/1558033/193284525-b31284da-8087-4079-9b3b-e500d31935e9.png">

There was an old, unused `secondary_section` variable (looks like this used to be for handling sidebar rendering? This is now handled elsewhere). I've replaced this with an `eyebrow` variable which refers to the current subsection or third-level section a page is nested within.