### PR TITLE
Convert two react class components to functional components

### DIFF
--- a/docs/admin/src/widgets/StringTrimmed.js
+++ b/docs/admin/src/widgets/StringTrimmed.js
@@ -9,11 +9,11 @@ export default function StringTrimmedControl({
   setActiveStyle,
   setInactiveStyle,
 }) {
-  const [state, setState] = React.useState({ value: value || '' });
+  const [inputValue, setInputValue] = React.useState(value || '');
 
   const handleChange = (event) => {
     onChange(event.target.value.trim());
-    setState({ value: event.target.value });
+    setInputValue(event.target.value);
   };
 
   return (
@@ -21,8 +21,8 @@ export default function StringTrimmedControl({
       type="text"
       id={forID}
       className={classNameWrapper}
-      value={state.value}
-      onChange={(event) => handleChange(event)}
+      value={inputValue}
+      onChange={handleChange}
       onFocus={setActiveStyle}
       onBlur={setInactiveStyle}
     />
@@ -32,7 +32,7 @@ export default function StringTrimmedControl({
 StringTrimmedControl.propTypes = {
   onChange: PropTypes.func.isRequired,
   forID: PropTypes.string,
-  value: PropTypes.node,
+  value: PropTypes.string,
   classNameWrapper: PropTypes.string.isRequired,
   setActiveStyle: PropTypes.func.isRequired,
   setInactiveStyle: PropTypes.func.isRequired,

--- a/docs/admin/src/widgets/StringTrimmed.js
+++ b/docs/admin/src/widgets/StringTrimmed.js
@@ -1,39 +1,39 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default class StringTrimmedControl extends React.Component {
-  static propTypes = {
-    onChange: PropTypes.func.isRequired,
-    forID: PropTypes.string,
-    value: PropTypes.node,
-    classNameWrapper: PropTypes.string.isRequired,
-    setActiveStyle: PropTypes.func.isRequired,
-    setInactiveStyle: PropTypes.func.isRequired,
+export default function StringTrimmedControl({
+  onChange,
+  forID,
+  value,
+  classNameWrapper,
+  setActiveStyle,
+  setInactiveStyle,
+}) {
+  const [state, setState] = React.useState({ value: value || '' });
+
+  const handleChange = (event) => {
+    onChange(event.target.value.trim());
+    setState({ value: event.target.value });
   };
 
-  state = {
-    value: this.props.value || '',
-  };
-
-  handleChange(event) {
-    this.props.onChange(event.target.value.trim());
-    this.setState({ value: event.target.value });
-  }
-
-  render() {
-    const { forID, classNameWrapper, setActiveStyle, setInactiveStyle } =
-      this.props;
-
-    return (
-      <input
-        type="text"
-        id={forID}
-        className={classNameWrapper}
-        value={this.state.value}
-        onChange={(event) => this.handleChange(event)}
-        onFocus={setActiveStyle}
-        onBlur={setInactiveStyle}
-      />
-    );
-  }
+  return (
+    <input
+      type="text"
+      id={forID}
+      className={classNameWrapper}
+      value={state.value}
+      onChange={(event) => handleChange(event)}
+      onFocus={setActiveStyle}
+      onBlur={setInactiveStyle}
+    />
+  );
 }
+
+StringTrimmedControl.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  forID: PropTypes.string,
+  value: PropTypes.node,
+  classNameWrapper: PropTypes.string.isRequired,
+  setActiveStyle: PropTypes.func.isRequired,
+  setInactiveStyle: PropTypes.func.isRequired,
+};

--- a/docs/admin/src/widgets/StringWithInstructions.js
+++ b/docs/admin/src/widgets/StringWithInstructions.js
@@ -13,53 +13,53 @@ const instructionsLinkStyle = {
   'text-decoration': 'underline',
 };
 
-export default class StringTrimmedControl extends React.Component {
-  static propTypes = {
-    onChange: PropTypes.func.isRequired,
-    forID: PropTypes.string,
-    value: PropTypes.node,
-    classNameWrapper: PropTypes.string.isRequired,
-    setActiveStyle: PropTypes.func.isRequired,
-    setInactiveStyle: PropTypes.func.isRequired,
+export default function StringTrimmedControl({
+  onChange,
+  forID,
+  value,
+  classNameWrapper,
+  setActiveStyle,
+  setInactiveStyle,
+}) {
+  const [inputValue, setInputValue] = React.useState(value || '');
+
+  const handleChange = (event) => {
+    onChange(event.target.value.trim());
+    setInputValue(event.target.value);
   };
 
-  state = {
-    value: this.props.value || '',
-  };
-
-  handleChange(event) {
-    this.props.onChange(event.target.value.trim());
-    this.setState({ value: event.target.value });
-  }
-
-  render() {
-    const { forID, classNameWrapper, setActiveStyle, setInactiveStyle } =
-      this.props;
-
-    return (
-      <div>
-        <input
-          type="text"
-          id={forID}
-          className={classNameWrapper}
-          value={this.state.value}
-          onChange={(event) => this.handleChange(event)}
-          onFocus={setActiveStyle}
-          onBlur={setInactiveStyle}
-        />
-        <div style={instructionsContainerStyle}>
-          Need help? Check out our guide on&nbsp;
-          <a
-            href="/design-system/updating-this-website/"
-            target="_blank"
-            rel="noopener noreferrer"
-            style={instructionsLinkStyle}
-          >
-            how to use this CMS
-          </a>
-          .
-        </div>
+  return (
+    <div>
+      <input
+        type="text"
+        id={forID}
+        className={classNameWrapper}
+        value={inputValue}
+        onChange={handleChange}
+        onFocus={setActiveStyle}
+        onBlur={setInactiveStyle}
+      />
+      <div style={instructionsContainerStyle}>
+        Need help? Check out our guide on&nbsp;
+        <a
+          href="/design-system/updating-this-website/"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={instructionsLinkStyle}
+        >
+          how to use this CMS
+        </a>
+        .
       </div>
-    );
-  }
+    </div>
+  );
 }
+
+StringTrimmedControl.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  forID: PropTypes.string,
+  value: PropTypes.node,
+  classNameWrapper: PropTypes.string.isRequired,
+  setActiveStyle: PropTypes.func.isRequired,
+  setInactiveStyle: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
Refactors two react classes to use functional components instead of class components, per #1423.

## Changes

- Refactors `StringTrimmedControl` to use functional components instead of class components.

## Testing

1. PR checks should pass.
2. Any regressions should show up in the netlify preview.

## Notes

- I'm new to some of these libraries, so apologies if I'm doing something non-idiomatic. (Please let me know, if so!)
- There are three more class components in `admin/src/widgets`, which I'm planning on handling in a subsequent PR.