### PR TITLE
Add Summary component

### DIFF
--- a/docs/_data/side-navigation.yml
+++ b/docs/_data/side-navigation.yml
@@ -33,6 +33,7 @@ first-level:
       - heading: Behavior
         nav-items:
           - page: Expandables
+          - page: Summaries
       - heading: Form elements
         nav-items:
           - page: Buttons

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -1,6 +1,7 @@
 import { toggleAllDetails, toggleDetails } from './toggle-details.js';
 import AnchorJS from 'anchor-js';
 import Expandable from '@cfpb/cfpb-expandables/src/Expandable.js';
+import Summary from '@cfpb/cfpb-expandables/src/Summary.js';
 import Multiselect from '@cfpb/cfpb-forms/src/organisms/Multiselect.js';
 import AlphaTransition from '@cfpb/cfpb-atomic-component/src/utilities/transition/AlphaTransition.js';
 import MoveTransition from '@cfpb/cfpb-atomic-component/src/utilities/transition/MoveTransition.js';
@@ -32,6 +33,7 @@ if (multiselectDom) {
   multiselect.init();
 }
 
+Summary.init();
 Expandable.init();
 
 // Exporting these classes to the window so that the transition-patterns.md

--- a/docs/pages/summaries.md
+++ b/docs/pages/summaries.md
@@ -1,0 +1,43 @@
+---
+layout: variation
+section: components
+status: Released
+variation_groups:
+  - variation_group_name: Summaries
+    variations:
+      - variation_name: Summary
+        variation_code_snippet: |-
+          <div class="o-summary">
+              <div class="o-summary_content">
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+              </div>
+
+              <button class="o-summary_btn">
+                  Read full answer
+                  {% include icons/plus-round.svg %}
+              </button>
+          </div>
+
+      - variation_name: Summary on Mobile
+        variation_code_snippet: |-
+          <div class="o-summary o-summary__mobile">
+            <div class="o-summary_content">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </div>
+
+            <button class="o-summary_btn">
+                Read full answer
+                {% include icons/plus-round.svg %}
+            </button>
+          </div>
+        variation_description:
+          Adding the `o-summary__mobile` modifier makes the summary
+          behavior only show up on a mobile (narrow) page width.
+
+eyebrow: Behavior
+title: Summaries
+description: Summary components hides content over a certain height. When
+  the hidden content is shown it can't be reverted to the summary until the page
+  is reloaded.
+last_updated: 2019-12-16T18:43:19.784Z
+---

