### PR TITLE
Set a min-width for expandable toggles

### DIFF
--- a/packages/cfpb-expandables/src/cfpb-expandables.less
+++ b/packages/cfpb-expandables/src/cfpb-expandables.less
@@ -101,6 +101,8 @@
   }
 
   &_link {
+    min-width: 60px;
+    text-align: right;
     color: @expandable_link-text;
     font-size: unit( ( @expandable_link-font-size / @base-font-size-px ), em );
     line-height: unit( ( @base-line-height-px / @expandable_link-font-size ) );


### PR DESCRIPTION
If an expandable has a very long header text, the toggle will wrap. This change sets a min-width on the toggle so it doesn't wrap, and also right aligns the text so the toggle aligns between the show and hide text.

## Changes

- Set a min-width for expandable toggles.

## Testing

1. Visit the PR preview and edit the header text for an expandable to a really long string and see how the toggle responds.

## Screenshots

Before:
<img width="823" alt="Screen Shot 2022-10-17 at 12 24 57 PM" src="https://user-images.githubusercontent.com/704760/196231485-f0086a41-393a-4fbf-bd78-f6b184ed9a32.png">

After:
<img width="817" alt="Screen Shot 2022-10-17 at 12 25 03 PM" src="https://user-images.githubusercontent.com/704760/196231503-2c9f7b1a-71cf-418d-a428-5d63d42dba04.png">
