### PR TITLE
Fix broken require to lunr in search

### DIFF
--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -1,4 +1,4 @@
-const lunr = require('lunr');
+import lunr from 'lunr';
 
 /**
  * Update page markup with search results.

--- a/packages/cfpb-icons/src/icons-svg-inline.js
+++ b/packages/cfpb-icons/src/icons-svg-inline.js
@@ -1,4 +1,4 @@
-const path = require('path');
+import path from 'path';
 
 /**
  * This file is a less plugin that gets included in a less file via the


### PR DESCRIPTION
Oops this should be an import not a require in an esm world.

## Changes

- Change to an import for lunr search package.

## Testing

1. PR preview search should work.
