### PR TITLE
Increase netlify admin button z-index to 100

### DIFF
--- a/docs/assets/css/netlify.less
+++ b/docs/assets/css/netlify.less
@@ -2,7 +2,7 @@
   position: fixed;
   bottom: 60px;
   right: 30px;
-  z-index: 1;
+  z-index: 100;
 
   &#toggle-details {
     bottom: 105px;


### PR DESCRIPTION
The edit buttons could appear under content, if the content's z-index was greater than 1. This PR increases the edit button's z-index to 100.

## Changes

- Increase netlify edit button's z-index to 100.

## Testing

1. PR checks should pass.
