### PR TITLE
Set same node version for netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  environment = { NODE_VERSION = "16.17.1" }
+  environment = { NODE_VERSION = "16.18.0" }
   publish = "docs/_site/"
   command = "./scripts/build-netlify-pr-preview.sh"
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "a11y": "lhci autorun",
     "build": "yarn run compile-dev && bundle exec jekyll build",
-    "build-netlify": "NODE_VERSION=14.17.5 && yarn && yarn run compile-prod && bundle exec jekyll build",
+    "build-netlify": "NODE_VERSION=16.18.0 && yarn && yarn run compile-prod && bundle exec jekyll build",
     "changelog": "./scripts/generate-changelog.sh",
     "compile-dev": "webpack --config webpack.config.docs.js --mode=development",
     "compile-prod": "webpack --config webpack.config.docs.js --mode=production",


### PR DESCRIPTION
Netlify settings and script had differing node versions. This sets both to the latest 16.x version

## Changes

- Set same node version for netlify settings.

## Testing

1. PR checks should pass.
