### PR TITLE
Summary: move padding to prevent clipping focus rectangle

### DIFF
--- a/packages/cfpb-expandables/src/summary.less
+++ b/packages/cfpb-expandables/src/summary.less
@@ -37,7 +37,13 @@
 
 .o-summary {
   &_content {
-    overflow: hidden;
+    overflow-y: hidden;
+
+    // Move the bounding box one pixel to avoid clipping link focus boxes.
+    padding: 2px;
+    left: -2px;
+    top: -2px;
+
     position: relative;
 
     &[aria-expanded='false']::after {


### PR DESCRIPTION
## Changes

- Summary: move padding to prevent clipping focus rectangle

## Testing

1. Visit http://localhost:4000/design-system/components/summaries# and ensure that the focus area on a link rectangle within a summary is not clipped.