### PR TITLE
Downgrade to commonjs syntax in less plugin

### DIFF
--- a/packages/cfpb-icons/src/icons-svg-inline.js
+++ b/packages/cfpb-icons/src/icons-svg-inline.js
@@ -1,4 +1,4 @@
-import path from 'path';
+const path = require('path');
 
 /**
  * This file is a less plugin that gets included in a less file via the


### PR DESCRIPTION
Fixes issue where https://github.com/cfpb/design-system/pull/1505 broke `yarn start`