--- a/packages/cfpb-core/src/breakpoint-state.js
+++ b/packages/cfpb-core/src/breakpoint-state.js
@@ -1,0 +1,97 @@
+/* ==========================================================================
+   Get Breakpoint State
+   ========================================================================== */
+
+import varsBreakpoints from '@cfpb/cfpb-core/src/vars-breakpoints.js';
+
+/**
+ * @returns {number} The base font size set on the body element.
+ */
+function _getBodyBaseFontSize() {
+  let fontSize = getComputedStyle(document.body).fontSize;
+  fontSize = fontSize === '' ? -1 : fontSize;
+  return parseFloat(fontSize);
+}
+
+/**
+ * @param {object} breakpointRange - Object containing breakpoint constants.
+ *   For example, for `bpXS` the value `{ min: 0, max: 600 }` would be passed.
+ * @param {number} width - Current window width.
+ * @returns {boolean} Whether the passed width is within a breakpoint range.
+ */
+function _inBreakpointRange(breakpointRange, width) {
+  let breakpointRangeMin = breakpointRange.min;
+  let breakpointRangeMax = breakpointRange.max;
+
+  // Whether the user has set a custom size for the font in their browser.
+  const useEmsConversation =
+    _getBodyBaseFontSize() > 0 && _getBodyBaseFontSize() !== 16;
+  if (useEmsConversation) {
+    /* 16 = base font size without adjustments.
+       The CSS converts breakpoints to ems, which then change the width of the
+       pixel width of the breakpoint. In JavaScript, the breakpoints are defined
+       in pixels, so we first convert them to ems using the 16px base font size
+       and then multiply them by any adjustments set by customizations of the
+       font size in the user's browser. */
+    breakpointRangeMin = (breakpointRangeMin / 16) * _getBodyBaseFontSize();
+    breakpointRangeMax = (breakpointRangeMax / 16) * _getBodyBaseFontSize();
+  }
+
+  const min = breakpointRangeMin || 0;
+  const max = breakpointRangeMax || Number.POSITIVE_INFINITY;
+
+  return min <= width && width <= max;
+}
+
+/**
+ * @param {number} width - Current window width.
+ * @returns {object} An object literal with boolean
+ *   bpXS, bpSM, bpMED, bpLG, bpXL properties.
+ */
+function getBreakpointState(width) {
+  const breakpointState = {};
+  width = width || window.innerWidth;
+
+  let rangeKey;
+  // eslint-disable-next-line guard-for-in
+  for (rangeKey in varsBreakpoints) {
+    breakpointState[rangeKey] = _inBreakpointRange(
+      varsBreakpoints[rangeKey],
+      width
+    );
+  }
+
+  return breakpointState;
+}
+
+// Constants for breakpoint groupings.
+const MOBILE = 'mobile';
+const TABLET = 'tablet';
+const DESKTOP = 'desktop';
+
+/**
+ * Checks whether the current breakpoint is in a particular breakpoint group.
+ *
+ * @param {string} breakpointGroup - Breakpoint group names.
+ * @returns {boolean} True if in the breakpoint group, otherwise false.
+ */
+function viewportIsIn(breakpointGroup) {
+  let response = false;
+  const currentBreakpoint = getBreakpointState();
+
+  if (
+    (breakpointGroup === MOBILE && currentBreakpoint.bpXS) ||
+    (breakpointGroup === TABLET && currentBreakpoint.bpSM) ||
+    (breakpointGroup === DESKTOP &&
+      (currentBreakpoint.bpMED ||
+        currentBreakpoint.bpLG ||
+        currentBreakpoint.bpXL))
+  ) {
+    response = true;
+  }
+
+  return response;
+}
+
+// Expose public methods.
+export { MOBILE, TABLET, DESKTOP, getBreakpointState, viewportIsIn };

