### PR TITLE
Upgrade to node 18

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -15,7 +15,7 @@ jobs:
       # Install Node and configure its cache.
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
 
       # https://github.com/actions/cache/blob/master/examples.md#node---yarn
       - name: Get yarn cache directory path

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,7 +11,7 @@ jobs:
         steps:
         - uses: actions/setup-node@v3
           with:
-            node-version: 16
+            node-version: 18
         - uses: ruby/setup-ruby@v1.81.0
           with:
             ruby-version: '2.7.1'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           registry-url: 'https://npm.pkg.github.com'
 
       - name: Config Git

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Install dependencies with Yarn
       run: yarn
@@ -43,7 +43,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Set up Ruby for Jekyll
       uses: ruby/setup-ruby@v1.81.0

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  environment = { NODE_VERSION = "16.17.1" }
+  environment = { NODE_VERSION = "18.12.0" }
   publish = "docs/_site/"
   command = "./scripts/build-netlify-pr-preview.sh"
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "a11y": "lhci autorun",
     "build": "yarn run compile-dev && bundle exec jekyll build",
-    "build-netlify": "NODE_VERSION=14.17.5 && yarn && yarn run compile-prod && bundle exec jekyll build",
+    "build-netlify": "NODE_VERSION=18.12.0 && yarn && yarn run compile-prod && bundle exec jekyll build",
     "changelog": "./scripts/generate-changelog.sh",
     "compile-dev": "webpack --config webpack.config.docs.js --mode=development",
     "compile-prod": "webpack --config webpack.config.docs.js --mode=production",


### PR DESCRIPTION
Migrating to node 18 will allow use to update to latest Jest.

## Changes

- Upgrade to node 18 from 16

## Testing

1. PR checks should pass.
2. Update your local node via `nvm install 18 && nvm use 18`
