### PR TITLE
Convert expandable header to flexbox

### DIFF
--- a/docs/pages/expandables.md
+++ b/docs/pages/expandables.md
@@ -19,10 +19,10 @@ variation_groups:
                       o-expandable__border">
               <button class="o-expandable_header o-expandable_target"
                       title="Expand content">
-                  <h3 class="h4 o-expandable_header-left o-expandable_label">
+                  <h3 class="h4 o-expandable_label">
                       Expandable Header
                   </h3>
-                  <span class="o-expandable_header-right o-expandable_link">
+                  <span class="o-expandable_link">
                       <span class="o-expandable_cue o-expandable_cue-open">
                           <span class="u-visually-hidden-on-mobile">Show</span>
                           {% include icons/plus-round.svg %}
@@ -124,10 +124,10 @@ variation_groups:
                       o-expandable__border">
               <button class="o-expandable_header o-expandable_target"
                       title="Expand content">
-                  <h3 class="h4 o-expandable_header-left o-expandable_label">
+                  <h3 class="h4 o-expandable_label">
                       Expandable Header
                   </h3>
-                  <span class="o-expandable_header-right o-expandable_link">
+                  <span class="o-expandable_link">
                       <span class="o-expandable_cue o-expandable_cue-open">
                           <span class="u-visually-hidden-on-mobile">Show</span>
                           {% include icons/plus-round.svg %}
@@ -164,10 +164,10 @@ variation_groups:
               <div class="o-expandable o-expandable__padded">
                   <button class="o-expandable_header o-expandable_target"
                           title="Expand content">
-                      <h3 class="h4 o-expandable_header-left o-expandable_label">
+                      <h3 class="h4 o-expandable_label">
                           Expandable Header 1
                       </h3>
-                      <span class="o-expandable_header-right o-expandable_link">
+                      <span class="o-expandable_link">
                           <span class="o-expandable_cue o-expandable_cue-open">
                               <span class="u-visually-hidden-on-mobile">Show</span>
                               {% include icons/plus-round.svg %}
@@ -192,10 +192,10 @@ variation_groups:
               <div class="o-expandable o-expandable__padded">
                   <button class="o-expandable_header o-expandable_target"
                           title="Expand content">
-                      <h3 class="h4 o-expandable_header-left o-expandable_label">
+                      <h3 class="h4 o-expandable_label">
                           Expandable Header 2
                       </h3>
-                      <span class="o-expandable_header-right o-expandable_link">
+                      <span class="o-expandable_link">
                           <span class="o-expandable_cue o-expandable_cue-open">
                               <span class="u-visually-hidden-on-mobile">Show</span>
                               {% include icons/plus-round.svg %}
@@ -220,10 +220,10 @@ variation_groups:
               <div class="o-expandable o-expandable__padded">
                   <button class="o-expandable_header o-expandable_target"
                           title="Expand content">
-                      <h3 class="h4 o-expandable_header-left o-expandable_label">
+                      <h3 class="h4 o-expandable_label">
                           Expandable Header 3
                       </h3>
-                      <span class="o-expandable_header-right o-expandable_link">
+                      <span class="o-expandable_link">
                           <span class="o-expandable_cue o-expandable_cue-open">
                               <span class="u-visually-hidden-on-mobile">Show</span>
                               {% include icons/plus-round.svg %}
@@ -288,10 +288,10 @@ variation_groups:
               <div class="o-expandable o-expandable__padded">
                   <button class="o-expandable_header o-expandable_target"
                           title="Expand content">
-                      <h3 class="h4 o-expandable_header-left o-expandable_label">
+                      <h3 class="h4 o-expandable_label">
                           Expandable Header 1
                       </h3>
-                      <span class="o-expandable_header-right o-expandable_link">
+                      <span class="o-expandable_link">
                           <span class="o-expandable_cue o-expandable_cue-open">
                               <span class="u-visually-hidden-on-mobile">Show</span>
                               {% include icons/plus-round.svg %}
@@ -316,10 +316,10 @@ variation_groups:
               <div class="o-expandable o-expandable__padded">
                   <button class="o-expandable_header o-expandable_target"
                           title="Expand content">
-                      <h3 class="h4 o-expandable_header-left o-expandable_label">
+                      <h3 class="h4 o-expandable_label">
                           Expandable Header 2
                       </h3>
