### PR TITLE
Transitions: Enforce having both expand and collapse transitions

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
+++ b/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
@@ -240,7 +240,8 @@ function FlyoutMenu(element) {
       _deferFunct = noopFunct;
       this.dispatchEvent('expandBegin', { target: this, type: 'expandBegin' });
 
-      if (_expandTransitionMethod) {
+      // Only use transitions if both expand and collapse are set.
+      if (_expandTransitionMethod && _collapseTransitionMethod) {
         const hasTransition =
           _expandTransition && _expandTransition.isAnimated();
         if (hasTransition) {
@@ -281,7 +282,9 @@ function FlyoutMenu(element) {
         target: this,
         type: 'collapseBegin',
       });
-      if (_collapseTransitionMethod) {
+
+      // Only use transitions if both expand and collapse are set.
+      if (_collapseTransitionMethod && _expandTransitionMethod) {
         const hasTransition =
           _collapseTransition && _collapseTransition.isAnimated();
         if (hasTransition) {
@@ -362,6 +365,8 @@ function FlyoutMenu(element) {
     _expandTransition = transition;
     _expandTransitionMethod = method;
     _expandTransitionMethodArgs = args;
+
+    _initTransitions();
   }
 
   /**
@@ -375,7 +380,19 @@ function FlyoutMenu(element) {
     _collapseTransitionMethod = method;
     _collapseTransitionMethodArgs = args;
 
-    if (!_isExpanded) {
+    _initTransitions();
+  }
+
+  /**
+   * Make initial call to transition expand or collapse methods.
+   * Called after the transitions are set on the FlyoutMenu.
+   */
+  function _initTransitions() {
+    if (_isExpanded && _expandTransition) {
+      _expandTransition.animateOff();
+      _expandTransitionMethod();
+      _expandTransition.animateOn();
+    } else if (_collapseTransition) {
       _collapseTransition.animateOff();
       _collapseTransitionMethod();
       _collapseTransition.animateOn();

--- a/packages/cfpb-atomic-component/src/utilities/transition/AlphaTransition.js
+++ b/packages/cfpb-atomic-component/src/utilities/transition/AlphaTransition.js
@@ -32,11 +32,8 @@ function AlphaTransition(element) {
    */
   function init() {
     _baseTransition.init();
-    const _transitionCompleteBinded = _transitionComplete.bind(this);
-    _baseTransition.addEventListener(
-      BaseTransition.END_EVENT,
-      _transitionCompleteBinded
-    );
+    _baseTransition.proxyEvents(this, _transitionComplete.bind(this));
+
     return this;
   }
 

--- a/packages/cfpb-atomic-component/src/utilities/transition/BaseTransition.js
+++ b/packages/cfpb-atomic-component/src/utilities/transition/BaseTransition.js
@@ -1,6 +1,5 @@
 import EventObserver from '@cfpb/cfpb-atomic-component/src/mixins/EventObserver.js';
 
-// eslint-disable-next-line max-statements
 /**
  * BaseTransition
  *
@@ -52,9 +51,13 @@ function BaseTransition(element, classes) {
       !_dom.classList.contains(BaseTransition.NO_ANIMATION_CLASS)
     ) {
       _dom.addEventListener(_transitionEndEvent, _transitionCompleteBinded);
-      this.dispatchEvent(BaseTransition.BEGIN_EVENT, { target: this });
+      this.dispatchEvent(BaseTransition.BEGIN_EVENT, {
+        target: this,
+      });
     } else {
-      this.dispatchEvent(BaseTransition.BEGIN_EVENT, { target: this });
+      this.dispatchEvent(BaseTransition.BEGIN_EVENT, {
+        target: this,
+      });
       _transitionCompleteBinded();
     }
   }
@@ -80,7 +83,9 @@ function BaseTransition(element, classes) {
 
     _removeEventListener();
     _dom.classList.remove(BaseTransition.ANIMATING_CLASS);
-    this.dispatchEvent(BaseTransition.END_EVENT, { target: this });
+    this.dispatchEvent(BaseTransition.END_EVENT, {
+      target: this,
+    });
     _isAnimating = false;
     return true;
   }
@@ -267,6 +272,23 @@ function BaseTransition(element, classes) {
     return true;
   }
 
+  /**
+   * Passes events fired on BaseTransition to the passed event target.
+   * @param {Object} eventTarget - A child transition to proxy events to.
+   * @param {Function} transitionComplete - what to call when transition ends.
+   * @returns {BaseTransition} An instance.
+   */
+  function proxyEvents(eventTarget, transitionComplete) {
+    this.addEventListener(BaseTransition.BEGIN_EVENT, () => {
+      eventTarget.dispatchEvent(BaseTransition.BEGIN_EVENT, {
+        target: eventTarget,
+      });
+    });
+    this.addEventListener(BaseTransition.END_EVENT, transitionComplete);
+
+    return this;
+  }
+
   // Attach public events.
   const eventObserver = new EventObserver();
   this.addEventListener = eventObserver.addEventListener;
@@ -281,6 +303,7 @@ function BaseTransition(element, classes) {
   this.isAnimated = isAnimated;
   this.remove = remove;
   this.setElement = setElement;
+  this.proxyEvents = proxyEvents;
 
   return this;
 }

--- a/packages/cfpb-atomic-component/src/utilities/transition/BaseTransition.js
+++ b/packages/cfpb-atomic-component/src/utilities/transition/BaseTransition.js
@@ -274,7 +274,8 @@ function BaseTransition(element, classes) {
 
   /**
    * Passes events fired on BaseTransition to the passed event target.
-   * @param {Object} eventTarget - A child transition to proxy events to.
+   *
+   * @param {object} eventTarget - A child transition to proxy events to.
    * @param {Function} transitionComplete - what to call when transition ends.
    * @returns {BaseTransition} An instance.
    */

--- a/packages/cfpb-atomic-component/src/utilities/transition/MaxHeightTransition.js
+++ b/packages/cfpb-atomic-component/src/utilities/transition/MaxHeightTransition.js
@@ -61,11 +61,7 @@ function MaxHeightTransition(element) {
        the element max-height. */
     window.addEventListener('load', _pageLoaded);
 
-    const _transitionCompleteBinded = _transitionComplete.bind(this);
-    _baseTransition.addEventListener(
-      BaseTransition.END_EVENT,
-      _transitionCompleteBinded
-    );
+    _baseTransition.proxyEvents(this, _transitionComplete.bind(this));
 
     return this;
   }

--- a/packages/cfpb-atomic-component/src/utilities/transition/MoveTransition.js
+++ b/packages/cfpb-atomic-component/src/utilities/transition/MoveTransition.js
@@ -36,11 +36,8 @@ function MoveTransition(element) {
    */
   function init() {
     _baseTransition.init();
-    const _transitionCompleteBinded = _transitionComplete.bind(this);
-    _baseTransition.addEventListener(
-      BaseTransition.END_EVENT,
-      _transitionCompleteBinded
-    );
+    _baseTransition.proxyEvents(this, _transitionComplete.bind(this));
+
     return this;
   }
 


### PR DESCRIPTION
If you have only a collapse transition, or an expand transition, then the transition completion events won't fire since there's no state to expand or collapse from.

## Additions

- Add `proxyEvents` method to BaseTransition to pass its events through to its child transitions.

## Changes

- Transitions: Enforce having both expand and collapse transitions.


## Testing

1. PR checks should pass.
