### PR TITLE
Migrate deprecated keyCode to KeyboardEvent.key

### DIFF
--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -11,6 +11,20 @@ import * as closeIconSrc from '@cfpb/cfpb-icons/src/icons/close.svg';
 const closeIcon = closeIconSrc.default;
 
 const BASE_CLASS = 'o-multiselect';
+const CHECKBOX_INPUT_CLASS = 'a-checkbox';
+const TEXT_INPUT_CLASS = 'a-text-input';
+
+// Constants for direction.
+const DIR_PREV = 'prev';
+const DIR_NEXT = 'next';
+
+// Constants for key binding.
+const KEY_RETURN = 'Enter';
+const KEY_SPACE = ' ';
+const KEY_ESCAPE = 'Escape';
+const KEY_UP = 'ArrowUp';
+const KEY_DOWN = 'ArrowDown';
+const KEY_TAB = 'Tab';
 
 /**
  * Multiselect
@@ -22,26 +36,11 @@ const BASE_CLASS = 'o-multiselect';
  * @returns {Multiselect} An instance.
  */
 function Multiselect(element) {
-  const CHECKBOX_INPUT_CLASS = 'a-checkbox';
-  const TEXT_INPUT_CLASS = 'a-text-input';
-
   /* TODO: As the multiselect is developed further
      explore whether it should use an updated
      class name or data-* attribute in the
      markup so that it doesn't apply globally by default. */
   element.classList.add(BASE_CLASS);
-
-  // Constants for direction.
-  const DIR_PREV = 'prev';
-  const DIR_NEXT = 'next';
-
-  // Constants for key binding.
-  const KEY_RETURN = 13;
-  const KEY_SPACE = 32;
-  const KEY_ESCAPE = 27;
-  const KEY_UP = 38;
-  const KEY_DOWN = 40;
-  const KEY_TAB = 9;
 
   // Internal vars.
   let _dom = checkDom(element, BASE_CLASS);
@@ -228,7 +227,7 @@ function Multiselect(element) {
    * @param {KeyboardEvent} event - The key down event object.
    */
   function _selectionKeyDownHandler(event) {
-    if (event.keyCode === KEY_SPACE || event.keyCode === KEY_RETURN) {
+    if (event.key === KEY_SPACE || event.key === KEY_RETURN) {
       const label = event.target.querySelector('label');
       const checkbox = _optionsDom.querySelector(
         '#' + label.getAttribute('for')
@@ -378,7 +377,7 @@ function Multiselect(element) {
     });
 
     _searchDom.addEventListener('keydown', function (event) {
-      const key = event.keyCode;
+      const key = event.key;
 
       if (
         _fieldsetDom.getAttribute('aria-hidden') === 'true' &&
@@ -409,7 +408,7 @@ function Multiselect(element) {
     });
 
     _optionsDom.addEventListener('keydown', function (event) {
-      const key = event.keyCode;
+      const key = event.key;
       const target = event.target;
       const checked = target.checked;
 

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/behavior/behavior.spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/behavior/behavior.spec.js
@@ -30,14 +30,14 @@ const HTML_SNIPPET = `
 /**
  * @param {HTMLElement} target - The target element of the event.
  * @param {string} eventType - The event type description.
- * @param {string} eventOption - A keyCode, if the event is a keyup event.
+ * @param {string} eventOption - A key, if the event is a keyup event.
  */
-function triggerEvent(target, eventType, eventOption) {
-  const event = document.createEvent('Event');
-  if (eventType === 'keyup') {
-    event.keyCode = eventOption || '';
-  }
-  event.initEvent(eventType, true, true);
+function triggerEvent(target, eventType) {
+  const event = new MouseEvent(eventType, {
+    bubbles: true,
+    cancelable: true,
+    view: window,
+  });
   target.dispatchEvent(event);
 }
 

--- a/test/unit-test/src/cfpb-expandables/src/Expandable.spec.js
+++ b/test/unit-test/src/cfpb-expandables/src/Expandable.spec.js
@@ -1,5 +1,5 @@
 import Expandable from '../../../../../packages/cfpb-expandables/src/Expandable.js';
-import simulateEvent from '../../../../util/simulate-event.js';
+import { simulateEvent } from '../../../../util/simulate-event.js';
 
 const HTML_SNIPPET = `
 <div class="o-expandable-group"

--- a/test/unit-test/src/cfpb-forms/src/organisms/Multiselect.spec.js
+++ b/test/unit-test/src/cfpb-forms/src/organisms/Multiselect.spec.js
@@ -1,5 +1,5 @@
 import Multiselect from '../../../../../../packages/cfpb-forms/src/organisms/Multiselect.js';
-import simulateEvent from '../../../../../util/simulate-event.js';
+import { simulateEvent } from '../../../../../util/simulate-event.js';
 
 let multiselect;
 let selectDom;
@@ -73,7 +73,7 @@ describe('Multiselect', () => {
       multiselect.init();
       const search = document.querySelector('#test-select');
       search.click();
-      simulateEvent('keydown', search, { keyCode: 40 });
+      simulateEvent('keydown', search, { key: 'ArrowDown' });
 
       expect(document.activeElement.id).toBe('test-select-debt-collection');
       expect(document.activeElement.value).toBe('Debt collection');

--- a/test/util/simulate-event.js
+++ b/test/util/simulate-event.js
@@ -4,13 +4,26 @@
  * @param {object} eventOption - Options to add to the event.
  * @returns {HTMLElement} The target of the event.
  */
-function simulateEvent(eventType, target, eventOption) {
-  const event = document.createEvent('Event');
-  if (eventOption && eventOption.keyCode) {
-    event.keyCode = eventOption.keyCode;
+function simulateEvent(eventType, target, eventOption = {}) {
+  let event;
+
+  if (eventType === 'click') {
+    event = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+    });
+    // TODO: migrate to KeyBoardEvent, etc.
+  } else {
+    event = window.document.createEvent('Event', eventOption.currentTarget);
+    event.initEvent(eventType, true, true);
+
+    if (eventOption && eventOption.key) {
+      event.key = eventOption.key;
+    }
   }
-  event.initEvent(eventType, true, true);
+
   return target.dispatchEvent(event);
 }
 
-export default simulateEvent;
+export { simulateEvent };


### PR DESCRIPTION
See [GHE]/CFGOV/platform/issues/4391

## Changes

- Unit tests: Migrate deprecated keyCode to KeyboardEvent.key.
- Mulltiselect: Migrate deprecated keyCode to KeyboardEvent.key.
- Mulltiselect: Move constants outside of instance.

## Testing

1. PR checks should pass. Multiselect should work as before.
