### PR TITLE
Fix font.sh curl commands 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --ignore-scripts
 
-      - name: Postinstall
-        run: yarn run postinstall
-
       - name: Build styles
         run: yarn run gulp styles
 

--- a/scripts/fonts.sh
+++ b/scripts/fonts.sh
@@ -3,9 +3,9 @@
 # Add required webfonts locally to docs/fonts/ directory.
 mkdir ./docs/fonts/
 cd ./docs/fonts
-# Flags: s = silent, O = same output file name as remote, L = follow redirects.
-curl -sOL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/1e9892c0-6927-4412-9874-1b82801ba47a.woff?raw=true'
-curl -sOL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?raw=true'
-curl -sOL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?raw=true'
-curl -sOL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/f26faddb-86cc-4477-a253-1e1287684336.woff?raw=true'
+# Flags: s = silent, L = follow redirects.
+curl -sL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/1e9892c0-6927-4412-9874-1b82801ba47a.woff?raw=true' >> '1e9892c0-6927-4412-9874-1b82801ba47a.woff'
+curl -sL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?raw=true' >> '2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2'
+curl -sL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?raw=true' >> '627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2'
+curl -sL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/f26faddb-86cc-4477-a253-1e1287684336.woff?raw=true' >> 'f26faddb-86cc-4477-a253-1e1287684336.woff'
 cd ../../

--- a/scripts/fonts.sh
+++ b/scripts/fonts.sh
@@ -3,9 +3,10 @@
 # Add required webfonts locally to docs/fonts/ directory.
 mkdir ./docs/fonts/
 cd ./docs/fonts
-# Flags: s = silent, L = follow redirects.
-curl -sL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/1e9892c0-6927-4412-9874-1b82801ba47a.woff?raw=true' >> '1e9892c0-6927-4412-9874-1b82801ba47a.woff'
-curl -sL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?raw=true' >> '2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2'
-curl -sL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?raw=true' >> '627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2'
-curl -sL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/f26faddb-86cc-4477-a253-1e1287684336.woff?raw=true' >> 'f26faddb-86cc-4477-a253-1e1287684336.woff'
+prefix="https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/"
+fonts=("1e9892c0-6927-4412-9874-1b82801ba47a.woff" "2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2" "627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2" "f26faddb-86cc-4477-a253-1e1287684336.woff")
+for font in ${fonts[@]}; do
+  # Flags: s = silent, L = follow redirects.
+  curl -sL "${prefix}${font}?raw=true" > ${font}
+done
 cd ../../

--- a/scripts/fonts.sh
+++ b/scripts/fonts.sh
@@ -3,9 +3,9 @@
 # Add required webfonts locally to docs/fonts/ directory.
 mkdir ./docs/fonts/
 cd ./docs/fonts
-curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?raw=true' --output '1e9892c0-6927-4412-9874-1b82801ba47a.woff'
-curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?raw=true' --output '2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2'
-curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?raw=true' --output '627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2'
-curl -s 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?raw=true' --output 'f26faddb-86cc-4477-a253-1e1287684336.woff'
+# Flags: s = silent, O = same output file name as remote, L = follow redirects.
+curl -sOL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/1e9892c0-6927-4412-9874-1b82801ba47a.woff?raw=true'
+curl -sOL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2?raw=true'
+curl -sOL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2?raw=true'
+curl -sOL 'https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/f26faddb-86cc-4477-a253-1e1287684336.woff?raw=true'
 cd ../../
-


### PR DESCRIPTION
Oops the curl commands here for the fonts were incorrect and were downloading zero kb files!

## Changes

- Fixes curl command URLs and flags to be correct in fonts.sh script.
- Reverts https://github.com/cfpb/design-system/pull/1429

## Testing

- PR checks should pass.
- Running ./scripts/fonts.sh should produce font files that have a file size.
