### PR TITLE
Remove aria-expanded from content area

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
+++ b/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
@@ -126,7 +126,6 @@ function FlyoutMenu(element) {
       triggerDom.addEventListener('mouseover', _handleTriggerOver.bind(this));
       triggerDom.addEventListener('mouseout', _handleTriggerOut.bind(this));
     });
-    _setAriaAttr('expanded', _contentDom, isExpanded);
 
     resume();
 
@@ -267,8 +266,6 @@ function FlyoutMenu(element) {
       _setAriaAttr('expanded', _triggerDoms[i], false);
     }
 
-    _setAriaAttr('expanded', _contentDom, false);
-
     _state = COLLAPSING;
     this.dispatchEvent('collapsebegin', {
       target: this,
@@ -316,8 +313,6 @@ function FlyoutMenu(element) {
     for (let i = 0, len = _triggerDoms.length; i < len; i++) {
       _setAriaAttr('expanded', _triggerDoms[i], true);
     }
-
-    _setAriaAttr('expanded', _contentDom, true);
   }
 
   /**

--- a/packages/cfpb-expandables/src/Summary.js
+++ b/packages/cfpb-expandables/src/Summary.js
@@ -47,6 +47,21 @@ function Summary(element) {
     addDataHook(_contentDom, 'behavior_flyout-menu_content');
     addDataHook(_btnDom, 'behavior_flyout-menu_trigger');
 
+    _dom.classList.add(`${BASE_CLASS}__loading`);
+
+    // Don't initialize the Summary till the page has loaded, so we can have
+    // an accurate idea of its height.
+    window.addEventListener('load', _pageLoadHandler);
+
+    return this;
+  }
+
+  /**
+   * The page (content + CSS) has loaded.
+   */
+  function _pageLoadHandler() {
+    window.removeEventListener('load', _pageLoadHandler);
+
     _flyout = new FlyoutMenu(_dom);
     _transition = new MaxHeightTransition(_contentDom);
     _transition.init(
@@ -78,7 +93,7 @@ function Summary(element) {
        just in case. */
     _contentDom.addEventListener('click', _contentClicked);
 
-    return this;
+    _dom.classList.remove(`${BASE_CLASS}__loading`);
   }
 
   /**
@@ -110,10 +125,6 @@ function Summary(element) {
    * suspends or resumes the mobile or desktop behaviors.
    */
   function _resizeHandler() {
-    /* Bail out of initializatiion if the height of the summary's content
-       is less then our summary height of 5.5ems (16 * 5.5 = 88)
-       See https://github.com/cfpb/design-system/blob/72623270013f2ad08dbe92b5b709ed2b434ee41e/packages/cfpb-atomic-component/src/utilities/transition/transition.less#L84
-    */
     if (_shouldSuspend()) {
       _suspend();
     } else {
@@ -125,9 +136,14 @@ function Summary(element) {
    * @returns {boolean} True if this should be suspended, false otherwise.
    */
   function _shouldSuspend() {
+    /* Bail out of initializatiion if the height of the summary's content
+       is less than our summary height of 5.5ems + 4px padding
+       16 * 5.5 = 88 + 4 = 92
+       See https://github.com/cfpb/design-system/blob/72623270013f2ad08dbe92b5b709ed2b434ee41e/packages/cfpb-atomic-component/src/utilities/transition/transition.less#L84
+    */
     return (
       (_hasMobileModifier && !viewportIsIn(MOBILE)) ||
-      _contentDom.scrollHeight <= 88
+      _contentDom.scrollHeight <= 92
     );
   }
 

--- a/packages/cfpb-expandables/src/summary.less
+++ b/packages/cfpb-expandables/src/summary.less
@@ -36,6 +36,13 @@
 */
 
 .o-summary {
+  &__loading {
+    // Base summary height of 5.5ems + 4px padding
+    // 16 * 5.5 = 88 + 4 = 92.
+    height: 92px;
+    overflow: hidden;
+  }
+
   &_content {
     overflow-y: hidden;
 
@@ -48,6 +55,11 @@
   }
 
   &_btn {
+    // Hide button in no-js state.
+    .no-js & {
+      display: none;
+    }
+
     position: relative;
     z-index: 2;
     display: block;
@@ -65,7 +77,7 @@
       outline-offset: 2px;
     }
 
-    &[aria-expanded='false']::after {
+    &[aria-expanded='false']::before {
       // Fades content out over approximately 2 lines.
       display: block;
       pointer-events: none;

--- a/packages/cfpb-expandables/src/summary.less
+++ b/packages/cfpb-expandables/src/summary.less
@@ -45,27 +45,6 @@
     top: -2px;
 
     position: relative;
-
-    &[aria-expanded='false']::after {
-      // Fades content out over approximately 2 lines.
-      display: block;
-      height: unit(((@base-line-height-px * 2) / @base-font-size-px), em);
-      margin: 0;
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      background: linear-gradient(
-        to bottom,
-        rgba(255, 255, 255, 0) 0%,
-        rgba(255, 255, 255, 1) 100%
-      );
-      content: '';
-
-      .respond-to-print({
-        background: none;
-      });
-    }
   }
 
   &_btn {
@@ -85,18 +64,35 @@
       outline: 1px dotted @pacific;
       outline-offset: 2px;
     }
+
+    &[aria-expanded='false']::after {
+      // Fades content out over approximately 2 lines.
+      display: block;
+      pointer-events: none;
+      height: unit(((@base-line-height-px * 2) / @base-font-size-px), em);
+      margin: 0;
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: -100%;
+      background: linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0) 0%,
+        rgba(255, 255, 255, 1) 100%
+      );
+      content: '';
+
+      .respond-to-print({
+        background: none;
+      });
+    }
   }
 
   // If we're mobile-only…
   &__mobile {
     @media only screen and (min-width: @bp-sm-min) {
-      .o-summary_content[aria-expanded='false']::after {
-        // Don't fade content if on desktop.
-        display: none;
-      }
-
       .o-summary_btn {
-        // Hide the "read more" button on desktop.
+        // Hide the "read more" button and fading on desktop.
         display: none;
       }
     }

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.spec.js
@@ -7,9 +7,8 @@ import {
 const HTML_SNIPPET = `
 <div data-js-hook="behavior_flyout-menu">
     <button data-js-hook="behavior_flyout-menu_trigger"
-            aria-haspopup="menu"
             aria-expanded="false"></button>
-    <div data-js-hook="behavior_flyout-menu_content" aria-expanded="false">
+    <div data-js-hook="behavior_flyout-menu_content">
       <button data-js-hook="behavior_flyout-menu_trigger"
               aria-expanded="false"></button>
     </div>
@@ -54,7 +53,6 @@ describe('FlyoutMenu', () => {
 
     it('should have correct state before initializing', () => {
       expect(triggerDom.getAttribute('aria-expanded')).toBe('false');
-      expect(contentDom.getAttribute('aria-expanded')).toBe('false');
       expect(altTriggerDom.getAttribute('aria-expanded')).toBe('false');
 
       expect(flyoutMenu.isAnimating()).toBe(false);
@@ -66,13 +64,11 @@ describe('FlyoutMenu', () => {
     it('should have correct state after initializing as collapsed', () => {
       expect(flyoutMenu.init()).toBeInstanceOf(FlyoutMenu);
       expect(triggerDom.getAttribute('aria-expanded')).toBe('false');
-      expect(contentDom.getAttribute('aria-expanded')).toBe('false');
     });
 
     it('should have correct state after initializing as expanded', () => {
       expect(flyoutMenu.init(true)).toBeInstanceOf(FlyoutMenu);
       expect(triggerDom.getAttribute('aria-expanded')).toBe('true');
-      expect(contentDom.getAttribute('aria-expanded')).toBe('true');
     });
   });
 
@@ -148,7 +144,6 @@ describe('FlyoutMenu', () => {
 
       // Check expected aria attributes state.
       expect(triggerDom.getAttribute('aria-expanded')).toBe('true');
-      expect(contentDom.getAttribute('aria-expanded')).toBe('true');
       expect(altTriggerDom.getAttribute('aria-expanded')).toBe('true');
     });
 
@@ -205,7 +200,6 @@ describe('FlyoutMenu', () => {
 
       // Check expected aria attribute states.
       expect(triggerDom.getAttribute('aria-expanded')).toBe('false');
-      expect(contentDom.getAttribute('aria-expanded')).toBe('false');
       expect(altTriggerDom.getAttribute('aria-expanded')).toBe('false');
     });
 

--- a/test/unit-test/src/cfpb-expandables/src/Summary-spec.js
+++ b/test/unit-test/src/cfpb-expandables/src/Summary-spec.js
@@ -78,7 +78,6 @@ describe('Summary', () => {
         .mockImplementation(() => 50);
       summary.init();
       windowResizeTo(300);
-      expect(contentDom.getAttribute('aria-expanded')).toBe(null);
       expect(targetDom.classList.contains('u-hidden')).toBe(true);
     });
 
@@ -88,7 +87,6 @@ describe('Summary', () => {
         .mockImplementation(() => 200);
       summary.init();
       windowResizeTo(300);
-      expect(contentDom.getAttribute('aria-expanded')).toBe('false');
       expect(targetDom.getAttribute('aria-expanded')).toBe('false');
       simulateEvent('click', targetDom);
 
@@ -102,7 +100,6 @@ describe('Summary', () => {
       contentDom.dispatchEvent(event);
 
       expect(contentDom.style.maxHeight).not.toBe('0');
-      expect(contentDom.getAttribute('aria-expanded')).toBe('true');
       expect(targetDom.getAttribute('aria-expanded')).toBe('true');
 
       expect(targetDom.classList.contains('u-hidden')).toBe(true);


### PR DESCRIPTION
Lighthouse is reporting that the `aria-expanded` attribute on the content element of the flyout menu is not correct. 
The trigger should have an `aria-controls` or `aria-owns` property with the ID of the content area they control. However, this means we'd need to add a unique ID pair to each trigger and content. We could do this in the JS using something like https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID, but let's just strip `aria-expanded` off the content to begin with and see how we fair.

## Changes

- Remove aria-expanded from the content area.
- Refactor Summary component to originate the content fade from the button's `::after`.

## Testing

1. Should be no visual change.