-                      <span class="o-expandable_header-right o-expandable_link">
+                      <span class="o-expandable_link">
                           <span class="o-expandable_cue o-expandable_cue-open">
                               <span class="u-visually-hidden-on-mobile">Show</span>
                               {% include icons/plus-round.svg %}
@@ -344,10 +344,10 @@ variation_groups:
               <div class="o-expandable o-expandable__padded">
                   <button class="o-expandable_header o-expandable_target"
                           title="Expand content">
-                      <h3 class="h4 o-expandable_header-left o-expandable_label">
+                      <h3 class="h4 o-expandable_label">
                           Expandable Header 3
                       </h3>
-                      <span class="o-expandable_header-right o-expandable_link">
+                      <span class="o-expandable_link">
                           <span class="o-expandable_cue o-expandable_cue-open">
                               <span class="u-visually-hidden-on-mobile">Show</span>
                               {% include icons/plus-round.svg %}
@@ -495,7 +495,7 @@ variation_groups:
           expandable](https://cfpb.github.io/design-system/components/expandables#standard-expandables).
       - variation_name: Header elements
         variation_description: >
-          
+
           These additional elements are useful for more complicated expandables that need to convey more information than just ‘Show/Hide’ before the user expands it.
 
 

--- a/docs/pages/filterable-list-control-panels.md
+++ b/docs/pages/filterable-list-control-panels.md
@@ -17,10 +17,10 @@ variation_groups:
                   o-expandable__background
                   o-expandable__border">
                   <button class="o-expandable_header o-expandable_target o-expandable_target__expanded" type="button">
-                      <span class="h4 o-expandable_header-left o-expandable_label">
+                      <span class="h4 o-expandable_label">
                       Filter posts
                       </span>
-                      <span class="o-expandable_header-right o-expandable_link">
+                      <span class="o-expandable_link">
                           <span class="o-expandable_cue o-expandable_cue-open">
                               <span class="u-visually-hidden-on-mobile">
                               Show

--- a/docs/special-pages/updating-this-website.md
+++ b/docs/special-pages/updating-this-website.md
@@ -25,7 +25,7 @@ description: >-
   ## Editing pages
 
 
-  We use a content management system called [Netlify CMS](https://www.netlifycms.org/). 
+  We use a content management system called [Netlify CMS](https://www.netlifycms.org/).
 
   It's powered by GitHub and will let you edit any page of this website.
 
@@ -34,10 +34,10 @@ description: >-
       <div class="o-expandable o-expandable__padded">
           <button class="o-expandable_header o-expandable_target"
                   title="Expand content">
-              <h3 class="h4 o-expandable_header-left o-expandable_label">
+              <h3 class="h4 o-expandable_label">
                   Step 1. Click a page's "Edit this page" pencil icon.
               </h3>
-              <span class="o-expandable_header-right o-expandable_link">
+              <span class="o-expandable_link">
                   <span class="o-expandable_cue o-expandable_cue-open">
                       <span class="u-visually-hidden-on-mobile">Show</span>
                       {% include icons/plus-round.svg %}
@@ -60,10 +60,10 @@ description: >-
       <div class="o-expandable o-expandable__padded">
           <button class="o-expandable_header o-expandable_target"
                   title="Expand content">
-              <h3 class="h4 o-expandable_header-left o-expandable_label">
+              <h3 class="h4 o-expandable_label">
                   Step 2. Log into the CMS
               </h3>
-              <span class="o-expandable_header-right o-expandable_link">
+              <span class="o-expandable_link">
                   <span class="o-expandable_cue o-expandable_cue-open">
                       <span class="u-visually-hidden-on-mobile">Show</span>
                       {% include icons/plus-round.svg %}
@@ -76,9 +76,9 @@ description: >-
           </button>
           <div class="o-expandable_content">
               <p>
-                  Log into the CMS by clicking the "Login with Github" button. 
-                  You'll need a github.com account and you'll need to be added to <a href="https://github.com/orgs/cfpb/people">CFPB's GitHub organization</a>. 
-                  If you're new to GitHub and need to be added to this organization, 
+                  Log into the CMS by clicking the "Login with Github" button.
+                  You'll need a github.com account and you'll need to be added to <a href="https://github.com/orgs/cfpb/people">CFPB's GitHub organization</a>.
+                  If you're new to GitHub and need to be added to this organization,
                   post a message in the <code>Design System</code> mattermost channel and someone will assist you.
               </p>
               <div class="o-well">
@@ -89,10 +89,10 @@ description: >-
       <div class="o-expandable o-expandable__padded">
           <button class="o-expandable_header o-expandable_target"
                   title="Expand content">
-              <h3 class="h4 o-expandable_header-left o-expandable_label">
+              <h3 class="h4 o-expandable_label">
                   Step 3. Edit a page's content
               </h3>
-              <span class="o-expandable_header-right o-expandable_link">
+              <span class="o-expandable_link">
                   <span class="o-expandable_cue o-expandable_cue-open">
                       <span class="u-visually-hidden-on-mobile">Show</span>
                       {% include icons/plus-round.svg %}
@@ -115,10 +115,10 @@ description: >-
       <div class="o-expandable o-expandable__padded">
           <button class="o-expandable_header o-expandable_target"
                   title="Expand content">
-              <h3 class="h4 o-expandable_header-left o-expandable_label">
+              <h3 class="h4 o-expandable_label">
                   Step 4. Save your changes
               </h3>
-              <span class="o-expandable_header-right o-expandable_link">
+              <span class="o-expandable_link">
                   <span class="o-expandable_cue o-expandable_cue-open">
                       <span class="u-visually-hidden-on-mobile">Show</span>
                       {% include icons/plus-round.svg %}
@@ -131,9 +131,9 @@ description: >-
           </button>
           <div class="o-expandable_content">
               <p>
-                  Click the blue 'Save' button in the top left to save your changes as a draft. 
-                  Don't worry, the live site won't be affected. 
-                  Netlify CMS will build a temporary version of the website with your changes so that you can preview them. 
+                  Click the blue 'Save' button in the top left to save your changes as a draft.
+                  Don't worry, the live site won't be affected.
+                  Netlify CMS will build a temporary version of the website with your changes so that you can preview them.
                   After you click the 'Save' button you can close the tab and come back to it later if you want, your temporary changes will persist.
               </p>
               <div class="o-well">
@@ -144,10 +144,10 @@ description: >-
       <div class="o-expandable o-expandable__padded">
           <button class="o-expandable_header o-expandable_target"
                   title="Expand content">
-              <h3 class="h4 o-expandable_header-left o-expandable_label">
+              <h3 class="h4 o-expandable_label">
                   Step 5. Preview your changes
               </h3>
-              <span class="o-expandable_header-right o-expandable_link">
+              <span class="o-expandable_link">
                   <span class="o-expandable_cue o-expandable_cue-open">
                       <span class="u-visually-hidden-on-mobile">Show</span>
                       {% include icons/plus-round.svg %}
@@ -160,9 +160,9 @@ description: >-
           </button>
           <div class="o-expandable_content">
               <p>
-                  After you save some changes, Netlify CMS will build a preview of the entire website with your new content. 
-                  This takes a few minutes. 
-                  When the preview is ready you’ll see a "View Preview" link at the top of the editing page. 
+                  After you save some changes, Netlify CMS will build a preview of the entire website with your new content.
+                  This takes a few minutes.
+                  When the preview is ready you’ll see a "View Preview" link at the top of the editing page.
                   Feel free to share this link with your peers if you’d like feedback on your new page.
               </p>
               <div class="o-well">
@@ -173,10 +173,10 @@ description: >-
       <div class="o-expandable o-expandable__padded">
           <button class="o-expandable_header o-expandable_target"
                   title="Expand content">
-              <h3 class="h4 o-expandable_header-left o-expandable_label">
+              <h3 class="h4 o-expandable_label">
                   Step 6. Publish your changes
               </h3>
-              <span class="o-expandable_header-right o-expandable_link">
+              <span class="o-expandable_link">
                   <span class="o-expandable_cue o-expandable_cue-open">
                       <span class="u-visually-hidden-on-mobile">Show</span>
                       {% include icons/plus-round.svg %}
@@ -189,11 +189,11 @@ description: >-
           </button>
           <div class="o-expandable_content">
               <p>
-                  When you are ready to publish your changes, set the page's status to "Ready". 
-                  Then click the “Publish” drop down menu and choose "Publish now." 
+                  When you are ready to publish your changes, set the page's status to "Ready".
+                  Then click the “Publish” drop down menu and choose "Publish now."
               </p>
               <p>
-                  Hooray! 
+                  Hooray!
                   After you publish, our servers will re-deploy the live website and you'll see your changes in a few minutes at https://cfpb.github.io/design-system.
               </p>
               <div class="o-well">

--- a/packages/cfpb-expandables/src/cfpb-expandables.less
+++ b/packages/cfpb-expandables/src/cfpb-expandables.less
@@ -111,8 +111,7 @@
   //
 
   &_header {
-    display: block;
-    .u-clearfix();
+    display: flex;
 
     // Using the button element with .o-expandable_header requires setting
     // an explicit width.
@@ -126,14 +125,9 @@
     }
 
 
-    // TODO: Convert float layout to flexbox
     &-left {
-      float: left;
-      width: 85%;
-    }
-
-    &-right {
-      float: right;
+      // Grow to available width.
+      flex-grow: 1;
     }
   }
 

--- a/packages/cfpb-expandables/src/cfpb-expandables.less
+++ b/packages/cfpb-expandables/src/cfpb-expandables.less
@@ -125,7 +125,7 @@
     }
 
 
-    &-left {
+    .o-expandable_label {
       // Grow to available width.
       flex-grow: 1;
     }

--- a/packages/cfpb-expandables/usage.md
+++ b/packages/cfpb-expandables/usage.md
@@ -184,10 +184,10 @@ The following combination is our recommended go-to expandable pattern.
             o-expandable__border">
     <button class="o-expandable_header o-expandable_target"
             title="Expand content">
-        <h3 class="h4 o-expandable_header-left o-expandable_label">
+        <h3 class="h4 o-expandable_label">
             Expandable Header
         </h3>
-        <span class="o-expandable_header-right o-expandable_link">
+        <span class="o-expandable_link">
             <span class="o-expandable_cue o-expandable_cue-open">
                 <span class="u-visually-hidden-on-mobile">Show</span>
                 {% include icons/plus-round.svg %}
@@ -216,10 +216,10 @@ The following combination is our recommended go-to expandable pattern.
             o-expandable__border">
     <button class="o-expandable_header o-expandable_target"
             title="Expand content">
-        <h3 class="h4 o-expandable_header-left o-expandable_label">
+        <h3 class="h4 o-expandable_label">
             Expandable Header
         </h3>
-        <span class="o-expandable_header-right o-expandable_link">
+        <span class="o-expandable_link">
             <span class="o-expandable_cue o-expandable_cue-open">
                 <span class="u-visually-hidden-on-mobile">Show</span>
                 {% raw %}{% include icons/plus-round.svg %}{% endraw %}
@@ -250,10 +250,10 @@ The following combination is our recommended go-to expandable pattern.
             o-expandable__border">
     <button class="o-expandable_header o-expandable_target"
             title="Expand content">
-        <h3 class="h4 o-expandable_header-left o-expandable_label">
+        <h3 class="h4 o-expandable_label">
             Expandable Header
         </h3>
-        <span class="o-expandable_header-right o-expandable_link">
+        <span class="o-expandable_link">
             <span class="o-expandable_cue o-expandable_cue-open">
                 <span class="u-visually-hidden-on-mobile">Show</span>
                 {% include icons/plus-round.svg %}
@@ -282,10 +282,10 @@ The following combination is our recommended go-to expandable pattern.
             o-expandable__border">
     <button class="o-expandable_header o-expandable_target"
             title="Expand content">
-        <h3 class="h4 o-expandable_header-left o-expandable_label">
+        <h3 class="h4 o-expandable_label">
             Expandable Header
         </h3>
-        <span class="o-expandable_header-right o-expandable_link">
+        <span class="o-expandable_link">
             <span class="o-expandable_cue o-expandable_cue-open">
                 <span class="u-visually-hidden-on-mobile">Show</span>
                 {% raw %}{% include icons/plus-round.svg %}{% endraw %}
@@ -364,10 +364,10 @@ In this barebones example there are no visual styles.
     <div class="o-expandable o-expandable__padded">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
-            <h3 class="h4 o-expandable_header-left o-expandable_label">
+            <h3 class="h4 o-expandable_label">
                 Expandable Header 1
             </h3>
-            <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
                     {% include icons/plus-round.svg %}
@@ -391,10 +391,10 @@ In this barebones example there are no visual styles.
     <div class="o-expandable o-expandable__padded">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
-            <h3 class="h4 o-expandable_header-left o-expandable_label">
+            <h3 class="h4 o-expandable_label">
                 Expandable Header 2
             </h3>
-            <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
                     {% include icons/plus-round.svg %}
@@ -418,10 +418,10 @@ In this barebones example there are no visual styles.
     <div class="o-expandable o-expandable__padded">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
-            <h3 class="h4 o-expandable_header-left o-expandable_label">
+            <h3 class="h4 o-expandable_label">
                 Expandable Header 3
             </h3>
-            <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
                     {% include icons/plus-round.svg %}
@@ -449,10 +449,10 @@ In this barebones example there are no visual styles.
     <div class="o-expandable o-expandable__padded">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
-            <h3 class="h4 o-expandable_header-left o-expandable_label">
+            <h3 class="h4 o-expandable_label">
                 Expandable Header 1
             </h3>
-            <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
@@ -476,10 +476,10 @@ In this barebones example there are no visual styles.
     <div class="o-expandable o-expandable__padded">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
-            <h3 class="h4 o-expandable_header-left o-expandable_label">
+            <h3 class="h4 o-expandable_label">
                 Expandable Header 2
             </h3>
-            <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
@@ -503,10 +503,10 @@ In this barebones example there are no visual styles.
     <div class="o-expandable o-expandable__padded">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
-            <h3 class="h4 o-expandable_header-left o-expandable_label">
+            <h3 class="h4 o-expandable_label">
                 Expandable Header 3
             </h3>
-            <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
@@ -540,10 +540,10 @@ to activate the accordion mode.
     <div class="o-expandable o-expandable__padded">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
-            <h3 class="h4 o-expandable_header-left o-expandable_label">
+            <h3 class="h4 o-expandable_label">
                 Expandable Header 1
             </h3>
-            <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
                     {% include icons/plus-round.svg %}
@@ -567,10 +567,10 @@ to activate the accordion mode.
     <div class="o-expandable o-expandable__padded">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
-            <h3 class="h4 o-expandable_header-left o-expandable_label">
+            <h3 class="h4 o-expandable_label">
                 Expandable Header 2
             </h3>
-            <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
                     {% include icons/plus-round.svg %}
@@ -594,10 +594,10 @@ to activate the accordion mode.
     <div class="o-expandable o-expandable__padded">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
-            <h3 class="h4 o-expandable_header-left o-expandable_label">
+            <h3 class="h4 o-expandable_label">
                 Expandable Header 3
             </h3>
-            <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
                     {% include icons/plus-round.svg %}
@@ -625,10 +625,10 @@ to activate the accordion mode.
     <div class="o-expandable o-expandable__padded">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
-            <h3 class="h4 o-expandable_header-left o-expandable_label">
+            <h3 class="h4 o-expandable_label">
                 Expandable Header 1
             </h3>
-            <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
@@ -652,10 +652,10 @@ to activate the accordion mode.
     <div class="o-expandable o-expandable__padded">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
-            <h3 class="h4 o-expandable_header-left o-expandable_label">
+            <h3 class="h4 o-expandable_label">
                 Expandable Header 2
             </h3>
-            <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
@@ -679,10 +679,10 @@ to activate the accordion mode.
     <div class="o-expandable o-expandable__padded">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
-            <h3 class="h4 o-expandable_header-left o-expandable_label">
+            <h3 class="h4 o-expandable_label">
                 Expandable Header 3
             </h3>
-            <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}

--- a/test/unit-test/src/cfpb-expandables/src/Expandable-spec.js
+++ b/test/unit-test/src/cfpb-expandables/src/Expandable-spec.js
@@ -11,7 +11,7 @@ const HTML_SNIPPET = `
             <span class="o-expandable_header-left o-expandable_label">
                 Expandable Header 1
             </span>
-            <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     Show
                 </span>
@@ -37,7 +37,7 @@ const HTML_SNIPPET = `
             <span class="o-expandable_header-left o-expandable_label">
                 Expandable Header 2
             </span>
-            <span class="o-expandable_header-right o-expandable_link">
+            <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     Show
                 </span>


### PR DESCRIPTION
Fixes https://github.com/cfpb/design-system/issues/1398

## Changes

- Converts expandable header from a float to a flexbox layout.

## Testing

1. `yarn start` and view http://localhost:4000/design-system/components/expandables and resize the window and expand/collapse the expandables.

## Screenshots

Before:

<img width="435" alt="Screen Shot 2022-10-11 at 12 31 57 PM" src="https://user-images.githubusercontent.com/704760/195148878-09a0652b-74bb-4d5a-aa38-5fd379c9c4c8.png">

After:

<img width="443" alt="Screen Shot 2022-10-11 at 12 31 01 PM" src="https://user-images.githubusercontent.com/704760/195148922-894e30a1-4730-43e5-a20d-07dc1b5d014d.png">