### PR TITLE
Fix stylelint config

### DIFF
--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -13,7 +13,7 @@ less/no-duplicate-variables
   https://github.com/ssivanatarajan/stylelint-less/issues/6 is addressed.
 */
 module.exports = {
-  extends: ['stylelint-config-recommended-less', 'stylelint-config-standard'],
+  extends: ['stylelint-config-recommended-less', 'stylelint-config-prettier'],
   ignoreFiles: ['packages/**/node_modules/**/*.less'],
   customSyntax: 'postcss-less',
   rules: {

--- a/docs/assets/css/code.less
+++ b/docs/assets/css/code.less
@@ -15,28 +15,13 @@ pre[class*='language-'] {
   word-wrap: normal;
   line-height: 1.5;
 
-  -moz-tab-size: 4;
-  -o-tab-size: 4;
   tab-size: 4;
 
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
   hyphens: none;
 }
 
-pre[class*='language-']::-moz-selection,
-pre[class*='language-'] ::-moz-selection,
-code[class*='language-']::-moz-selection,
-code[class*='language-'] ::-moz-selection {
-  text-shadow: none;
-  background: #b3d4fc;
-}
-
 pre[class*='language-']::selection,
-pre[class*='language-'] ::selection,
-code[class*='language-']::selection,
-code[class*='language-'] ::selection {
+code[class*='language-']::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -107,7 +92,7 @@ pre[class*='language-'] {
 .language-css .token.string,
 .style .token.string {
   color: #a67f59;
-  background: hsla(0, 0%, 100%, 0.5);
+  background: hsl(0deg 0% 100% / 50%);
 }
 
 .token.atrule,
@@ -144,245 +129,305 @@ pre[class*='language-'] {
 .highlight .hll {
   background-color: #ffc;
 }
+
 /* Comment */
 .highlight .c {
   color: #999;
 }
+
 /* Error */
 .highlight .err {
   color: #a00;
   background-color: #faa;
 }
+
 /* Keyword */
 .highlight .k {
   color: #069;
 }
+
 /* Operator */
 .highlight .o {
   color: #555;
 }
+
 /* Comment.Multiline */
 .highlight .cm {
   color: #09f;
   font-style: italic;
 }
+
 /* Comment.Preproc */
 .highlight .cp {
   color: #099;
 }
+
 /* Comment.Single */
 .highlight .c1 {
   color: #999;
 }
+
 /* Comment.Special */
 .highlight .cs {
   color: #999;
 }
+
 /* Generic.Deleted */
 .highlight .gd {
   background-color: #fcc;
   border: 1px solid #c00;
 }
+
 /* Generic.Emph */
 .highlight .ge {
   font-style: italic;
 }
+
 /* Generic.Error */
 .highlight .gr {
   color: #f00;
 }
+
 /* Generic.Heading */
 .highlight .gh {
   color: #030;
 }
+
 /* Generic.Inserted */
 .highlight .gi {
   background-color: #cfc;
   border: 1px solid #0c0;
 }
+
 /* Generic.Output */
 .highlight .go {
   color: #aaa;
 }
+
 /* Generic.Prompt */
 .highlight .gp {
   color: #009;
 }
+
 /* Generic.Strong */
 // .highlight .gs { }
+
 /* Generic.Subheading */
 .highlight .gu {
   color: #030;
 }
+
 /* Generic.Traceback */
 .highlight .gt {
   color: #9c6;
 }
+
 /* Keyword.Constant */
 .highlight .kc {
   color: #069;
 }
+
 /* Keyword.Declaration */
 .highlight .kd {
   color: #069;
 }
+
 /* Keyword.Namespace */
 .highlight .kn {
   color: #069;
 }
+
 /* Keyword.Pseudo */
 .highlight .kp {
   color: #069;
 }
+
 /* Keyword.Reserved */
 .highlight .kr {
   color: #069;
 }
+
 /* Keyword.Type */
 .highlight .kt {
   color: #078;
 }
+
 /* Literal.Number */
 .highlight .m {
   color: #f60;
 }
+
 /* Literal.String */
 .highlight .s {
   color: #d44950;
 }
+
 /* Name.Attribute */
 .highlight .na {
   color: #4f9fcf;
 }
+
 /* Name.Builtin */
 .highlight .nb {
   color: #366;
 }
+
 /* Name.Class */
 .highlight .nc {
   color: #0a8;
 }
+
 /* Name.Constant */
 .highlight .no {
   color: #360;
 }
+
 /* Name.Decorator */
 .highlight .nd {
   color: #99f;
 }
+
 /* Name.Entity */
 .highlight .ni {
   color: #999;
 }
+
 /* Name.Exception */
 .highlight .ne {
   color: #c00;
 }
+
 /* Name.Function */
 .highlight .nf {
   color: #c0f;
 }
+
 /* Name.Label */
 .highlight .nl {
   color: #99f;
 }
+
 /* Name.Namespace */
 .highlight .nn {
   color: #0cf;
 }
+
 /* Name.Tag */
 .highlight .nt {
   color: #2f6f9f;
 }
+
 /* Name.Variable */
 .highlight .nv {
   color: #033;
 }
+
 /* Operator.Word */
 .highlight .ow {
   color: #000;
 }
+
 /* Text.Whitespace */
 .highlight .w {
   color: #bbb;
 }
+
 /* Literal.Number.Float */
 .highlight .mf {
   color: #f60;
 }
+
 /* Literal.Number.Hex */
 .highlight .mh {
   color: #f60;
 }
+
 /* Literal.Number.Integer */
 .highlight .mi {
   color: #f60;
 }
+
 /* Literal.Number.Oct */
 .highlight .mo {
   color: #f60;
 }
+
 /* Literal.String.Backtick */
 .highlight .sb {
   color: #c30;
 }
+
 /* Literal.String.Char */
 .highlight .sc {
   color: #c30;
 }
+
 /* Literal.String.Doc */
 .highlight .sd {
   color: #c30;
   font-style: italic;
 }
+
 /* Literal.String.Double */
 .highlight .s2 {
   color: #c30;
 }
+
 /* Literal.String.Escape */
 .highlight .se {
   color: #c30;
 }
+
 /* Literal.String.Heredoc */
 .highlight .sh {
   color: #c30;
 }
+
 /* Literal.String.Interpol */
 .highlight .si {
   color: #a00;
 }
+
 /* Literal.String.Other */
 .highlight .sx {
   color: #c30;
 }
+
 /* Literal.String.Regex */
 .highlight .sr {
   color: #3aa;
 }
+
 /* Literal.String.Single */
 .highlight .s1 {
   color: #c30;
 }
+
 /* Literal.String.Symbol */
 .highlight .ss {
   color: #fc3;
 }
+
 /* Name.Builtin.Pseudo */
 .highlight .bp {
   color: #366;
 }
+
 /* Name.Variable.Class */
 .highlight .vc {
   color: #033;
 }
+
 /* Name.Variable.Global */
 .highlight .vg {
   color: #033;
 }
+
 /* Name.Variable.Instance */
 .highlight .vi {
   color: #033;
 }
+
 /* Literal.Number.Integer.Long */
 .highlight .il {
   color: #f60;

--- a/docs/assets/css/code.less
+++ b/docs/assets/css/code.less
@@ -299,7 +299,7 @@ pre[class*='language-'] {
 
 /* Name.Function */
 .highlight .nf {
-  color: #c0f;
+  color: #8f00b3;
 }
 
 /* Name.Label */
@@ -354,33 +354,33 @@ pre[class*='language-'] {
 
 /* Literal.String.Backtick */
 .highlight .sb {
-  color: #c30;
+  color: #a12800;
 }
 
 /* Literal.String.Char */
 .highlight .sc {
-  color: #c30;
+  color: #a12800;
 }
 
 /* Literal.String.Doc */
 .highlight .sd {
-  color: #c30;
+  color: #a12800;
   font-style: italic;
 }
 
 /* Literal.String.Double */
 .highlight .s2 {
-  color: #c30;
+  color: #a12800;
 }
 
 /* Literal.String.Escape */
 .highlight .se {
-  color: #c30;
+  color: #a12800;
 }
 
 /* Literal.String.Heredoc */
 .highlight .sh {
-  color: #c30;
+  color: #a12800;
 }
 
 /* Literal.String.Interpol */
@@ -390,7 +390,7 @@ pre[class*='language-'] {
 
 /* Literal.String.Other */
 .highlight .sx {
-  color: #c30;
+  color: #a12800;
 }
 
 /* Literal.String.Regex */
@@ -400,7 +400,7 @@ pre[class*='language-'] {
 
 /* Literal.String.Single */
 .highlight .s1 {
-  color: #c30;
+  color: #a12800;
 }
 
 /* Literal.String.Symbol */

--- a/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
+++ b/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
@@ -335,6 +335,13 @@ function FlyoutMenu(element) {
     this.dispatchEvent('collapseend', { target: this, type: 'collapseend' });
   }
 
+  /**
+   * Set the transition that runs when this flyout is expanded/collapsed.
+   *
+   * @param {BaseTransition} transition - A transition object.
+   * @param {Function} collapseMethod - The collapse method to call on the transition.
+   * @param {Function} expandMethod - The expand method to call on the transition.
+   */
   function setTransition(transition, collapseMethod, expandMethod) {
     _transition = transition;
 

--- a/packages/cfpb-atomic-component/src/utilities/transition/BaseTransition.js
+++ b/packages/cfpb-atomic-component/src/utilities/transition/BaseTransition.js
@@ -7,14 +7,14 @@
  *   the base class used through composition by a specific transition.
  * @param {HTMLElement} element - DOM element to apply transition to.
  * @param {object} classes - The classes to apply to this transition.
- * @param {Object} child - The child transition using this as a base.
+ * @param {object} child - The child transition using this as a base.
  * @returns {BaseTransition} An instance.
  */
 function BaseTransition(element, classes, child) {
   const _classes = classes;
   let _dom = element;
   if (!child) throw new Error('Child transition argument must be defined!');
-  let _child = child;
+  const _child = child;
 
   let _lastClass;
   let _transitionEndEvent;

--- a/packages/cfpb-expandables/src/summary.less
+++ b/packages/cfpb-expandables/src/summary.less
@@ -57,8 +57,8 @@
       right: 0;
       background: linear-gradient(
         to bottom,
-        rgb(255 255 255 / 0%) 0%,
-        rgb(255 255 255 / 100%) 100%
+        rgba(255, 255, 255, 0) 0%,
+        rgba(255, 255, 255, 1) 100%
       );
       content: '';
 

--- a/packages/cfpb-layout/src/molecules/card.less
+++ b/packages/cfpb-layout/src/molecules/card.less
@@ -70,11 +70,21 @@
     border-bottom-width: 3px;
   }
 
-  &:not(.m-card__featured, .m-card__breakout, .m-card__topic, .m-card__highlight) {
+  &:not(
+      .m-card__featured,
+      .m-card__breakout,
+      .m-card__topic,
+      .m-card__highlight
+    ) {
     padding: unit((@grid_gutter-width / @base-font-size-px), em);
   }
 
-  &:not(.m-card__featured, .m-card__breakout, .m-card__topic, .m-card__highlight),
+  &:not(
+      .m-card__featured,
+      .m-card__breakout,
+      .m-card__topic,
+      .m-card__highlight
+    ),
   & > a {
     display: flex;
     flex-direction: column;

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/transition/BaseTransition.spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/transition/BaseTransition.spec.js
@@ -1,7 +1,11 @@
 import BaseTransition from '../../../../../../../packages/cfpb-atomic-component/src/utilities/transition/BaseTransition.js';
 import EventObserver from '@cfpb/cfpb-atomic-component/src/mixins/EventObserver.js';
 
-let eventObserver = new EventObserver();
+const eventObserver = new EventObserver();
+
+/**
+ * Mock the default transition for a BaseTransition constructor.
+ */
 function MockChildTransition() {
   this.dispatchEvent = eventObserver.dispatchEvent;
   return this;

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/transition/BaseTransition.spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/transition/BaseTransition.spec.js
@@ -5,6 +5,8 @@ const eventObserver = new EventObserver();
 
 /**
  * Mock the default transition for a BaseTransition constructor.
+ *
+ * @returns {Function} A mock instance.
  */
 function MockChildTransition() {
   this.dispatchEvent = eventObserver.dispatchEvent;


### PR DESCRIPTION
https://github.com/cfpb/design-system/pull/1581/ updated stylelint and ran some autolinting, which turned a gradient to yellow. This reverts the gradient change and autofixes some other issues.

## Changes

- Remove `hyphens`, `tab-size`, and `::selection` browser prefixes from code.less.
- Revert to use `stylelint-config-prettier` for now.
- Reverts gradient syntax change.
- Autofixes other issues.

## Testing

1. PR checks should pass.
