### PR TITLE
cfpb-forms: downcase event and fix event dispatch

### DIFF
--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -159,8 +159,7 @@ function Multiselect(element) {
     _fieldsetDom.classList.add('u-invisible');
     _fieldsetDom.setAttribute('aria-hidden', true);
     _model.resetIndex();
-    // TODO: This should be collapsebegin, not expandend, but we have a dependency on this event in the filters in cf.gov.
-    _instance.dispatchEvent('expandend', { target: _instance });
+    _instance.dispatchEvent('collapsebegin', { target: _instance });
 
     return _instance;
   }
@@ -306,7 +305,7 @@ function Multiselect(element) {
         _optionsDom.classList.add('u-max-selections');
       }
 
-      _instance.dispatchEvent('selectionsUpdated', { target: _instance });
+      _instance.dispatchEvent('selectionsupdated', { target: _instance });
     }
 
     _model.resetIndex();


### PR DESCRIPTION
## Changes

- Downcase `selectionsupdated` event to match native event formatting.
- Fix event dispatch to be `collaspebegin` instead of `expandend`

## Testing

1. PR checks should pass.
