### PR TITLE
Add FlyoutMenu behavior to DS

### DIFF
--- a/docs/assets/css/main.less
+++ b/docs/assets/css/main.less
@@ -161,6 +161,14 @@ main {
   }
 }
 
+.example-flyout-content {
+  width: 100px;
+  background-color: @red;
+  text-align: center;
+  color: @white;
+  cursor: pointer;
+}
+
 // TODO: See if these imports can be moved to the file top.
 /* stylelint-disable no-invalid-position-at-import-rule */
 // custom modules

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -5,6 +5,7 @@ import Multiselect from '@cfpb/cfpb-forms/src/organisms/Multiselect.js';
 import AlphaTransition from '@cfpb/cfpb-atomic-component/src/utilities/transition/AlphaTransition.js';
 import MoveTransition from '@cfpb/cfpb-atomic-component/src/utilities/transition/MoveTransition.js';
 import MaxHeightTransition from '@cfpb/cfpb-atomic-component/src/utilities/transition/MaxHeightTransition.js';
+import FlyoutMenu from '@cfpb/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js';
 import Tabs from './Tabs.js';
 import redirectBanner from './redirect-banner.js';
 import sidebar from './sidebar.js';
@@ -38,6 +39,7 @@ Expandable.init();
 window.AlphaTransition = AlphaTransition;
 window.MoveTransition = MoveTransition;
 window.MaxHeightTransition = MaxHeightTransition;
+window.FlyoutMenu = FlyoutMenu;
 
 // Tabs show under the show/hide details button on a pattern.
 const tabsContainerDom = document.querySelectorAll(`.${Tabs.BASE_CLASS}`);

--- a/docs/pages/transition-patterns.md
+++ b/docs/pages/transition-patterns.md
@@ -183,7 +183,8 @@ variation_groups:
   - variation_group_name: Behavior
     variations:
       - variation_name: Flyout behavior
-        variation_description: 'A "flyout behavior" can be attached to a arbitrary
+        variation_description:
+          'A "flyout behavior" can be attached to a arbitrary
           container that contains one or more triggers and a content area. The
           flyout handles `aria-expanded` attribute toggling and dispatches the
           following events: `triggerOver`, `triggerOut`, `triggerClick`,
@@ -202,7 +203,8 @@ variation_groups:
                 Click me! ^
               </button>
             </div>
