### PR TITLE
Editorconfig: Change all indenting to 2 space

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,3 @@
-[*.js]
+[*.{js,jsx,less,css,html}]
 indent_style = space
 indent_size = 2
-
-[*.{less,css,html}]
-indent_style = space
-indent_size = 4


### PR DESCRIPTION
cfgov uses 2 spaces for CSS (updated in https://github.com/cfpb/consumerfinance.gov/pull/7009). This PR changes the editorconfig to use 2 spaces, since we do that already in e.g. https://github.com/cfpb/design-system/blob/main/packages/cfpb-forms/src/organisms/multiselect.less

## Changes

- Change all indenting to 2 space

## Testing

1. PR checks should pass.
