### PR TITLE
Hide bullet on multiselect dropdown

### DIFF
--- a/packages/cfpb-forms/src/organisms/multiselect.less
+++ b/packages/cfpb-forms/src/organisms/multiselect.less
@@ -99,6 +99,7 @@ select.o-multiselect {
   }
 
   &_options {
+    list-style-type: none;
     background-color: @white;
     padding: 0;
 


### PR DESCRIPTION
@wpears [fixed this bullet on cfgov](https://github.com/cfpb/consumerfinance.gov/pull/7205), but I just noticed we have a duplicate `multiselect.less` in cfgov and the design-system and the edit never made it over here. 


## Changes

- Hide bullet on the multiselect.

## Testing

1. In the PR preview, visit the multiselect and add five items and there shouldn't have a bullet. The bullet looks like this:

<img width="254" alt="Screen Shot 2023-01-17 at 1 43 41 PM" src="https://user-images.githubusercontent.com/704760/212984574-56b40a8a-9f2a-499b-b457-40f7978336c5.png">
