### PR TITLE
Remove default export from type-checkers

### DIFF
--- a/packages/cfpb-atomic-component/README.md
+++ b/packages/cfpb-atomic-component/README.md
@@ -46,7 +46,12 @@ Utility functions for checking Javascript types and primitives.
 
 ```
 var assert = require( 'assert' );
-import typeCheckers from '../utilities/type-checkers.js';
+import {
+  isUndefined,
+  isObject,
+  isFunction,
+  isDate
+} from '../utilities/type-checkers.js';
 
 var UNDEFINED;
 

--- a/packages/cfpb-atomic-component/src/components/AtomicComponent.js
+++ b/packages/cfpb-atomic-component/src/components/AtomicComponent.js
@@ -14,7 +14,7 @@ import { instantiateAll, setInitFlag } from '../utilities/atomic-helpers.js';
 import { assign } from '../utilities/object-assign.js';
 import Delegate from 'ftdomdelegate';
 import EventObserver from '../mixins/EventObserver.js';
-import typeCheckers from '../utilities/type-checkers.js';
+import { isFunction } from '../utilities/type-checkers.js';
 
 const TAG_NAME = 'div';
 
@@ -46,7 +46,7 @@ assign(AtomicComponent.prototype, new EventObserver(), {
    */
   init: function () {
     this.initializers.forEach(function (func) {
-      if (typeCheckers.isFunction(func)) {
+      if (isFunction(func)) {
         func.apply(this, arguments);
       }
     }, this);
@@ -205,7 +205,7 @@ assign(AtomicComponent.prototype, new EventObserver(), {
     for (key in events) {
       if ({}.hasOwnProperty.call(events, key)) {
         method = events[key];
-        if (typeCheckers.isFunction(this[method])) {
+        if (isFunction(this[method])) {
           method = this[method];
         }
         if (method) {

--- a/packages/cfpb-atomic-component/src/utilities/dom-traverse.js
+++ b/packages/cfpb-atomic-component/src/utilities/dom-traverse.js
@@ -1,4 +1,4 @@
-import typeCheckers from './type-checkers.js';
+import { isString } from './type-checkers.js';
 
 /**
  * Queries for the first match unless an HTMLElement is passed
@@ -8,9 +8,7 @@ import typeCheckers from './type-checkers.js';
  * @returns {HTMLElement} The element.
  */
 function queryOne(expr, con) {
-  return typeCheckers.isString(expr)
-    ? (con || document).querySelector(expr)
-    : expr || null;
+  return isString(expr) ? (con || document).querySelector(expr) : expr || null;
 }
 
 /**

--- a/packages/cfpb-atomic-component/src/utilities/type-checkers.js
+++ b/packages/cfpb-atomic-component/src/utilities/type-checkers.js
@@ -141,14 +141,14 @@ function isEmpty(value) {
 /* eslint-enable complexity, no-mixed-operators */
 
 // Expose public methods.
-export default {
-  isUndefined: isUndefined,
-  isDefined: isDefined,
-  isObject: isObject,
-  isString: isString,
-  isNumber: isNumber,
-  isDate: isDate,
-  isArray: isArray,
-  isFunction: isFunction,
-  isEmpty: isEmpty,
+export {
+  isUndefined,
+  isDefined,
+  isObject,
+  isString,
+  isNumber,
+  isDate,
+  isArray,
+  isFunction,
+  isEmpty,
 };

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/type-checkers.spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/type-checkers.spec.js
@@ -1,4 +1,14 @@
-import typeCheckers from '../../../../../../packages/cfpb-atomic-component/src/utilities/type-checkers.js';
+import {
+  isUndefined,
+  isDefined,
+  isObject,
+  isString,
+  isNumber,
+  isDate,
+  isArray,
+  isFunction,
+  isEmpty,
+} from '../../../../../../packages/cfpb-atomic-component/src/utilities/type-checkers.js';
 
 const blankVar = '';
 const aString = 'bar';
@@ -23,99 +33,99 @@ let UNDEFINED;
 
 describe('TypeCheckers isUndefined', () => {
   it('should identify undefined variables', () => {
-    expect(typeCheckers.isUndefined(UNDEFINED)).toBe(true);
+    expect(isUndefined(UNDEFINED)).toBe(true);
   });
 
   it('should NOT return true for blank variables', () => {
-    expect(typeCheckers.isUndefined(blankVar)).toBe(false);
+    expect(isUndefined(blankVar)).toBe(false);
   });
 
   it('should NOT return true for defined variables', () => {
-    expect(typeCheckers.isUndefined(aString)).toBe(false);
+    expect(isUndefined(aString)).toBe(false);
   });
 });
 
 describe('TypeCheckers isDefined', () => {
   it('should return true for defined variables', () => {
-    expect(typeCheckers.isDefined(aString)).toBe(true);
+    expect(isDefined(aString)).toBe(true);
   });
 
   it('should return true for blank variables', () => {
-    expect(typeCheckers.isDefined(blankVar)).toBe(true);
+    expect(isDefined(blankVar)).toBe(true);
   });
 
   it('should NOT return true for undefined variables', () => {
-    expect(typeCheckers.isDefined(UNDEFINED)).toBe(false);
+    expect(isDefined(UNDEFINED)).toBe(false);
   });
 });
 
 describe('TypeCheckers isObject', () => {
   it('should return true for objects', () => {
-    expect(typeCheckers.isObject(anObject)).toBe(true);
+    expect(isObject(anObject)).toBe(true);
   });
 
   it('should return false for strings', () => {
-    expect(typeCheckers.isObject(aString)).toBe(false);
+    expect(isObject(aString)).toBe(false);
   });
 });
 
 describe('TypeCheckers isString', () => {
   it('should return true for strings', () => {
-    expect(typeCheckers.isString(aString)).toBe(true);
+    expect(isString(aString)).toBe(true);
   });
 
   it('should return false for objects', () => {
-    expect(typeCheckers.isString(anObject)).toBe(false);
+    expect(isString(anObject)).toBe(false);
   });
 });
 
 describe('TypeCheckers isNumber', () => {
   it('should return true for numbers', () => {
-    expect(typeCheckers.isNumber(aNum)).toBe(true);
+    expect(isNumber(aNum)).toBe(true);
   });
 
   it('should return false for strings', () => {
-    expect(typeCheckers.isNumber(aString)).toBe(false);
-    expect(typeCheckers.isNumber('42')).toBe(false);
+    expect(isNumber(aString)).toBe(false);
+    expect(isNumber('42')).toBe(false);
   });
 });
 
 describe('TypeCheckers isDate', () => {
   it('should return true for dates', () => {
-    expect(typeCheckers.isDate(aDate)).toBe(true);
+    expect(isDate(aDate)).toBe(true);
   });
 
   it('should return false for numbers', () => {
-    expect(typeCheckers.isDate(aNum)).toBe(false);
+    expect(isDate(aNum)).toBe(false);
   });
 });
 
 describe('TypeCheckers isArray', () => {
   it('should return true for arrays', () => {
-    expect(typeCheckers.isArray(anArray)).toBe(true);
+    expect(isArray(anArray)).toBe(true);
   });
 
   it('should return false for objects', () => {
-    expect(typeCheckers.isArray(anObject)).toBe(false);
+    expect(isArray(anObject)).toBe(false);
   });
 });
 
 describe('TypeCheckers isFunction', () => {
   it('should return true for a functions', () => {
-    expect(typeCheckers.isFunction(aFunction)).toBe(true);
+    expect(isFunction(aFunction)).toBe(true);
   });
 
   it('should return false for a non-function', () => {
-    expect(typeCheckers.isFunction(aString)).toBe(false);
+    expect(isFunction(aString)).toBe(false);
   });
 });
 
 describe('TypeCheckers isEmpty', () => {
   it('should return true for empty vars', () => {
-    expect(typeCheckers.isEmpty(blankVar)).toBe(true);
+    expect(isEmpty(blankVar)).toBe(true);
   });
 
   it('should return false for non-empty vars', () => {
-    expect(typeCheckers.isEmpty(aString)).toBe(false);
+    expect(isEmpty(aString)).toBe(false);
   });
 });


### PR DESCRIPTION
If the type checkers don't use a default export we can import the individual checkers where needed, which seems better.

## Changes

- Remove default export from type-checkers

## Testing

1. PR checks should pass.
