### PR TITLE
Force postinstall run in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-scripts
 
+      - name: Postinstall
+        run: yarn run postinstall
+
       - name: Build styles
         run: yarn run gulp styles
 


### PR DESCRIPTION
We are `--ignore-scripts`ing the install which doesn't actually fetch the fonts (since we put it in postinstall for ergonomics). This manually runs postinstall.