--- a/packages/cfpb-expandables/src/Summary.js
+++ b/packages/cfpb-expandables/src/Summary.js
@@ -1,0 +1,185 @@
+import {
+  checkDom,
+  instantiateAll,
+  setInitFlag,
+} from '@cfpb/cfpb-atomic-component/src/utilities/atomic-helpers.js';
+import { add as addDataHook } from '@cfpb/cfpb-atomic-component/src/utilities/data-hook.js';
+import EventObserver from '@cfpb/cfpb-atomic-component/src/mixins/EventObserver.js';
+import MaxHeightTransition from '@cfpb/cfpb-atomic-component/src/utilities/transition/MaxHeightTransition.js';
+import FlyoutMenu from '../../cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js';
+import {
+  DESKTOP,
+  TABLET,
+  viewportIsIn,
+} from '../../cfpb-core/src/breakpoint-state.js';
+
+const BASE_CLASS = 'o-summary';
+
+/**
+ * Summary
+ *
+ * @class
+ * @classdesc Initializes a new Summary organism.
+ * @param {HTMLElement} element - The DOM element within which to search
+ *   for the organism.
+ * @returns {Summary} An instance.
+ */
+function Summary(element) {
+  const _dom = checkDom(element, BASE_CLASS);
+  const _hasMobileModifier = _dom.classList.contains(`${BASE_CLASS}__mobile`);
+  const _contentDom = _dom.querySelector(`.${BASE_CLASS}_content`);
+  const _btnDom = _dom.querySelector(`.${BASE_CLASS}_btn`);
+  let _transition;
+  let _flyout;
+
+  // Whether the menu has been expanded or not.
+  let _isExpanded = false;
+
+  // Whether this instance's behaviors are suspended or not.
+  let _suspended = true;
+
+  /**
+   * @returns {Summary} An instance.
+   */
+  function init() {
+    if (!setInitFlag(_dom)) {
+      return this;
+    }
+
+    /* Bail out of initializatiion if the height of the summary's content
+       is less then our summary height of 5.5ems (16 * 5.5 = 88)
+       See https://github.com/cfpb/design-system/blob/72623270013f2ad08dbe92b5b709ed2b434ee41e/packages/cfpb-atomic-component/src/utilities/transition/transition.less#L84 */
+    if (_contentDom.offsetHeight <= 88) {
+      _hideButton();
+      return this;
+    }
+
+    // Add FlyoutMenu behavior data-js-hooks.
+    addDataHook(_dom, 'behavior_flyout-menu');
+    addDataHook(_contentDom, 'behavior_flyout-menu_content');
+    addDataHook(_btnDom, 'behavior_flyout-menu_trigger');
+
+    _transition = new MaxHeightTransition(_contentDom).init();
+    _flyout = new FlyoutMenu(_dom).init();
+
+    _resizeHandler();
+
+    window.addEventListener('resize', _resizeHandler);
+    // Pipe window resize handler into orientation change on supported devices.
+    if ('onorientationchange' in window) {
+      window.addEventListener('orientationchange', _resizeHandler);
+    }
+
+    /* When we click inside the content area we may be changing the size,
+       such as when a video player expands on being clicked.
+       So, let's refresh the transition to recalculate the max-height,
+       just in case. */
+    _contentDom.addEventListener('click', _contentClicked);
+
+    return this;
+  }
+
+  /**
+   * Handler for when the content area is clicked.
+   * Refresh the transition to recalculate the max-height.
+   *
+   * @param {MouseEvent} evt - the mouse event object.
+   */
+  function _contentClicked(evt) {
+    /* We don't need to refresh if a link was clicked as we'll be navigating
+       to another page. */
+    if (evt.target.tagName !== 'A') {
+      _transition.refresh();
+    }
+  }
+
+  /**
+   * Handle resizing of the window,
+   * suspends or resumes the mobile or desktop menu behaviors.
+   */
+  function _resizeHandler() {
+    if ((_hasMobileModifier && viewportIsIn(DESKTOP)) || viewportIsIn(TABLET)) {
+      _suspend();
+    } else {
+      _resume();
+    }
+  }
+
+  /**
+   * After the summary opens, remove the "read more" button.
+   */
+  function _expandEndHandler() {
+    _hideButton();
+    _isExpanded = true;
+  }
+
+  /**
+   *
+   */
+  function _showButton() {
+    _btnDom.classList.remove('u-hidden');
+  }
+
+  /**
+   *
+   */
+  function _hideButton() {
+    _btnDom.classList.add('u-hidden');
+  }
+
+  /**
+   * Add events necessary for the desktop menu behaviors.
+   *
+   * @returns {boolean} Whether it has successfully been resumed or not.
+   */
+  function _resume() {
+    // Re-initialize the transition on every resize to set the max-height.
+    _transition.refresh();
+
+    if (_suspended && _isExpanded === false) {
+      _flyout.addEventListener('expandEnd', _expandEndHandler);
+      // Set resume state.
+      _transition.setElement(_contentDom);
+      _flyout.setExpandTransition(_transition, _transition.maxHeightDefault);
+      _flyout.setCollapseTransition(_transition, _transition.maxHeightSummary);
+      _transition.animateOff();
+      _transition.maxHeightSummary();
+      _transition.animateOn();
+      _showButton();
+
+      _suspended = false;
+    }
+
+    return !_suspended;
+  }
+
+  /**
+   * Remove events necessary for the desktop menu behaviors.
+   *
+   * @returns {boolean} Whether it has successfully been suspended or not.
+   */
+  function _suspend() {
+    if (!_suspended) {
+      _suspended = true;
+      _flyout.removeEventListener('expandEnd', _expandEndHandler);
+      _flyout.clearTransitions();
+    }
+
+    return _suspended;
+  }
+
+  // Attach public events.
+  const eventObserver = new EventObserver();
+  this.addEventListener = eventObserver.addEventListener;
+  this.removeEventListener = eventObserver.removeEventListener;
+  this.dispatchEvent = eventObserver.dispatchEvent;
+
+  this.init = init;
+
+  return this;
+}
+
+Summary.BASE_CLASS = BASE_CLASS;
+Summary.init = () => instantiateAll(`.${BASE_CLASS}`, Summary);
+
+export default Summary;

