### PR TITLE
cfpb-atomic-component: Don't set u-is-animating if transitionComplete handler is called right away

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/transition/BaseTransition.js
+++ b/packages/cfpb-atomic-component/src/utilities/transition/BaseTransition.js
@@ -53,6 +53,9 @@ function BaseTransition(element, classes, child) {
         target: _child,
         type: BaseTransition.BEGIN_EVENT,
       });
+
+      _dom.classList.add(BaseTransition.ANIMATING_CLASS);
+      _isAnimating = true;
     } else {
       _child.dispatchEvent(BaseTransition.BEGIN_EVENT, {
         target: _child,
@@ -60,9 +63,6 @@ function BaseTransition(element, classes, child) {
       });
       _transitionCompleteBinded();
     }
-
-    _dom.classList.add(BaseTransition.ANIMATING_CLASS);
-    _isAnimating = true;
   }
 
   /**


### PR DESCRIPTION
`u-is-animating` class was set on the transition element, regardless of whether it was animating or if the completion handler was called right away, which led to cases where `u-is-animating` was stuck on the element after it was done transitioning. This PR sets it so it only is set when the element is actually animating.

## Changes

- Don't set u-is-animating if transitionComplete handler is called right away

## Testing

1. PR checks should pass.
