### PR TITLE
Refactor email signup to simplify margins and handle different layouts

### DIFF
--- a/docs/pages/e-mail-signup-forms.md
+++ b/docs/pages/e-mail-signup-forms.md
@@ -29,7 +29,7 @@ variation_groups:
                       </label>
                       <input class="a-text-input a-text-input__full" id="email_2" name="email" type="email" placeholder="mail@example.com" required="">
                   </div>
-                  <div class="m-btn-group">
+                  <div class="o-email-signup_buttons">
                       <button class="a-btn">Sign up</button>
                       <a class="a-btn a-btn__link a-btn__secondary" href="#" target="_blank" rel="noopener noreferrer">
                       See Privacy Act statement
@@ -37,7 +37,8 @@ variation_groups:
                   </div>
               </form>
           </div>
-        variation_description: When implemented into a side bar, the h2 includes CFPB
+        variation_description:
+          When implemented into a side bar, the h2 includes CFPB
           standard top green border.
         variation_name: Sidebar email sign up
         variation_specs: |-
@@ -71,7 +72,7 @@ variation_groups:
                           </label>
                           <input class="a-text-input a-text-input__full" id="email_2" name="email" type="email" placeholder="mail@example.com" required="">
                       </div>
-                      <div class="m-btn-group">
+                      <div class="o-email-signup_buttons">
                           <button class="a-btn">Sign up</button>
                           <a class="a-btn a-btn__link a-btn__secondary" href="#" target="_blank" rel="noopener noreferrer">
                           See Privacy Act statement
@@ -80,8 +81,8 @@ variation_groups:
                   </form>
               </div>
           </div>
-        variation_implementation: ""
-      - variation_code_snippet: ""
+        variation_implementation: ''
+      - variation_code_snippet: ''
         variation_description: >-
           The inset email signup module is a variation on the main email signup
           that can be used in the body content of
@@ -112,7 +113,7 @@ variation_groups:
         variation_specs: |-
           * Heading: H3
           * Body copy: Avenir paragraph
-        variation_code_snippet_rendered: ""
+        variation_code_snippet_rendered: ''
     variation_group_name: Types
     variation_group_description: >-
       The email sign up form is comprised of a slug heading, custom description
@@ -151,7 +152,7 @@ description: Email sign-ups allow users to stay engaged on a specific topic or
   content type produced by the Bureau. They are used to add individual email
   addresses to a specific mailing list that is relevant to the content on the
   page or the section it is contained within.
-use_cases: ""
+use_cases: ''
 behavior: >-
   The mockups below show simultaneously how this pattern works within either a
   sidebar or a prefooter area.
@@ -194,7 +195,7 @@ behavior: >-
   | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 
   | ![Inset email sign up 900 breakpoint](/design-system/images/uploads/email-sign-up_learn.png) | ![Inset breakpoint 601](/design-system/images/uploads/email-sign-up_learn_601.png) | ![Inset breakpoint 320](/design-system/images/uploads/email-sign-up_learn_320.png) |
-accessibility: ""
+accessibility: ''
 last_updated: 2020-01-28T15:55:47.394Z
-research: ""
+research: ''
 ---

--- a/packages/cfpb-layout/src/organisms/email-signup.less
+++ b/packages/cfpb-layout/src/organisms/email-signup.less
@@ -9,24 +9,12 @@
     max-width: unit((370px / @base-font-size-px), rem);
   }
 
-  .m-btn-group {
+  &_buttons {
     display: flex;
     margin-top: unit((@grid_gutter-width / 2 / @base-font-size-px), em);
-    align-items: flex-start;
+    align-items: center;
     flex-wrap: wrap-reverse;
-  }
-
-  button {
-    margin-right: unit((@grid_gutter-width / 3 / @base-font-size-px), em);
-  }
-
-  // Extra class in selector needed to override default .m-btn-group margin
-  .a-btn.a-btn__secondary {
-    // Magic number below is to align its baseline with the button
-    // label to its left when they are side-by-side.
-    margin-bottom: unit((8px / @base-font-size-px), em);
-    margin-left: 0;
-    order: 1;
+    gap: unit((@grid_gutter-width / 2 / @base-font-size-px), em);
   }
 
   .respond-to-max( @bp-xs-max, {


### PR DESCRIPTION
We can remove much of the margin settings in the email signup organism by using the `gap` property. Also, we gain no use of `m-btn-group`, other than introducing styles we need to override. So, we should create an element specific to the email signup, which I'll call `o-email-signup_buttons`.

## Changes

- Use `gap` property so that margin settings can be removed.
- Change `m-btn-group` to `o-email-signup_buttons`.

## Testing

1. Visit https://deploy-preview-1594--cfpb-design-system.netlify.app/design-system/patterns/e-mail-signup-forms and compare to https://cfpb.github.io/design-system/patterns/e-mail-signup-forms
There is a very slight difference in the gap between the button and link, but it's 1 or 2 pixels.

## Screenshots

Before:
<img width="393" alt="Screen Shot 2023-02-24 at 3 58 59 PM" src="https://user-images.githubusercontent.com/704760/221290787-6bbb2877-84ed-4a07-a4c6-d8f4dd2962b9.png">

After:
<img width="389" alt="Screen Shot 2023-02-24 at 3 59 20 PM" src="https://user-images.githubusercontent.com/704760/221290847-b45c4189-9b0f-41c1-b262-60c91d7d05cb.png">

