### PR TITLE
Add fonts.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ test/unit-test-coverage/
 #################
 docs/dist/
 docs/assets/icons/
+docs/fonts/
 docs/_site
 .lighthouseci
 .sass-cache

--- a/docs/assets/css/main.less
+++ b/docs/assets/css/main.less
@@ -24,7 +24,7 @@
 
 // Webfont variables
 // This is the path for self-hosted fonts.
-@cf-fonts-path: '/static/fonts';
+@cf-fonts-path: '/design-system/fonts';
 
 // Documentation specific stlyes
 html,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "design-system-link": "lerna exec -- yarn link",
     "design-system-unlink": "lerna exec -- yarn unlink",
     "lint": "scripts/lint.sh",
-    "postinstall": "yarn run copy-icons && bundle install",
+    "postinstall": "./scripts/fonts.sh && yarn run copy-icons && bundle install",
     "process-icon-svgs": "svgo -f packages/cfpb-icons/src/icons --config=svgo.config.js",
     "release": "yarn run build && gulp build && lerna publish --no-verify-access",
     "start": "yarn run compile-dev && concurrently --kill-others \"yarn serve-netlify\" \"yarn serve-jekyll\" \"yarn run compile-dev --watch\"",

--- a/scripts/fonts.sh
+++ b/scripts/fonts.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
-# Add required webfonts locally to src/static/fonts/ directory.
-mkdir ./static/
-mkdir ./static/fonts
-cd ./static/fonts
+# Add required webfonts locally to docs/fonts/ directory.
+mkdir ./docs/fonts/
+cd ./docs/fonts
 curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?raw=true' --output '1e9892c0-6927-4412-9874-1b82801ba47a.woff'
 curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?raw=true' --output '2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2'
 curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?raw=true' --output '627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2'

--- a/scripts/fonts.sh
+++ b/scripts/fonts.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Add required webfonts locally to src/static/fonts/ directory.
+mkdir ./static/
+mkdir ./static/fonts
+cd ./static/fonts
+curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?raw=true' --output '1e9892c0-6927-4412-9874-1b82801ba47a.woff'
+curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?raw=true' --output '2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2'
+curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?raw=true' --output '627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2'
+curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?raw=true' --output 'f26faddb-86cc-4477-a253-1e1287684336.woff'
+cd ../../
+


### PR DESCRIPTION
https://github.com/cfpb/design-system/pull/1370 removed the fonts cdn logic, but we still need to install the fonts to be served on the site.

## Additions

- Add fonts.sh script 

## Changes

- Runs font download script on postinstall

## Testing

1. PR Checks should pass and PR preview should not have 404s for the fonts.
