### PR TITLE
Update cfpb-expandables.less to include `justify-content: space-between;`

### DIFF
--- a/packages/cfpb-expandables/src/cfpb-expandables.less
+++ b/packages/cfpb-expandables/src/cfpb-expandables.less
@@ -112,6 +112,7 @@
 
   &_header {
     display: flex;
+    justify-content: space-between;
 
     // Using the button element with .o-expandable_header requires setting
     // an explicit width.


### PR DESCRIPTION
This is needed for an expandable in the rural and underserved populations app.

## Changes

- Update cfpb-expandables.less to include `justify-content: space-between;`

## Testing

1. Check the expandables page in the PR preview and see that the expandables toggle is unchanged.