--- a/packages/cfpb-expandables/src/cfpb-expandables.less
+++ b/packages/cfpb-expandables/src/cfpb-expandables.less
@@ -2,6 +2,7 @@
 @import (reference) '@cfpb/cfpb-core/src/cfpb-core.less';
 @import (reference) '@cfpb/cfpb-buttons/src/cfpb-buttons.less';
 @import (reference) '@cfpb/cfpb-icons/src/cfpb-icons.less';
+@import (less) './summary.less';
 
 /* ==========================================================================
    Design System

--- a/packages/cfpb-expandables/src/summary.less
+++ b/packages/cfpb-expandables/src/summary.less
@@ -1,0 +1,98 @@
+@import (reference) '@cfpb/cfpb-core/src/cfpb-core.less';
+
+/* topdoc
+  name: Summary
+  family: cf-organisms
+  notes:
+    - "Styles a one-way Expandable-like organism that previews content."
+  patterns:
+  - name: Summary Mobile organism
+    markup: |
+      <div class="o-summary o-summary__mobile"
+           data-js-hook="behavior_flyout-menu">
+          <div class="o-summary_content"
+               data-js-hook="behavior_flyout-menu_content">
+               Content
+          </div>
+          <button class="o-summary_btn u-hidden"
+                  data-js-hook="behavior_flyout-menu_trigger">
+            Read full description
+          </button>
+      </div>
+    codenotes:
+      - |
+        Pattern structure
+        -----------------
+        .o-summary
+          .o-summary_content
+          .o-summary_btn.u-hidden
+
+    notes:
+      - "One-way expandable. Displays an approximately 4-line
+         preview of content on mobile screen sizes only
+         when __mobile modifier is used."
+  tags:
+  - cf-organisms
+*/
+
+.o-summary {
+  &_content {
+    overflow: hidden;
+    position: relative;
+
+    &[aria-expanded='false']:after {
+      // Fades content out over approximately 2 lines.
+      display: block;
+      height: unit(((@base-line-height-px * 2) / @base-font-size-px), em);
+      margin: 0;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0) 0%,
+        rgba(255, 255, 255, 1) 100%
+      );
+      content: '';
+
+      .respond-to-print({
+        background: none;
+      });
+    }
+  }
+
+  &_btn {
+    position: relative;
+    z-index: 2;
+    display: block;
+    width: 100%;
+    padding-top: 15px;
+    padding-bottom: 15px;
+    border: dotted @pacific;
+    border-width: 1px 0;
+    text-align: center;
+    color: @pacific;
+    background: #fff;
+
+    &:focus {
+      outline: 1px dotted @pacific;
+      outline-offset: 2px;
+    }
+  }
+
+  // If we're mobile-only…
+  &__mobile {
+    @media only screen and (min-width: @bp-sm-min) {
+      .o-summary_content[aria-expanded='false']:after {
+        // Don't fade content if on desktop.
+        display: none;
+      }
+
+      .o-summary_btn {
+        // Hide the "read more" button on desktop.
+        display: none;
+      }
+    }
+  }
+}

