### PR TITLE
Add after-install command to build-netlify yarn command

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "a11y": "lhci autorun",
     "build": "yarn compile-dev && bundle exec jekyll build",
-    "build-netlify": "yarn && yarn compile-prod && bundle exec jekyll build",
+    "build-netlify": "yarn install && yarn after-install && yarn compile-prod && bundle exec jekyll build",
     "changelog": "./scripts/generate-changelog.sh",
     "compile-dev": "webpack --config webpack.config.docs.js --mode=development",
     "compile-prod": "webpack --config webpack.config.docs.js --mode=production",


### PR DESCRIPTION
https://github.com/cfpb/design-system/pull/1532 made `yarn` or `yarn install` not automatically run `postinstall` (since it was renamed), so `after-install` needs to instead be manually run after `yarn`. This PR adds that in the `build-netlify` step, which had been calling `yarn`.

## Changes

- Add after-install command to build-netlify yarn command

## Testing

1. PR checks should pass.
