### PR TITLE
Ignore some linting rules

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
+++ b/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-use-before-define */
 import {
   BEHAVIOR_PREFIX,
   JS_HOOK,
@@ -33,7 +34,6 @@ const SEL_PREFIX = '[' + JS_HOOK + '=' + BASE_CLASS;
  * @returns {FlyoutMenu} An instance.
  */
 function FlyoutMenu(element) {
-  // eslint-disable-line max-statements, no-inline-comments, max-len
   // Verify that the expected dom attributes are present.
   const _dom = checkBehaviorDom(element, BASE_CLASS);
   const _triggerDoms = _findTriggers(element);
@@ -353,7 +353,7 @@ function FlyoutMenu(element) {
   }
 
   /**
-   * @param {MoveTransition|AlphaTransition} transition - A transition instance
+   * @param {BaseTransition} transition - A transition instance
    *   to watch for events on.
    * @param {Function} method - The transition method to call on expand.
    * @param {Array} [args] - List of arguments to apply to expand method.
@@ -365,7 +365,7 @@ function FlyoutMenu(element) {
   }
 
   /**
-   * @param {MoveTransition|AlphaTransition} transition - A transition instance
+   * @param {BaseTransition} transition - A transition instance
    *   to watch for events on.
    * @param {Function} method - The transition method to call on collapse.
    * @param {Array} [args] - List of arguments to apply to collapse method.
@@ -412,7 +412,7 @@ function FlyoutMenu(element) {
    *   `FlyoutMenu.EXPAND_TYPE` and `FlyoutMenu.COLLAPSE_TYPE` can be used
    *   as type-safe constants passed into this method.
    *   If neither or something else is supplied, expand type is returned.
-   * @returns {MoveTransition|AlphaTransition|undefined} A transition instance
+   * @returns {BaseTransition|undefined} A transition instance
    *   set on this instance, or undefined if none is set.
    */
   function getTransition(type) {

--- a/packages/cfpb-atomic-component/src/utilities/behavior/behavior.js
+++ b/packages/cfpb-atomic-component/src/utilities/behavior/behavior.js
@@ -48,6 +48,7 @@ function _findElements(behaviorSelector, baseElement) {
     behaviorElements.length === 0 &&
     behaviorSelector.indexOf(BEHAVIOR_PREFIX) === -1
   ) {
+    // eslint-disable-next-line no-use-before-define
     behaviorElements = find(behaviorSelector, baseElement);
   }
 

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -22,8 +22,6 @@ const BASE_CLASS = 'o-multiselect';
  * @returns {Multiselect} An instance.
  */
 function Multiselect(element) {
-  // eslint-disable-line max-statements
-
   const CHECKBOX_INPUT_CLASS = 'a-checkbox';
   const TEXT_INPUT_CLASS = 'a-text-input';
 


### PR DESCRIPTION
## Changes

- Remove linting ignore comments that are not being applied.
- Ignore `no-use-before-define` in some cases.
- Update transition comment to be parent transition `BaseTransition`.

## Testing

1. PR checks should pass. `yarn lint` should pass.