--- a/test/unit-test/src/cfpb-expandables/src/Summary-spec.js
+++ b/test/unit-test/src/cfpb-expandables/src/Summary-spec.js
@@ -1,0 +1,130 @@
+import { jest } from '@jest/globals';
+import Summary from '../../../../../packages/cfpb-expandables/src/Summary.js';
+import { simulateEvent } from '../../../util/simulate-event.js';
+
+const HTML_SNIPPET = `
+<div class="o-summary o-summary__mobile"
+     data-js-hook="behavior_flyout-menu">
+    <div class="o-summary_content"
+         data-js-hook="behavior_flyout-menu_content">
+        <a href="#">Content</a>
+        <details>
+            <summary>
+                I have keys but no doors.
+                I have space but no room.
+                You can enter but can’t leave.
+                What am I?
+            </summary>
+            A keyboard.
+        </details>
+    </div>
+    <button class="o-summary_btn u-hidden"
+            data-js-hook="behavior_flyout-menu_trigger">
+        Read full description
+    </button>
+</div>
+`;
+
+let summary;
+let summaryDom;
+let targetDom;
+let contentDom;
+let contentLinkDom;
+let expandableContentDom;
+
+/**
+ * Change the viewport to width x height. Mocks window.resizeTo( w, h ).
+ *
+ * @param {number} width - width in pixels.
+ * @param {number} height - height in pixels.
+ */
+function windowResizeTo(width, height) {
+  // Change the viewport to width x height. Mocks window.resizeTo( w, h ).
+  global.innerWidth = width;
+  global.innerHeight = height;
+
+  // Trigger the window resize event.
+  global.dispatchEvent(new Event('resize'));
+}
+
+describe('Summary', () => {
+  beforeEach(() => {
+    document.body.innerHTML = HTML_SNIPPET;
+    summaryDom = document.querySelector('.o-summary__mobile');
+    targetDom = summaryDom.querySelector('.o-summary_btn');
+    contentDom = summaryDom.querySelector('.o-summary_content');
+    contentLinkDom = summaryDom.querySelector('a');
+    expandableContentDom = summaryDom.querySelector('details');
+
+    summary = new Summary(summaryDom);
+  });
+
+  describe('initialized state', () => {
+    it('should be initialized', () => {
+      expect(summaryDom.getAttribute('data-js-hook')).toBe(
+        'behavior_flyout-menu'
+      );
+      summary.init();
+      expect(summaryDom.getAttribute('data-js-hook')).toBe(
+        'behavior_flyout-menu state_atomic_init'
+      );
+    });
+  });
+
+  describe('interactions', () => {
+    it('should be absent when content is too brief', () => {
+      jest
+        .spyOn(contentDom, 'offsetHeight', 'get')
+        .mockImplementation(() => 50);
+      summary.init();
+      windowResizeTo(300);
+      expect(contentDom.getAttribute('aria-expanded')).toBe(null);
+      expect(targetDom.classList.contains('u-hidden')).toBe(true);
+    });
+
+    it('should expand on click', () => {
+      jest
+        .spyOn(contentDom, 'offsetHeight', 'get')
+        .mockImplementation(() => 200);
+      summary.init();
+      windowResizeTo(300);
+      expect(contentDom.getAttribute('aria-expanded')).toBe('false');
+      expect(targetDom.getAttribute('aria-expanded')).toBe('false');
+      simulateEvent('click', targetDom);
+
+      /* The transitionend event should fire on its own,
+         but for some reason the transitionend event is not firing within JSDom.
+         In a future JSDom update this should be revisited.
+         See https://github.com/jsdom/jsdom/issues/1781
+      */
+      const event = new Event('transitionend');
+      event.propertyName = 'max-height';
+      contentDom.dispatchEvent(event);
+
+      expect(contentDom.style.maxHeight).not.toBe('0');
+      expect(contentDom.getAttribute('aria-expanded')).toBe('true');
+      expect(targetDom.getAttribute('aria-expanded')).toBe('true');
+
+      expect(targetDom.classList.contains('u-hidden')).toBe(true);
+      windowResizeTo(1200);
+    });
+
+    it('should refresh height when non-link content is clicked', () => {
+      jest
+        .spyOn(contentDom, 'offsetHeight', 'get')
+        .mockImplementation(() => 200);
+      summary.init();
+      windowResizeTo(300);
+      simulateEvent('click', targetDom);
+
+      const spy = jest.spyOn(contentDom, 'scrollHeight', 'get');
+      expect(spy).not.toHaveBeenCalled();
+
+      simulateEvent('click', contentLinkDom);
+      expect(spy).not.toHaveBeenCalled();
+
+      simulateEvent('click', expandableContentDom);
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Add summary component and breakpoint-state from cfgov repo.

## Additions

- Add summary component.
- Add breakpoint-state.js to cfpb-core.

## Testing

1. PR preview should have a Summaries page, which when resized to mobile should have two summary buttons.

## Screenshots

<img width="969" alt="Screen Shot 2023-01-19 at 5 53 22 PM" src="https://user-images.githubusercontent.com/704760/213580258-b0a2808e-1b95-4aba-a77f-2933a2cc47c0.png">
