### PR TITLE
Bugfix: Update banner URL in test

### DIFF
--- a/test/browser/docs/interstitial.js
+++ b/test/browser/docs/interstitial.js
@@ -8,7 +8,7 @@ describe('CMS interstitial page with editing instructions', () => {
 
   describe('Editing a component page', () => {
     beforeEach(async () => {
-      await browser.url('/design-system/components/banners');
+      await browser.url('/design-system/components/banner-notification');
       const editButton = await $('#edit-page');
       await editButton.waitForDisplayed();
       await editButton.click();


### PR DESCRIPTION
https://github.com/cfpb/design-system/pull/1546 updated the banners component URL. We have a test that depends on that URL, which then broke. This PR updates the URL in the test.

## Changes

- Update banner URL in test.

## Testing

1. PR checks should pass.