-          </div> <script>
+          </div>
+          <script>
             const flyoutExample = document.querySelector( '.example-flyout' );
             const flyoutExampleContent = document.querySelector(
               '.example-flyout-content'
@@ -224,7 +226,8 @@ variation_groups:
                 Click me! ^
               </button>
             </div>
-          </div> <script>
+          </div>
+          <script>
             document.addEventListener( 'DOMContentLoaded', function() {
               const flyoutExample = document.querySelector( '.example-flyout' );
               const flyoutExampleContent = document.querySelector(
@@ -306,15 +309,15 @@ variation_groups:
           flyout.init();
 
           ```
-guidelines: ""
+guidelines: ''
 eyebrow: Transitions
 status: Released
 description: Transition patterns are animations that happen when a user
   interacts with an element on the page. They are CSS transition styles that are
   controlled via JavaScript.
-use_cases: ""
-behavior: ""
-accessibility: ""
+use_cases: ''
+behavior: ''
+accessibility: ''
 last_updated: 2020-01-28T15:55:47.394Z
-research: ""
+research: ''
 ---

--- a/docs/pages/transition-patterns.md
+++ b/docs/pages/transition-patterns.md
@@ -2,13 +2,9 @@
 title: Transition patterns
 layout: variation
 section: patterns
-eyebrow: Transitions
-status: Released
-description: Transition patterns are animations that happen when a user
-  interacts with an element on the page. They are CSS transition styles that are
-  controlled via JavaScript.
 variation_groups:
-  - variations:
+  - variation_group_name: Types
+    variations:
       - variation_name: Move transition
         variation_description: A transition that moves from one position to another.
         variation_code_snippet: >-
@@ -25,8 +21,7 @@ variation_groups:
             } );
           </script>
         variation_code_snippet_rendered: >-
-          <div class="u-move-transition example-box">Click me!</div>
-          <script>
+          <div class="u-move-transition example-box">Click me!</div> <script>
             document.addEventListener( 'DOMContentLoaded', function() {
               const moveTransitionExample = document.querySelector( '.example-box.u-move-transition' );
               const moveTransition = new MoveTransition( moveTransitionExample ).init();
@@ -81,8 +76,7 @@ variation_groups:
             } );
           </script>
         variation_code_snippet_rendered: >-
-          <div class="u-alpha-transition example-box">Click me!</div>
-          <script>
+          <div class="u-alpha-transition example-box">Click me!</div> <script>
             document.addEventListener( 'DOMContentLoaded', function() {
               const alphaTransitionExample = document.querySelector( '.example-box.u-alpha-transition' );
               const alphaTransition = new AlphaTransition( alphaTransitionExample ).init();
@@ -147,8 +141,7 @@ variation_groups:
 
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-          </div>
-          <script>
+          </div> <script>
             document.addEventListener( 'DOMContentLoaded', function() {
               const maxHeightTransitionExample = document.querySelector( '.example-box.u-max-height-summary' );
               const maxHeightTransition = new MaxHeightTransition( maxHeightTransitionExample ).init();
@@ -161,8 +154,8 @@ variation_groups:
             } );
           </script>
         variation_implementation: >-
-          The max-height transition is added to an element by creating a
-          new MaxHeightTransition instance in JavaScript and calling its methods:
+          The max-height transition is added to an element by creating a new
+          MaxHeightTransition instance in JavaScript and calling its methods:
 
 
           ```
@@ -187,12 +180,141 @@ variation_groups:
           transition.maxHeightSummary();
 
           ```
-    variation_group_name: Types
-    variation_group_description: ''
-use_cases: ''
-guidelines: ''
-behavior: ''
-accessibility: ''
+  - variation_group_name: Behavior
+    variations:
+      - variation_name: Flyout behavior
+        variation_description: 'A "flyout behavior" can be attached to a arbitrary
+          container that contains one or more triggers and a content area. The
+          flyout handles `aria-expanded` attribute toggling and dispatches the
+          following events: `triggerOver`, `triggerOut`, `triggerClick`,
+          `expandBegin`, `expandEnd`, `collapseBegin`, `collapseEnd`. This
+          handles the markup semantics of toggling a content area, which can
+          then be combined with a transition from above to create an animated
+          container that shows and hides content.'
+        variation_code_snippet: >-
+          <div class="example-flyout" data-js-hook="behavior_flyout-menu">
+            <button class="example-btn" data-js-hook="behavior_flyout-menu_trigger">
+              Click me! v
+            </button>
+            <div class="example-flyout-content" data-js-hook="behavior_flyout-menu_content">
+              Show this content
+              <button class="example-btn" data-js-hook="behavior_flyout-menu_trigger">
+                Click me! ^
+              </button>
+            </div>
+          </div> <script>
+            const flyoutExample = document.querySelector( '.example-flyout' );
+            const flyoutExampleContent = document.querySelector(
+              '.example-flyout-content'
+            );
+            const transition = new MaxHeightTransition(flyoutExampleContent).init();
+            const flyout = new FlyoutMenu(flyoutExample);
+            flyout.setExpandTransition(transition, transition.maxHeightDefault);
+            flyout.setCollapseTransition(transition, transition.maxHeightZero);
+            flyout.init();
+          </script>
+        variation_code_snippet_rendered: >-
+          <div class="example-flyout" data-js-hook="behavior_flyout-menu">
+            <button class="example-btn" data-js-hook="behavior_flyout-menu_trigger">
+              Click me! v
+            </button>
+            <div class="example-flyout-content" data-js-hook="behavior_flyout-menu_content">
+              Show this content
+              <button class="example-btn" data-js-hook="behavior_flyout-menu_trigger">
+                Click me! ^
+              </button>
+            </div>
+          </div> <script>
+            document.addEventListener( 'DOMContentLoaded', function() {
+              const flyoutExample = document.querySelector( '.example-flyout' );
+              const flyoutExampleContent = document.querySelector(
+                '.example-flyout-content'
+              );
+              const transition = new MaxHeightTransition(flyoutExampleContent).init();
+              const flyout = new FlyoutMenu(flyoutExample);
+              flyout.setExpandTransition(transition, transition.maxHeightDefault);
+              flyout.setCollapseTransition(transition, transition.maxHeightZero);
+              flyout.init();
+            } );
+          </script>
+        variation_implementation: >-
+          Behaviors are functionality that can be shared between different
+          pieces of markup. They are not strictly atomic, though they likely are
+          used on atomic components. As added JS behavior, this is added through
+          HTML data-js-hook attributes.
+
+          The structure is:
+            behavior_flyout-menu
+              behavior_flyout-menu_trigger
+              behavior_flyout-menu_content
+                behavior_flyout-menu_trigger (optional)
+
+          The second trigger is optional and may be used for a button in the content area, which may obscure the first trigger. The flyout can be triggered through a click of either trigger.
+
+          For example, at its most basic, the structure is:
+
+
+          ```
+
+          <div data-js-hook="behavior_flyout-menu">
+            <button data-js-hook="behavior_flyout-menu_trigger">
+              Click me!
+            </button>
+            <div data-js-hook="behavior_flyout-menu_content">
+              Show this content
+            </div>
+          </div>
+
+          ```
+
+
+          The `data-js-hook` attributes can be hardcoded in markup, or added via a JavaScript initialization script.
+
+
+          The initialization would then look like:
+
+
+          ```\<div
+
+          // Create reference to the container and content element in the DOM.
+
+          const elementDom = document.querySelector( [data-js-hook="behavior_flyout-menu"] ); const elementContentDom = elementDom.querySelector( [data-js-hook="behavior_flyout-menu_content"] );
+
+
+          // Create a new transition instance and pass in the content area reference.
+
+          const transition = new MaxHeightTransition(elementContentDom);
+
+
+          // Initialize the transition.
+
+          transition.init();
+
+
+          // Create a new FlyoutMenu instance and pass in the container reference.
+
+          const flyout = new FlyoutMenu(elementDom);
+
+
+          // Set the expand/collapse transitions.
+
+          flyout.setExpandTransition(transition, transition.maxHeightDefault); flyout.setCollapseTransition(transition, transition.maxHeightZero);
+
+
+          // Initialize the flyout.
+
+          flyout.init();
+
+          ```
+guidelines: ""
+eyebrow: Transitions
+status: Released
+description: Transition patterns are animations that happen when a user
+  interacts with an element on the page. They are CSS transition styles that are
+  controlled via JavaScript.
+use_cases: ""
+behavior: ""
+accessibility: ""
 last_updated: 2020-01-28T15:55:47.394Z
-research: ''
+research: ""
 ---

--- a/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
+++ b/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
@@ -461,20 +461,17 @@ function FlyoutMenu(element) {
     return _suspended;
   }
 
-  /* TODO: Use Object.defineProperty to create a getter/setter.
-     See https://github.com/cfpb/consumerfinance.gov/pull/1566/
-     files#diff-7a844d22219d7d3db1fa7c1e70d7ba45R35 */
   /**
-   * @returns {number | string | object} A data identifier such as an Array index,
-   *   Hash key, or Tree node.
+   * @returns {number | string | object} A data identifier
+   *   such as an Array index, Hash key, or Tree node.
    */
   function getData() {
     return _data;
   }
 
   /**
-   * @param {number | string | object} data - A data identifier such
-   *   as an Array index, Hash key, or Tree node.
+   * @param {number | string | object} data - A data identifier
+   *   such as an Array index, Hash key, or Tree node.
    * @returns {FlyoutMenu} An instance.
    */
   function setData(data) {

--- a/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
+++ b/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
@@ -1,0 +1,529 @@
+import {
+  BEHAVIOR_PREFIX,
+  JS_HOOK,
+  noopFunct,
+} from '@cfpb/cfpb-atomic-component/src/utilities/standard-type.js';
+import BaseTransition from '@cfpb/cfpb-atomic-component/src/utilities/transition/BaseTransition.js';
+import EventObserver from '@cfpb/cfpb-atomic-component/src/mixins/EventObserver.js';
+import { checkBehaviorDom } from './behavior.js';
+
+const BASE_CLASS = BEHAVIOR_PREFIX + 'flyout-menu';
+const SEL_PREFIX = '[' + JS_HOOK + '=' + BASE_CLASS;
+
+/**
+ * FlyoutMenu
+ *
+ * @class
+ * @classdesc Initializes new FlyoutMenu behavior.
+ * Behaviors are functionality that can be shared between different pieces
+ * of markup. They are not strictly atomic, though they likely are used
+ * on atomic components.
+ * As added JS behavior, this is added through HTML data-js-hook attributes.
+ *
+ * Structure is:
+ * behavior_flyout-menu
+ *   behavior_flyout-menu_trigger
+ *   behavior_flyout-menu_content
+ *     behavior_flyout-menu_trigger (optional)
+ *
+ * The second trigger is optional and may be used for a button in the content
+ * area, which may obscure the first trigger.
+ * The flyout can be triggered through a click of either trigger.
+ * @param {HTMLElement} element - The DOM element to attach FlyoutMenu behavior.
+ * @returns {FlyoutMenu} An instance.
+ */
+function FlyoutMenu(element) {
+  // eslint-disable-line max-statements, no-inline-comments, max-len
+  // Verify that the expected dom attributes are present.
+  const _dom = checkBehaviorDom(element, BASE_CLASS);
+  const _triggerDoms = _findTriggers(element);
+  const _contentDom = checkBehaviorDom(element, BASE_CLASS + '_content');
+
+  let _isExpanded = false;
+  let _isAnimating = false;
+
+  let _expandTransition;
+  let _expandTransitionMethod;
+  let _expandTransitionMethodArgs = [];
+
+  let _collapseTransition;
+  let _collapseTransitionMethod;
+  let _collapseTransitionMethodArgs = [];
+
+  // Binded events.
+  const _collapseBinded = collapse.bind(this);
+  // Needed to add and remove events to transitions.
+  const _collapseEndBinded = _collapseEnd.bind(this);
+  const _expandEndBinded = _expandEnd.bind(this);
+
+  /* If this menu appears in a data source,
+     this can be used to store the source.
+     Examples include the index in an Array,
+     a key in an Hash, or a node in a Tree. */
+  let _data;
+
+  /* Set this function to a queued collapse function,
+     which is called if collapse is called while
+     expand is animating. */
+  let _deferFunct = noopFunct;
+
+  // Whether this instance's behaviors are suspended or not.
+  let _suspended = true;
+
+  /* Event immediately preceeding mouseover is touchstart,
+     if that event's present we'll want to ignore mouseover
+     to avoid a mouseover and click immediately after each other. */
+  let _touchTriggered = false;
+
+  /**
+   * Iterate over dom tree and find FlyoutMenu triggers.
+   * We need to exclude the ones that are nested FlyoutMenus, since those
+   * will be managed by their own instance of this class.
+   *
+   * @param {HTMLElement} element - The DOM element to search for triggers within.
+   * @returns {Array} List of trigger DOM references within this FlyoutMenu.
+   */
+  function _findTriggers(element) {
+    const triggersList = [];
+    const triggers = element.querySelectorAll(`${SEL_PREFIX}_trigger]`);
+
+    let trigger;
+    let triggerParent;
+    let isSubTrigger;
+    // Iterate backwards ensuring that length is an UInt32.
+    for (let i = triggers.length >>> 0; i--; ) {
+      isSubTrigger = false;
+      trigger = triggers[i];
+      triggerParent = trigger.parentElement;
+      while (triggerParent !== element) {
+        if (
+          triggerParent.getAttribute(JS_HOOK) &&
+          triggerParent.getAttribute(JS_HOOK).split(' ').indexOf(BASE_CLASS) !==
+            -1
+        ) {
+          isSubTrigger = true;
+          triggerParent = element;
+        } else {
+          triggerParent = triggerParent.parentElement;
+        }
+      }
+
+      if (!isSubTrigger) {
+        triggersList.unshift(triggers[i]);
+      }
+    }
+
+    return triggersList;
+  }
+
+  /**
+   * @returns {FlyoutMenu} An instance.
+   * @param {boolean} isExpanded - Whether the flyout menu is expanded at
+   *   initialization-time or collapsed.
+   */
+  function init(isExpanded = false) {
+    const handleTriggerClickedBinded = _handleTriggerClicked.bind(this);
+    const handleTriggerOverBinded = _handleTriggerOver.bind(this);
+    const handleTriggerOutBinded = _handleTriggerOut.bind(this);
+
+    let triggerDom;
+    for (let i = 0, len = _triggerDoms.length; i < len; i++) {
+      triggerDom = _triggerDoms[i];
+
+      // Set initial aria attributes to false.
+      _isExpanded = isExpanded;
+      if (isExpanded) {
+        _setAriaAttr('expanded', triggerDom, 'true');
+        _setAriaAttr('expanded', _contentDom, 'true');
+      } else {
+        _setAriaAttr('expanded', triggerDom, 'false');
+        _setAriaAttr('expanded', _contentDom, 'false');
+      }
+
+      triggerDom.addEventListener('click', handleTriggerClickedBinded);
+      triggerDom.addEventListener('touchstart', _handleTouchStart, {
+        passive: true,
+      });
+      triggerDom.addEventListener('mouseover', handleTriggerOverBinded);
+      triggerDom.addEventListener('mouseout', handleTriggerOutBinded);
+    }
+
+    resume();
+
+    return this;
+  }
+
+  /**
+   * Set an aria attribute on an HTML element.
+   *
+   * @param {string} type - The aria attribute to set
+   *   (without the aria- prefix).
+   * @param {HTMLElement} elem - The element to set.
+   * @param {boolean} value - The value to set on `aria-expanded`,
+   *   casts to a string.
+   * @returns {string} The cast value.
+   */
+  function _setAriaAttr(type, elem, value) {
+    const strValue = String(value);
+    elem.setAttribute('aria-' + type, strValue);
+    return strValue;
+  }
+
+  /**
+   * Event handler for when the search input trigger is touched.
+   */
+  function _handleTouchStart() {
+    _touchTriggered = true;
+  }
+
+  /**
+   * Event handler for when the trigger is hovered over.
+   *
+   * @param {MouseEvent} event - The clicked flyout trigger event object.
+   */
+  function _handleTriggerOver(event) {
+    if (!_touchTriggered && !_suspended) {
+      this.dispatchEvent('triggerOver', {
+        target: this,
+        trigger: event.target,
+        type: 'triggerOver',
+      });
+    }
+    _touchTriggered = false;
+  }
+
+  /**
+   * Event handler for when the trigger is hovered out.
+   *
+   * @param {MouseEvent} event - The clicked flyout trigger event object.
+   */
+  function _handleTriggerOut(event) {
+    if (!_suspended) {
+      this.dispatchEvent('triggerOut', {
+        target: this,
+        trigger: event.target,
+        type: 'triggerOut',
+      });
+    }
+  }
+
+  /**
+   * Event handler for when the search input trigger is clicked,
+   * which opens/closes the search input.
+   *
+   * @param {MouseEvent} event - The clicked flyout trigger event object.
+   */
+  function _handleTriggerClicked(event) {
+    if (!_suspended) {
+      this.dispatchEvent('triggerClick', {
+        target: this,
+        trigger: event.target,
+        type: 'triggerClick',
+      });
+      event.preventDefault();
+      if (_isExpanded) {
+        this.collapse();
+      } else {
+        this.expand();
+      }
+    }
+  }
+
+  /**
+   * Open the search box.
+   *
+   * @returns {FlyoutMenu} An instance.
+   */
+  function expand() {
+    if (!_isExpanded && !_isAnimating) {
+      _isAnimating = true;
+      _deferFunct = noopFunct;
+      this.dispatchEvent('expandBegin', { target: this, type: 'expandBegin' });
+
+      if (_expandTransitionMethod) {
+        const hasTransition =
+          _expandTransition && _expandTransition.isAnimated();
+        if (hasTransition) {
+          _expandTransition.addEventListener(
+            BaseTransition.END_EVENT,
+            _expandEndBinded
+          );
+        }
+        _expandTransitionMethod.apply(
+          _expandTransition,
+          _expandTransitionMethodArgs
+        );
+        if (!hasTransition) {
+          _expandEndBinded();
+        }
+      } else {
+        _expandEndBinded();
+      }
+    }
+
+    return this;
+  }
+
+  /**
+   * Close the search box.
+   * If collapse is called when expand animation is underway,
+   * save a deferred call to collapse, which is called when
+   * expand completes.
+   *
+   * @returns {FlyoutMenu} An instance.
+   */
+  function collapse() {
+    if (_isExpanded && !_isAnimating) {
+      _deferFunct = noopFunct;
+      _isAnimating = true;
+      _isExpanded = false;
+      this.dispatchEvent('collapseBegin', {
+        target: this,
+        type: 'collapseBegin',
+      });
+      if (_collapseTransitionMethod) {
+        const hasTransition =
+          _collapseTransition && _collapseTransition.isAnimated();
+        if (hasTransition) {
+          _collapseTransition.addEventListener(
+            BaseTransition.END_EVENT,
+            _collapseEndBinded
+          );
+        }
+        _collapseTransitionMethod.apply(
+          _collapseTransition,
+          _collapseTransitionMethodArgs
+        );
+        if (!hasTransition) {
+          _collapseEndBinded();
+        }
+      } else {
+        _collapseEndBinded();
+      }
+
+      for (let i = 0, len = _triggerDoms.length; i < len; i++) {
+        _setAriaAttr('expanded', _triggerDoms[i], false);
+      }
+
+      _setAriaAttr('expanded', _contentDom, false);
+    } else {
+      _deferFunct = _collapseBinded;
+    }
+
+    return this;
+  }
+
+  /**
+   * Expand animation has completed.
+   * Call deferred collapse function,
+   * if set (otherwise it will call a noop function).
+   */
+  function _expandEnd() {
+    _isAnimating = false;
+    _isExpanded = true;
+    if (_expandTransition) {
+      _expandTransition.removeEventListener(
+        BaseTransition.END_EVENT,
+        _expandEndBinded
+      );
+    }
+    this.dispatchEvent('expandEnd', { target: this, type: 'expandEnd' });
+
+    for (let i = 0, len = _triggerDoms.length; i < len; i++) {
+      _setAriaAttr('expanded', _triggerDoms[i], true);
+    }
+
+    _setAriaAttr('expanded', _contentDom, true);
+    // Call collapse, if it was called while expand was animating.
+    _deferFunct();
+  }
+
+  /**
+   * Collapse animation has completed.
+   */
+  function _collapseEnd() {
+    _isAnimating = false;
+    if (_collapseTransition) {
+      _collapseTransition.removeEventListener(
+        BaseTransition.END_EVENT,
+        _collapseEndBinded
+      );
+    }
+    this.dispatchEvent('collapseEnd', { target: this, type: 'collapseEnd' });
+  }
+
+  /**
+   * @param {MoveTransition|AlphaTransition} transition - A transition instance
+   *   to watch for events on.
+   * @param {Function} method - The transition method to call on expand.
+   * @param {Array} [args] - List of arguments to apply to expand method.
+   */
+  function setExpandTransition(transition, method, args) {
+    _expandTransition = transition;
+    _expandTransitionMethod = method;
+    _expandTransitionMethodArgs = args;
+  }
+
+  /**
+   * @param {MoveTransition|AlphaTransition} transition - A transition instance
+   *   to watch for events on.
+   * @param {Function} method - The transition method to call on collapse.
+   * @param {Array} [args] - List of arguments to apply to collapse method.
+   */
+  function setCollapseTransition(transition, method, args) {
+    _collapseTransition = transition;
+    _collapseTransitionMethod = method;
+    _collapseTransitionMethodArgs = args;
+
+    if (!_isExpanded) {
+      _collapseTransition.animateOff();
+      _collapseTransitionMethod();
+      _collapseTransition.animateOn();
+    }
+  }
+
+  /**
+   * Clear the transitions attached to this FlyoutMenu instance.
+   */
+  function clearTransitions() {
+    let transition = getTransition(FlyoutMenu.EXPAND_TYPE);
+    if (transition) {
+      transition.remove();
+    }
+    transition = getTransition(FlyoutMenu.COLLAPSE_TYPE);
+    if (transition) {
+      transition.remove();
+    }
+
+    let UNDEFINED;
+
+    _expandTransition = UNDEFINED;
+    _expandTransitionMethod = UNDEFINED;
+    _expandTransitionMethodArgs = [];
+
+    _collapseTransition = UNDEFINED;
+    _collapseTransitionMethod = UNDEFINED;
+    _collapseTransitionMethodArgs = [];
+  }
+
+  /**
+   * @param {string} [type] - The type of transition to return.
+   *   Accepts 'expand' or 'collapse'.
+   *   `FlyoutMenu.EXPAND_TYPE` and `FlyoutMenu.COLLAPSE_TYPE` can be used
+   *   as type-safe constants passed into this method.
+   *   If neither or something else is supplied, expand type is returned.
+   * @returns {MoveTransition|AlphaTransition|undefined} A transition instance
+   *   set on this instance, or undefined if none is set.
+   */
+  function getTransition(type) {
+    if (type === FlyoutMenu.COLLAPSE_TYPE) {
+      return _collapseTransition;
+    }
+
+    return _expandTransition;
+  }
+
+  /**
+   * @returns {object}
+   *   Hash of container, content DOM references, and a list of trigger DOMs.
+   */
+  function getDom() {
+    return {
+      container: _dom,
+      content: _contentDom,
+      trigger: _triggerDoms,
+    };
+  }
+
+  /**
+   * Enable broadcasting of trigger events.
+   *
+   * @returns {boolean} True if resumed, false otherwise.
+   */
+  function resume() {
+    if (_suspended) {
+      _suspended = false;
+    }
+
+    return !_suspended;
+  }
+
+  /**
+   * Suspend broadcasting of trigger events.
+   *
+   * @returns {boolean} True if suspended, false otherwise.
+   */
+  function suspend() {
+    if (!_suspended) {
+      _suspended = true;
+    }
+
+    return _suspended;
+  }
+
+  /* TODO: Use Object.defineProperty to create a getter/setter.
+     See https://github.com/cfpb/consumerfinance.gov/pull/1566/
+     files#diff-7a844d22219d7d3db1fa7c1e70d7ba45R35 */
+  /**
+   * @returns {number | string | object} A data identifier such as an Array index,
+   *   Hash key, or Tree node.
+   */
+  function getData() {
+    return _data;
+  }
+
+  /**
+   * @param {number | string | object} data - A data identifier such
+   *   as an Array index, Hash key, or Tree node.
+   * @returns {FlyoutMenu} An instance.
+   */
+  function setData(data) {
+    _data = data;
+
+    return this;
+  }
+
+  /**
+   * @returns {boolean} True if menu is animating, false otherwise.
+   */
+  function isAnimating() {
+    return _isAnimating;
+  }
+
+  /**
+   * @returns {boolean} True if menu is expanded, false otherwise.
+   */
+  function isExpanded() {
+    return _isExpanded;
+  }
+
+  // Attach public events.
+  const eventObserver = new EventObserver();
+  this.addEventListener = eventObserver.addEventListener;
+  this.removeEventListener = eventObserver.removeEventListener;
+  this.dispatchEvent = eventObserver.dispatchEvent;
+
+  this.init = init;
+  this.expand = expand;
+  this.collapse = collapse;
+  this.setExpandTransition = setExpandTransition;
+  this.setCollapseTransition = setCollapseTransition;
+  this.clearTransitions = clearTransitions;
+  this.getData = getData;
+  this.getTransition = getTransition;
+  this.getDom = getDom;
+  this.isAnimating = isAnimating;
+  this.isExpanded = isExpanded;
+  this.resume = resume;
+  this.setData = setData;
+  this.suspend = suspend;
+
+  // Public static properties.
+  FlyoutMenu.EXPAND_TYPE = 'expand';
+  FlyoutMenu.COLLAPSE_TYPE = 'collapse';
+  FlyoutMenu.BASE_CLASS = BASE_CLASS;
+
+  return this;
+}
+
+export default FlyoutMenu;

--- a/packages/cfpb-atomic-component/src/utilities/behavior/behavior.js
+++ b/packages/cfpb-atomic-component/src/utilities/behavior/behavior.js
@@ -1,0 +1,141 @@
+/* ==========================================================================
+   Dom Behaviors
+   Behaviors are functionality that can be shared between different pieces
+   of markup. They are not strictly atomic, though they likely are used
+   on atomic components. An example of shared behavior may be a menu that
+   expands and collapses and sets the aria-expanded attribute on the HTML.
+   Or an input field that can be cleared by clicking an (x) button in the
+   input. These are both behaviors that may appear in different parts of
+   the codebase, but could share the same functionality.
+   Behaviors are added through the `data-js-hook` attribute on the HTML
+   and have a prefix of `behavior_`
+   (both those designators are set in modules/util/standard-type.js).
+   For example, `behaviors/FlyoutMenu.js` defines the behavior of
+   expanding and collapsing an expandable menu. At a minimum, three things
+   need to be defined: (A) The containing scope of the menu, (B) the trigger
+   to activate the menu, and (C) the content to show/hide when the trigger
+   is clicked. So the markup looks something like:
+   <div data-js-hook="behavior_flyout-menu">
+   <button data-js-hook="behavior_flyout-menu_trigger">
+   <div data-js-hook="behavior_flyout-menu_content">
+   ========================================================================== */
+
+import { contains } from '@cfpb/cfpb-atomic-component/src/utilities/data-hook.js';
+import {
+  BEHAVIOR_PREFIX,
+  JS_HOOK,
+} from '@cfpb/cfpb-atomic-component/src/utilities/standard-type.js';
+
+/**
+ * @param {string} behaviorSelector - Behavior type used to find the element
+ *   within the dom.
+ * @param {HTMLElement} baseElement - Containing element for the behavior element.
+ * @returns {Array|NodeList} behaviorElements if it exists in the dom,
+ *   null otherwise.
+ */
+function _findElements(behaviorSelector, baseElement) {
+  baseElement = baseElement || document;
+  let behaviorElements = [];
+
+  try {
+    behaviorElements = baseElement.querySelectorAll(behaviorSelector);
+  } catch (error) {
+    const msg = `${behaviorSelector} not found in DOM! ${error}`;
+    throw new Error(msg);
+  }
+
+  if (
+    behaviorElements.length === 0 &&
+    behaviorSelector.indexOf(BEHAVIOR_PREFIX) === -1
+  ) {
+    behaviorElements = find(behaviorSelector, baseElement);
+  }
+
+  return behaviorElements;
+}
+
+/**
+ * @param {( string|HTMLElement|Array|NodeList )} behaviorElement - Used to
+ *   query dom for elements.
+ * @param {string} event - Event type to add to element.
+ * @param {Function} eventHandler - Callback for event.
+ * @param {HTMLElement} baseElement - Containing element
+ *   for the behavior element.
+ * @returns {Array|NodeList} if it exists in the dom, null otherwise.
+ */
+function attach(behaviorElement, event, eventHandler, baseElement) {
+  let behaviorElements = [];
+
+  if (behaviorElement instanceof NodeList === true) {
+    behaviorElements = behaviorElement;
+  } else if (behaviorElement instanceof Node === true) {
+    behaviorElements = [behaviorElement];
+  } else if (typeof behaviorElement === 'string') {
+    behaviorElements = _findElements(behaviorElement, baseElement);
+  }
+
+  for (let i = 0, len = behaviorElements.length; i < len; i++) {
+    behaviorElements[i].addEventListener(event, eventHandler, false);
+  }
+
+  return behaviorElements;
+}
+
+/**
+ * @param {HTMLElement} element - The DOM element within which to search
+ *   for the behavior in the data-js-hook attribute.
+ * @param {string} behaviorDataAttr - The value in the data-js-hook.
+ *   This is the name of the behavior.
+ *   E.g. `behavior_flyout-menu`, `behavior_flyout-menu_content`.
+ * @returns {HTMLElement} The DOM element that has an attached behavior.
+ * @throws {Error} If data-js-hook attribute value was not found on DOM element.
+ */
+function checkBehaviorDom(element, behaviorDataAttr) {
+  // Check that the behavior is found on the passed DOM node.
+  let dom;
+
+  if (contains(element, behaviorDataAttr)) {
+    dom = element;
+    return dom;
+  }
+
+  /* If the passed DOM node isn't null,
+     query the node to see if it's in the children. */
+  if (element) {
+    const selector = '[' + JS_HOOK + '=' + behaviorDataAttr + ']';
+    dom = element.querySelector(selector);
+  }
+
+  if (!dom) {
+    const msg = behaviorDataAttr + ' behavior not found on passed DOM node!';
+    throw new Error(msg);
+  }
+
+  return dom;
+}
+
+/**
+ * @param {string} behaviorSelector - Behavior type used to find
+ *   the element within the dom.
+ * @param {HTMLElement} baseElement - Containing element
+ *   for the behavior element.
+ * @returns {NodeList} if it exists in the dom, null otherwise.
+ */
+function find(behaviorSelector, baseElement) {
+  behaviorSelector = JS_HOOK + '*=' + BEHAVIOR_PREFIX + behaviorSelector;
+  behaviorSelector = '[' + behaviorSelector + ']';
+
+  return _findElements(behaviorSelector, baseElement);
+}
+
+/**
+ * @param {HTMLElement} behaviorElement - Element in which to remove the event.
+ * @param {string} event - Event type to remove from the element.
+ * @param {Function} eventHandler - Callback for event.
+ */
+function remove(behaviorElement, event, eventHandler) {
+  behaviorElement.removeEventListener(event, eventHandler);
+}
+
+// Expose public methods.
+export { attach, checkBehaviorDom, find, remove };

--- a/packages/cfpb-atomic-component/src/utilities/transition/transition.less
+++ b/packages/cfpb-atomic-component/src/utilities/transition/transition.less
@@ -68,8 +68,9 @@
 .u-max-height-transition {
   // This is an arbitrary value to give max-height an initial value.
   max-height: 1000px;
+  overflow: hidden;
 
-  transition: max-height 0.25s ease-out;
+  transition: max-height 0.15s ease-out;
 }
 
 .u-max-height-default {

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.spec.js
@@ -1,0 +1,502 @@
+import { jest } from '@jest/globals';
+import FlyoutMenu from '../../../../../../../packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js';
+import MoveTransition from '../../../../../../../packages/cfpb-atomic-component/src/utilities/transition/MoveTransition.js';
+
+const HTML_SNIPPET = `
+<div data-js-hook="behavior_flyout-menu">
+    <button data-js-hook="behavior_flyout-menu_trigger"
+            aria-haspopup="menu"
+            aria-expanded="false"></button>
+    <div data-js-hook="behavior_flyout-menu_content" aria-expanded="false">
+      <button data-js-hook="behavior_flyout-menu_trigger"
+              aria-expanded="false"></button>
+    </div>
+</div>
+`;
+
+describe('FlyoutMenu', () => {
+  let flyoutMenu;
+
+  // Mock-related settings.
+  let triggerClickSpy;
+  let triggerOverSpy;
+  let expandBeginSpy;
+  let expandEndSpy;
+  let collapseBeginSpy;
+  let collapseEndSpy;
+
+  // DOM-related settings.
+  const SEL_PREFIX = '[data-js-hook=behavior_flyout-menu';
+
+  let containerDom;
+  let triggerDom;
+  let contentDom;
+  let altTriggerDom;
+
+  beforeEach(() => {
+    document.body.innerHTML = HTML_SNIPPET;
+    containerDom = document.querySelector(SEL_PREFIX + ']');
+    const triggersDom = document.querySelectorAll(SEL_PREFIX + '_trigger]');
+    triggerDom = triggersDom[0];
+    contentDom = document.querySelector(SEL_PREFIX + '_content]');
+    // TODO: check for cases where alt trigger is absent.
+    altTriggerDom = triggersDom[1];
+
+    flyoutMenu = new FlyoutMenu(containerDom);
+  });
+
+  describe('.init()', () => {
+    it('should have public static methods', () => {
+      expect(FlyoutMenu.EXPAND_TYPE).toBe('expand');
+      expect(FlyoutMenu.COLLAPSE_TYPE).toBe('collapse');
+      expect(FlyoutMenu.BASE_CLASS).toBe('behavior_flyout-menu');
+    });
+
+    it('should have correct state before initializing', () => {
+      expect(triggerDom.getAttribute('aria-expanded')).toBe('false');
+      expect(contentDom.getAttribute('aria-expanded')).toBe('false');
+      expect(altTriggerDom.getAttribute('aria-expanded')).toBe('false');
+
+      expect(flyoutMenu.isAnimating()).toBe(false);
+      expect(flyoutMenu.isExpanded()).toBe(false);
+      expect(flyoutMenu.getTransition()).toBeUndefined();
+      expect(flyoutMenu.getData()).toBeUndefined();
+    });
+
+    it('should have correct state after initializing as collapsed', () => {
+      expect(flyoutMenu.init()).toBeInstanceOf(FlyoutMenu);
+      expect(triggerDom.getAttribute('aria-expanded')).toBe('false');
+      expect(contentDom.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('should have correct state after initializing as expanded', () => {
+      expect(flyoutMenu.init(true)).toBeInstanceOf(FlyoutMenu);
+      expect(triggerDom.getAttribute('aria-expanded')).toBe('true');
+      expect(contentDom.getAttribute('aria-expanded')).toBe('true');
+    });
+  });
+
+  describe('mouseover/click', () => {
+    beforeEach(() => {
+      // Set up expected event listeners.
+      triggerOverSpy = jest.fn();
+      triggerClickSpy = jest.fn();
+
+      flyoutMenu.init();
+      flyoutMenu.addEventListener('triggerOver', triggerOverSpy);
+      flyoutMenu.addEventListener('triggerClick', triggerClickSpy);
+    });
+
+    it('should dispatch events when called by trigger click', () => {
+      /* TODO: Ideally this would use `new MouseEvent`,
+         but how do we import MouseEvent (or Event) into Jest.
+         Please investigate. */
+      const mouseEvent = document.createEvent('MouseEvents');
+      mouseEvent.initEvent('mouseover', true, true);
+      triggerDom.dispatchEvent(mouseEvent);
+      triggerDom.click();
+
+      // Check expected event broadcasts.
+      expect(triggerOverSpy).toHaveBeenCalledTimes(1);
+      expect(triggerOverSpy).toHaveBeenCalledWith({
+        target: flyoutMenu,
+        trigger: triggerDom,
+        type: 'triggerOver',
+      });
+    });
+
+    it('should dispatch events when called by alt trigger click', () => {
+      const mouseEvent = document.createEvent('MouseEvents');
+      mouseEvent.initEvent('mouseover', true, true);
+      altTriggerDom.dispatchEvent(mouseEvent);
+      altTriggerDom.click();
+
+      // Check expected event broadcasts.
+      expect(triggerClickSpy).toHaveBeenCalledTimes(1);
+      expect(triggerClickSpy).toHaveBeenCalledWith({
+        target: flyoutMenu,
+        trigger: altTriggerDom,
+        type: 'triggerClick',
+      });
+    });
+  });
+
+  describe('.expand()', () => {
+    beforeEach(() => {
+      // Set up expected event listeners.
+      expandBeginSpy = jest.fn();
+      expandEndSpy = jest.fn();
+
+      flyoutMenu.init();
+      flyoutMenu.addEventListener('expandBegin', expandBeginSpy);
+      flyoutMenu.addEventListener('expandEnd', expandEndSpy);
+    });
+
+    afterEach(() => {
+      // Check expected event broadcasts.
+      expect(expandBeginSpy).toHaveBeenCalledTimes(1);
+      expect(expandBeginSpy).toHaveBeenCalledWith({
+        target: flyoutMenu,
+        type: 'expandBegin',
+      });
+
+      expect(expandEndSpy).toHaveBeenCalledTimes(1);
+      expect(expandEndSpy).toHaveBeenCalledWith({
+        target: flyoutMenu,
+        type: 'expandEnd',
+      });
+
+      // Check expected aria attributes state.
+      expect(triggerDom.getAttribute('aria-expanded')).toBe('true');
+      expect(contentDom.getAttribute('aria-expanded')).toBe('true');
+      expect(altTriggerDom.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it(
+      'should dispatch events and set aria attributes, ' +
+        'when called by trigger click',
+      () => {
+        triggerDom.click();
+      }
+    );
+
+    it(
+      'should dispatch events and set aria attributes, ' +
+        'when called by alt trigger click',
+      () => {
+        altTriggerDom.click();
+      }
+    );
+
+    it(
+      'should dispatch events and set aria attributes, ' +
+        'when called directly',
+      () => {
+        flyoutMenu.expand();
+      }
+    );
+  });
+
+  describe('.collapse()', () => {
+    beforeEach(() => {
+      // Set up expected event listeners.
+      collapseBeginSpy = jest.fn();
+      collapseEndSpy = jest.fn();
+
+      flyoutMenu.init();
+      flyoutMenu.addEventListener('collapseBegin', collapseBeginSpy);
+      flyoutMenu.addEventListener('collapseEnd', collapseEndSpy);
+      triggerDom.click();
+    });
+
+    afterEach(() => {
+      // Check expected event broadcasts.
+      expect(collapseBeginSpy).toHaveBeenCalledTimes(1);
+      expect(collapseBeginSpy).toHaveBeenCalledWith({
+        target: flyoutMenu,
+        type: 'collapseBegin',
+      });
+
+      expect(collapseEndSpy).toHaveBeenCalledTimes(1);
+      expect(collapseEndSpy).toHaveBeenCalledWith({
+        target: flyoutMenu,
+        type: 'collapseEnd',
+      });
+
+      // Check expected aria attribute states.
+      expect(triggerDom.getAttribute('aria-expanded')).toBe('false');
+      expect(contentDom.getAttribute('aria-expanded')).toBe('false');
+      expect(altTriggerDom.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it(
+      'should dispatch events and set aria attributes, ' +
+        'when called by trigger click',
+      () => {
+        triggerDom.click();
+      }
+    );
+
+    it(
+      'should dispatch events and set aria attributes, ' +
+        'when called by alt trigger click',
+      () => {
+        altTriggerDom.click();
+      }
+    );
+
+    it(
+      'should dispatch events and set aria attributes, ' +
+        'when called directly',
+      () => {
+        flyoutMenu.collapse();
+      }
+    );
+  });
+
+  describe('.setExpandTransition()', () => {
+    it('should set a transition', (done) => {
+      flyoutMenu.init();
+      const transition = new MoveTransition(contentDom).init();
+      flyoutMenu.setExpandTransition(transition, transition.moveLeft);
+      flyoutMenu.addEventListener('expandEnd', () => {
+        try {
+          const hasClass = contentDom.classList.contains('u-move-transition');
+          expect(hasClass).toBe(true);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      triggerDom.click();
+
+      /* The transitionend event should fire on its own,
+         but for some reason the transitionend event is not firing within JSDom.
+         In a future JSDom update this should be revisited.
+         See https://github.com/jsdom/jsdom/issues/1781
+      */
+      const event = new Event('transitionend');
+      event.propertyName = 'transform';
+      contentDom.dispatchEvent(event);
+    });
+  });
+
+  describe('.setCollapseTransition()', () => {
+    it('should set a transition', (done) => {
+      flyoutMenu.init();
+      const transition = new MoveTransition(contentDom).init();
+      triggerDom.click();
+      flyoutMenu.setCollapseTransition(transition, transition.moveLeft);
+      flyoutMenu.addEventListener('collapseEnd', () => {
+        try {
+          const hasClass = contentDom.classList.contains('u-move-transition');
+          expect(hasClass).toBe(true);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      triggerDom.click();
+
+      /* The transitionend event should fire on its own,
+         but for some reason the transitionend event is not firing within JSDom.
+         In a future JSDom update this should be revisited.
+         See https://github.com/jsdom/jsdom/issues/1781
+      */
+      const event = new Event('transitionend');
+      event.propertyName = 'transform';
+      contentDom.dispatchEvent(event);
+    });
+  });
+
+  describe('.getTransition()', () => {
+    it('should return a transition instance', () => {
+      flyoutMenu.init();
+      expect(flyoutMenu.getTransition()).toBeUndefined();
+      const transition = new MoveTransition(contentDom).init();
+      flyoutMenu.setExpandTransition(transition, transition.moveLeft);
+      flyoutMenu.setCollapseTransition(transition, transition.moveToOrigin);
+      expect(flyoutMenu.getTransition()).toStrictEqual(transition);
+      expect(flyoutMenu.getTransition(FlyoutMenu.COLLAPSE_TYPE)).toStrictEqual(
+        transition
+      );
+    });
+  });
+
+  describe('.clearTransitions()', () => {
+    it('should remove all transitions', () => {
+      flyoutMenu.init();
+      const transition = new MoveTransition(contentDom).init();
+      flyoutMenu.setExpandTransition(transition, transition.moveLeft);
+      flyoutMenu.setCollapseTransition(transition, transition.moveToOrigin);
+      let hasClass = contentDom.classList.contains('u-move-transition');
+      expect(hasClass).toBe(true);
+      flyoutMenu.clearTransitions();
+      expect(flyoutMenu.getTransition()).toBeUndefined();
+      hasClass = contentDom.classList.contains('u-move-transition');
+      expect(hasClass).toBe(false);
+    });
+  });
+
+  describe('.getDom()', () => {
+    it('should return references to full dom', () => {
+      flyoutMenu.init();
+      const dom = flyoutMenu.getDom();
+      expect(dom.container).toStrictEqual(containerDom);
+      expect(dom.trigger[0]).toStrictEqual(triggerDom);
+      expect(dom.content).toStrictEqual(contentDom);
+      expect(dom.trigger[1]).toStrictEqual(altTriggerDom);
+    });
+  });
+
+  describe('suspend/resume behavior', () => {
+    beforeEach(() => {
+      // Set up expected event listeners.
+      expandBeginSpy = jest.fn();
+      expandEndSpy = jest.fn();
+      collapseBeginSpy = jest.fn();
+      collapseEndSpy = jest.fn();
+      flyoutMenu.init();
+      flyoutMenu.addEventListener('expandBegin', expandBeginSpy);
+      flyoutMenu.addEventListener('expandEnd', expandEndSpy);
+      flyoutMenu.addEventListener('collapseBegin', collapseBeginSpy);
+      flyoutMenu.addEventListener('collapseEnd', collapseEndSpy);
+    });
+
+    describe('.suspend()', () => {
+      it('should not broadcast events after being suspended', () => {
+        // Set up expected event listeners.
+        flyoutMenu.suspend();
+        triggerDom.click();
+
+        expect(expandBeginSpy).toHaveBeenCalledTimes(0);
+        expect(expandEndSpy).toHaveBeenCalledTimes(0);
+        expect(collapseBeginSpy).toHaveBeenCalledTimes(0);
+        expect(collapseEndSpy).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe('.resume()', () => {
+      it('should broadcast events after resuming from suspended', () => {
+        // Set up expected event listeners.
+        flyoutMenu.suspend();
+        flyoutMenu.resume();
+        triggerDom.click();
+
+        expect(expandBeginSpy).toHaveBeenCalledTimes(1);
+        expect(expandEndSpy).toHaveBeenCalledTimes(1);
+        triggerDom.click();
+        expect(collapseBeginSpy).toHaveBeenCalledTimes(1);
+        expect(collapseEndSpy).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('.setData()', () => {
+    it('should return the instance when set', () => {
+      flyoutMenu.init();
+      const inst = flyoutMenu.setData('test-data');
+      expect(inst).toBeInstanceOf(FlyoutMenu);
+    });
+  });
+
+  describe('.getData()', () => {
+    it('should return the set data', () => {
+      flyoutMenu.init();
+      flyoutMenu.setData('test-data');
+      expect(flyoutMenu.getData()).toBe('test-data');
+    });
+  });
+
+  describe('.isAnimating()', () => {
+    it('should return true when expanding', (done) => {
+      flyoutMenu.init();
+      flyoutMenu.addEventListener('expandBegin', () => {
+        try {
+          expect(flyoutMenu.isAnimating()).toBe(true);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      triggerDom.click();
+    });
+
+    it('should return false after expanding', (done) => {
+      flyoutMenu.init();
+      flyoutMenu.addEventListener('expandEnd', () => {
+        try {
+          expect(flyoutMenu.isAnimating()).toBe(false);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      triggerDom.click();
+    });
+
+    it('should return true while collapsing', (done) => {
+      flyoutMenu.init();
+      flyoutMenu.addEventListener('collapseBegin', () => {
+        try {
+          expect(flyoutMenu.isAnimating()).toBe(true);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      triggerDom.click();
+      triggerDom.click();
+    });
+
+    it('should return false after collapsing', (done) => {
+      flyoutMenu.init();
+      flyoutMenu.addEventListener('collapseEnd', () => {
+        try {
+          expect(flyoutMenu.isAnimating()).toBe(false);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      triggerDom.click();
+      triggerDom.click();
+    });
+  });
+
+  describe('.isExpanded()', () => {
+    it('should return false before expanding', (done) => {
+      flyoutMenu.init();
+      flyoutMenu.addEventListener('expandBegin', () => {
+        try {
+          expect(flyoutMenu.isExpanded()).toBe(false);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      triggerDom.click();
+    });
+
+    it('should return true after expanding', (done) => {
+      flyoutMenu.init();
+      flyoutMenu.addEventListener('expandEnd', () => {
+        try {
+          expect(flyoutMenu.isExpanded()).toBe(true);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      triggerDom.click();
+    });
+
+    it('should return true before collapsing', (done) => {
+      flyoutMenu.init();
+      triggerDom.click();
+      flyoutMenu.addEventListener('triggerClick', () => {
+        try {
+          expect(flyoutMenu.isExpanded()).toBe(true);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      triggerDom.click();
+    });
+
+    it('should return false after collapsing', (done) => {
+      flyoutMenu.init();
+      flyoutMenu.addEventListener('collapseEnd', () => {
+        try {
+          expect(flyoutMenu.isExpanded()).toBe(false);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      triggerDom.click();
+      triggerDom.click();
+    });
+  });
+});

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/behavior/behavior.spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/behavior/behavior.spec.js
@@ -1,0 +1,161 @@
+import { jest } from '@jest/globals';
+import {
+  attach,
+  checkBehaviorDom,
+  find,
+  remove,
+} from '../../../../../../../packages/cfpb-atomic-component/src/utilities/behavior/behavior.js';
+
+let containerDom;
+let behaviorElmDom;
+const selector = 'data-js-hook=behavior_flyout-menu';
+
+const HTML_SNIPPET = `
+<div class="skip-nav">
+  <a href="#main" class="skip-nav_link">Skip to main content</a>
+</div>
+<a class="o-mega-menu_content-link o-mega-menu_content-1-link"
+   data-js-hook="behavior_flyout-menu_trigger">
+     Consumer Tools
+</a>
+<a class="o-mega-menu_content-link o-mega-menu_content-1-link"
+   data-js-hook="behavior_flyout-menu_trigger">
+      Educational Resources
+</a>
+<div data-js-hook="behavior_flyout-menu">
+    <div data-js-hook="behavior_flyout-menu_content"></div>
+</div>
+`;
+
+/**
+ * @param {HTMLElement} target - The target element of the event.
+ * @param {string} eventType - The event type description.
+ * @param {string} eventOption - A keyCode, if the event is a keyup event.
+ */
+function triggerEvent(target, eventType, eventOption) {
+  const event = document.createEvent('Event');
+  if (eventType === 'keyup') {
+    event.keyCode = eventOption || '';
+  }
+  event.initEvent(eventType, true, true);
+  target.dispatchEvent(event);
+}
+
+describe('behavior', () => {
+  beforeEach(() => {
+    document.body.innerHTML = HTML_SNIPPET;
+    containerDom = document.querySelector('[' + selector + ']');
+    behaviorElmDom = document.querySelector('[' + selector + '_content]');
+  });
+
+  describe('attach function', () => {
+    it('should register an event callback when passed a Node', () => {
+      const spy = jest.fn();
+      const linkDom = document.querySelector('a[href^="#"]');
+      attach(linkDom, 'click', spy);
+      triggerEvent(linkDom, 'click');
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should register an event callback when passed a NodeList', () => {
+      const spy = jest.fn();
+      const behaviorDom = find('flyout-menu_trigger');
+      attach(behaviorDom, 'mouseover', spy);
+      triggerEvent(behaviorDom[0], 'mouseover');
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should register an event callback when passed a behavior selector', () => {
+      const spy = jest.fn();
+      const behaviorDom = find('flyout-menu_trigger');
+      attach('flyout-menu_trigger', 'mouseover', spy);
+      triggerEvent(behaviorDom[0], 'mouseover');
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should register an event callback when passed a dom selector', () => {
+      const spy = jest.fn();
+      const linkDom = document.querySelector('a[href^="#"]');
+      attach('a[href^="#"]', 'click', spy);
+      triggerEvent(linkDom, 'click');
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('checkBehaviorDom function ', () => {
+    it('should throw an error if element DOM not found', () => {
+      const errMsg =
+        'behavior_flyout-menu behavior not found on passed DOM node!';
+      /**
+       *
+       */
+      function errFunc() {
+        checkBehaviorDom(null, 'behavior_flyout-menu');
+      }
+      expect(errFunc).toThrow(Error, errMsg);
+    });
+
+    it('should throw an error if behavior attribute not found', () => {
+      const errMsg = 'mock-attr behavior not found on passed DOM node!';
+      /**
+       *
+       */
+      function errFunc() {
+        checkBehaviorDom(containerDom, 'mock-attr');
+      }
+      expect(errFunc).toThrow(Error, errMsg);
+    });
+
+    it(
+      'should return the correct HTMLElement ' +
+        'when direct element is searched',
+      () => {
+        const dom = checkBehaviorDom(containerDom, 'behavior_flyout-menu');
+        expect(dom).toStrictEqual(containerDom);
+      }
+    );
+
+    it(
+      'should return the correct HTMLElement ' +
+        'when child element is searched',
+      () => {
+        const dom = checkBehaviorDom(
+          behaviorElmDom,
+          'behavior_flyout-menu_content'
+        );
+        expect(dom).toStrictEqual(behaviorElmDom);
+      }
+    );
+  });
+
+  describe('find function', () => {
+    it('should find all elements with the specific behavior hook', () => {
+      let behaviorDom = find('flyout-menu_trigger');
+      expect(behaviorDom.length === 2).toBe(true);
+      behaviorDom = find('flyout-menu_content');
+      expect(behaviorDom.length === 1).toBe(true);
+    });
+
+    it('should throw an error when passed an invalid behavior selector', () => {
+      const behaviorSelector = 'a[href^="#"]';
+      const errorMsg =
+        '[data-js-hook*=behavior_' + behaviorSelector + '] not found in DOM!';
+      const findFunction = find.bind(this, behaviorSelector);
+      expect(findFunction).toThrow(Error, errorMsg);
+    });
+  });
+
+  describe('remove function', () => {
+    it('should remove the event callback for the specific behavior hook', () => {
+      const spy = jest.fn();
+      const linkDom = document.querySelector('a[href^="#"]');
+      attach(linkDom, 'click', spy);
+      triggerEvent(linkDom, 'click');
+      expect(spy).toHaveBeenCalledTimes(1);
+      spy.mockReset();
+      remove(linkDom, 'click', spy);
+      triggerEvent(linkDom, 'click');
+      expect(spy).toHaveBeenCalledTimes(0);
+    });
+  });
+});


### PR DESCRIPTION
Moves mature code from cfgov to DS.

## Changes

- Add FlyoutMenu behavior and add to transitions page. 

## Testing
 
1. Visit /design-system/patterns/transition-patterns in the PR preview and scroll to the bottom and ensure the example works.
