### PR TITLE
Add ability to add custom jumplinks in admin view

### DIFF
--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -18,7 +18,7 @@
         that are empty.
     {% endcomment %}
 
-    {% assign jump_links = '' | split: ',' %}
+    {% assign jump_links = page.jumplinks | split: ',' or '' %}
 
     {% for variation_group in page.variation_groups %}
         {% assign variation_name = variation_group.variation_group_name %}

--- a/docs/admin/config.yml
+++ b/docs/admin/config.yml
@@ -139,6 +139,11 @@ collections:
             value: 'development'
           - label: 'Guidelines'
             value: 'guidelines'
+      - name: 'jumplinks'
+        label: 'Custom jump links'
+        widget: 'string'
+        hint: 'Enter jump links separated by commas'
+        required: false
       - name: 'status'
         label: 'Implementation status'
         widget: 'select'


### PR DESCRIPTION
This is being added to support the design of the equity-centered design page. The custom jump links play nice with the existing hardcoded jump links and jump link introduced via "variations."

Admin view:
<img width="826" alt="Screen Shot 2022-09-30 at 1 54 47 PM" src="https://user-images.githubusercontent.com/1558033/193332582-62623539-a4d4-4f7b-8fb4-c62de6be82ca.png">

Rendered view:
<img width="698" alt="Screen Shot 2022-09-30 at 1 54 54 PM" src="https://user-images.githubusercontent.com/1558033/193332625-47820e4a-c79d-438c-b42e-0128a96537c8.png">
