### PR TITLE
Remove empty link from Conducting Research

### DIFF
--- a/docs/pages/conducting-research-3.md
+++ b/docs/pages/conducting-research-3.md
@@ -24,7 +24,7 @@ description: >-
   Once the goals and objectives of a research initiative are established, it’s important to carefully define the audience ([see 18F’s guide for more info](https://ux-guide.18f.gov/research/plan/#participants-and-recruiting)) and then to take the time needed to recruit for that audience.   
 
 
-  To quote 18F, [you must do research with people who will actually use your services](https://ux-guide.18f.gov/research/plan/#participants-and-recruiting). It’s counterproductive and potentially harmful to[](bookmark://_Identify_hazards_and)draw conclusions from research conducted with people who are not in the right demographic or target group, or who don’t share the experience or situation that the research aims to understand.
+  To quote 18F, [you must do research with people who will actually use your services](https://ux-guide.18f.gov/research/plan/#participants-and-recruiting). It’s counterproductive and potentially harmful to draw conclusions from research conducted with people who are not in the right demographic or target group, or who don’t share the experience or situation that the research aims to understand.
 
 
   Consider the unintended consequences of your recruitment approach. For example, recruiting via personal networks can lead to hearing only from people who share similar characteristics, values, and beliefs as yourself. Ask yourself whether these people are authentic representatives of the people who will ultimately use your product. Similarly, recruiting via social media can omit people who don’t have internet access at all. These issues are known as [sampling bias](https://cfpb.github.io/design-system/guidelines/conducting-research#be-aware-of-how-bias-can-show-up-during-research).     


### PR DESCRIPTION
The [Conducting Research page](https://cfpb.github.io/design-system/guidelines/conducting-research) currently has an empty link that points to a non-existing bookmark (note "harmful todraw"):

<img width="673" alt="image" src="https://user-images.githubusercontent.com/654645/199486015-9ecd6ec5-aac6-48f2-9aae-2a3f798a70b2.png">

When the page [was first created](https://github.com/cfpb/design-system/commit/a7f05aa5a37c07a68892a5b76d5c6a1fdb55330e#diff-9f71e1d32f07f2458729149d0ab03d428cf4d8a10424439f8e3ee7628e98cc8dR23), the word "harmful" linked to an "Identify hazards and" bookmark. This link was seemingly removed [during the editing process](https://github.com/cfpb/design-system/commit/ea4493eb510d02a9fbcbaa0b36d2ca5bd3472cab#diff-9f71e1d32f07f2458729149d0ab03d428cf4d8a10424439f8e3ee7628e98cc8dR23) but an empty link was left behind, perhaps due to a Netlify CMS issue.

This empty link fails the Lighthouse accessibility audit for this page, [see report](https://github.com/cfpb/design-system/commit/ea4493eb510d02a9fbcbaa0b36d2ca5bd3472cab#diff-9f71e1d32f07f2458729149d0ab03d428cf4d8a10424439f8e3ee7628e98cc8dR23).

@jenn-franklin I've removed this link here, but please suggest if it should instead be restored pointing somewhere else on the page.