### PR TITLE
Consolidate cf.gov responsive table styles, ignore print media

### DIFF
--- a/docs/pages/tables.md
+++ b/docs/pages/tables.md
@@ -95,7 +95,7 @@ variation_groups:
       structure, even on a smaller screen.
 
 
-      Note that tables are **not** responsive unless you add one of the small screen classes detailed below. Also note that the `data-label` attribute must be used to label each cell in a `table` for small screen responsive views.
+      Note that tables are **not** responsive unless you add one of the small screen classes detailed below. Also note that the `data-label` attribute must be used to label each cell in a `table` for small screen responsive views. Responsive layouts are **not** applied to tables when pages are printed.
     variations:
       - variation_name: Responsive stacked table
         variation_description: >

--- a/packages/cfpb-tables/src/cfpb-tables.less
+++ b/packages/cfpb-tables/src/cfpb-tables.less
@@ -13,12 +13,12 @@
 
 // Color variables
 
-@table-cell-bg:              @white;
-@table-cell-bg_alt:          @gray-5;
-@table-row-link-bg-hover:    @pacific-80;
+@table-cell-bg: @white;
+@table-cell-bg_alt: @gray-5;
+@table-row-link-bg-hover: @pacific-80;
 @table-row-link-hover-color: @white;
-@table-scrolling-border:     @gray-40;
-@table-border:               @gray;
+@table-scrolling-border: @gray-40;
+@table-border: @gray;
 
 // Mixins
 .striped-table() {
@@ -114,12 +114,14 @@
   }
 } );
 
-.respond-to-max( @bp-xs-max, {
+// We don't want responsive table styles applied to the `print` media type
+// so we're not using .respond-to-max( @bp-xs-max ) here.
+@media only screen and ( max-width: @bp-xs-max ) {
   .o-table {
     width: 100%;
   }
 
-  .o-table__striped tr:nth-child(even) {
+  .o-table__striped tr:nth-child( even ) {
     & > th,
     & > td {
       background: @table-cell-bg;
@@ -127,31 +129,40 @@
   }
 
   .o-table__stack-on-small {
+    border-top: 1px solid @gray-40;
+
     tr,
-    td {
+    td,
+    [data-display-table='row'],
+    [data-display-table='cell'] {
       display: block;
     }
 
     th,
-    td {
+    td,
+    [data-display-table='cell'] {
+      padding-right: 0;
+      padding-left: 0;
       width: 100%;
     }
 
-    & > thead {
-      display: none
+    & > thead,
+    [data-display-table='thead'] {
+      display: none;
     }
 
     td[data-label]:before {
       .heading-5();
       display: block;
       margin-top: 0;
-      margin-bottom: 0.41666667em;
-      content: attr(data-label);
+      margin-bottom: unit( (5px / @base-font-size-px), em );
+      content: attr( data-label );
       line-height: 1.83333333;
     }
 
-    td:last-child {
-      margin-bottom: unit( ( 30px / @base-font-size-px ), em );
+    td:last-child,
+    [data-display-table='cell']:last-child {
+      margin-bottom: unit( (30px / @base-font-size-px), em );
     }
   }
 
@@ -159,7 +170,7 @@
     & > tbody td:first-child {
       padding-bottom: 0.75em;
       border-bottom: 1px solid @table-border;
-      margin-bottom: unit( ( 10px / @base-font-size-px), em);
+      margin-bottom: unit( (10px / @base-font-size-px), em );
       margin-top: 0;
       background-color: @table-head-bg;
       font-size: 1.125em;
@@ -173,7 +184,7 @@
 
     & > tbody > tr {
       border-bottom: none;
-      margin-bottom: unit( ( 30px / @base-font-size-px ), em );
+      margin-bottom: unit( (30px / @base-font-size-px), em );
     }
   }
-} );
+}


### PR DESCRIPTION
Our responsive table styles are [duplicated in cf.gov](https://github.com/cfpb/consumerfinance.gov/blob/2ace1532d9b24595db6b436f008f02cc7e03ae19/cfgov/unprocessed/css/enhancements/tables.less#L125-L170). This PR consolidates them in the DS and a subsequent PR will remove them from cf.gov.

Also, printing a page triggers our smallest 600px breakpoint, causing our mobile styles to be applied. This is fine for most of our design patterns but it provides a degraded experience on pages with HTML tables. The responsive table media query has been updated to only apply to `screen` media types and not `print`.

See https://github.local/CFPB/1071-data-collection/issues/317#issuecomment-326594

## Changes

- Consolidated our responsive tables styles from cf.gov.
- Tables are not responsive with `print` media types.

## Testing

1. The tables page at the PR preview link should look identical to the [production tables page](https://cfpb.github.io/design-system/components/tables).
2. Try print previewing the above two pages and the responsive tables should no longer be stacked.

## Screenshots

Here's the results on our table-heavy [FIG page](https://secret-dev4-demo-sever.cfpb.gov/data-research/small-business-lending/filing-instructions-guide/202x-filing-instructions-guide/):

| before | after |
|--------|-------|
| <img width="613" alt="2" src="https://user-images.githubusercontent.com/1060248/203394918-2849d0f9-4052-4a6f-8d73-c96a1c7eb29d.png"> | <img width="613" alt="1" src="https://user-images.githubusercontent.com/1060248/203394906-556391dc-026a-464f-b2c2-469ae3bd11aa.png"> |