### PR TITLE
Remove "expandables" variations

### DIFF
--- a/docs/pages/expandables.md
+++ b/docs/pages/expandables.md
@@ -144,15 +144,17 @@ variation_groups:
                   </p>
               </div>
           </div>
-        variation_description: Sometimes you may want the expandable to be open by
+        variation_description:
+          Sometimes you may want the expandable to be open by
           default. This is as easy as adding the
           `.o-expandable_content__onload-open` modifier to the
           `.o-expandable_content` block.
-        variation_implementation: A new array of Expandable instances can be created
+        variation_implementation:
+          A new array of Expandable instances can be created
           using a JavaScript API. For information, [open the "Implementation"
           tab under Standard
           expandable](https://cfpb.github.io/design-system/components/expandables#standard-expandables).
-    variation_group_description: ""
+    variation_group_description: ''
   - variations:
       - variation_code_snippet: >-
           <div class="o-expandable-group">
@@ -274,7 +276,8 @@ variation_groups:
           In the default mode, users are able to have multiple sections of an
           expandable group expanded at the same time, which allows users to
           easily compare information that is available in different sections.
-        variation_implementation: A new array of Expandable instances can be created
+        variation_implementation:
+          A new array of Expandable instances can be created
           using a JavaScript API. For information, [open the "Implementation"
           tab under Standard
           expandable](https://cfpb.github.io/design-system/components/expandables#standard-expandables).
@@ -401,30 +404,32 @@ variation_groups:
                   </div>
               </div>
           </div>
-        variation_description: To show only one open expandable at a time, use an
+        variation_description:
+          To show only one open expandable at a time, use an
           accordion group. Add the `o-expandable-group__accordion` class to the
           expandable group to activate the accordion mode.
         variation_name: Accordion-style group
-        variation_implementation: A new array of Expandable instances can be created
+        variation_implementation:
+          A new array of Expandable instances can be created
           using a JavaScript API. For information, [open the "Implementation"
           tab under Standard
           expandable](https://cfpb.github.io/design-system/components/expandables#standard-expandables).
     variation_group_name: Groups
-    variation_group_description: ""
+    variation_group_description: ''
   - variation_group_name: Variations
     variation_group_description: Should you need an expandable thing that is not
       covered by the expandables above, see the [Transition
       Patterns](https://cfpb.github.io/design-system/patterns/transition-patterns)
       for making a component with expandable-like behavior.
     variations: []
-guidelines: ""
+guidelines: ''
 eyebrow: Behavior
 title: Expandables
 description: Expandables are components that have additional content that can be
   opened (expanded) and closed (collapsed). They can appear on their own or in
   groups. They may be helpful for FAQ sections, schedules, and for conserving
   vertical space by collapsing secondary information on mobile devices.
-use_cases: ""
+use_cases: ''
 behavior: >
   ### Collapsed
 

--- a/docs/pages/expandables.md
+++ b/docs/pages/expandables.md
@@ -144,17 +144,15 @@ variation_groups:
                   </p>
               </div>
           </div>
-        variation_description:
-          Sometimes you may want the expandable to be open by
+        variation_description: Sometimes you may want the expandable to be open by
           default. This is as easy as adding the
           `.o-expandable_content__onload-open` modifier to the
           `.o-expandable_content` block.
-        variation_implementation:
-          A new array of Expandable instances can be created
+        variation_implementation: A new array of Expandable instances can be created
           using a JavaScript API. For information, [open the "Implementation"
           tab under Standard
           expandable](https://cfpb.github.io/design-system/components/expandables#standard-expandables).
-    variation_group_description: ''
+    variation_group_description: ""
   - variations:
       - variation_code_snippet: >-
           <div class="o-expandable-group">
@@ -276,8 +274,7 @@ variation_groups:
           In the default mode, users are able to have multiple sections of an
           expandable group expanded at the same time, which allows users to
           easily compare information that is available in different sections.
-        variation_implementation:
-          A new array of Expandable instances can be created
+        variation_implementation: A new array of Expandable instances can be created
           using a JavaScript API. For information, [open the "Implementation"
           tab under Standard
           expandable](https://cfpb.github.io/design-system/components/expandables#standard-expandables).
@@ -404,165 +401,30 @@ variation_groups:
                   </div>
               </div>
           </div>
-        variation_description:
-          To show only one open expandable at a time, use an
+        variation_description: To show only one open expandable at a time, use an
           accordion group. Add the `o-expandable-group__accordion` class to the
           expandable group to activate the accordion mode.
         variation_name: Accordion-style group
-        variation_implementation:
-          A new array of Expandable instances can be created
+        variation_implementation: A new array of Expandable instances can be created
           using a JavaScript API. For information, [open the "Implementation"
           tab under Standard
           expandable](https://cfpb.github.io/design-system/components/expandables#standard-expandables).
     variation_group_name: Groups
-    variation_group_description: ''
+    variation_group_description: ""
   - variation_group_name: Variations
-    variation_group_description: Expandables can be built by combining the basic
-      barebones structure described below with more specialized expandable
-      elements and modifiers described throughout.
-    variations:
-      - variation_name: Barebones expandable
-        variation_description:
-          This is the barebones structure for expandables that can
-          be used (along with other expanable elements and modifiers) to create
-          custom expandable patterns. In this barebones example there are no
-          visual styles.
-        variation_code_snippet: >-
-          <div class="o-expandable">
-              <button class="o-expandable_target" title="Expand content">
-                  <span class="o-expandable_cue o-expandable_cue-open">
-                      <span class="u-visually-hidden-on-mobile">Barebones expandable example </span>
-                  </span>
-                  <span class="o-expandable_cue o-expandable_cue-close">
-                      <span class="u-visually-hidden-on-mobile">Hide</span>
-                  </span>
-              </button>
-              <div class="o-expandable_content">
-                  <p>
-                      Lorem ipsum dolor sit amet, consectetur adipisicing
-                      elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-                      temporibus magnam debitis quidem. Ducimus ratione
-                      corporis nesciunt earum vel est quaerat blanditiis
-                      dolore ipsa?
-                      <a href="#">Lorem link</a>.
-                  </p>
-              </div>
-          </div>
-        variation_implementation:
-          A new array of Expandable instances can be created
-          using a JavaScript API. For information, [open the "Implementation"
-          tab under Standard
-          expandable](https://cfpb.github.io/design-system/components/expandables#standard-expandables).
-      - variation_name: Expanded modifier
-        variation_description: >-
-          Sometimes you may want the expandable to be open by default. This is
-          as easy as adding the `.o-expandable_content__onload-open` modifier to
-          the `.o-expandable_content block.`
-
-
-          ```
-
-          .o-expandable_content__onload-open
-
-          ```
-        variation_code_snippet: ''
-        variation_implementation:
-          A new array of Expandable instances can be created
-          using a JavaScript API. For information, [open the "Implementation"
-          tab under Standard
-          expandable](https://cfpb.github.io/design-system/components/expandables#standard-expandables).
-      - variation_name: Padded modifier
-        variation_description: >-
-          Adds padding and a background color to `.o-expandable_header` and
-          `.o-expandable_content`. In addition to using the
-          `.o-expandable__padded` modifier you also need to make sure you are
-          using `.o-expandable_header`.
-
-
-          ```
-
-          .o-expandable__padded
-
-          ```
-        variation_code_snippet: ''
-        variation_implementation:
-          A new array of Expandable instances can be created
-          using a JavaScript API. For information, [open the "Implementation"
-          tab under Standard
-          expandable](https://cfpb.github.io/design-system/components/expandables#standard-expandables).
-      - variation_name: Text elements
-        variation_description: |
-          #### Label
-
-          Allows you to add some styled text.
-
-          ```
-          <span class="o-expandable_label">
-              Lorem ipsum
-          </span>
-          ```
-
-          #### Link
-
-          Allows you to add some styled text to look like a link.
-          Note: only use this in the expandable header
-
-          ```
-          <span class="o-expandable_link">
-              Lorem ipsum
-          </span>
-          ```
-        variation_code_snippet: ''
-        variation_implementation:
-          A new array of Expandable instances can be created
-          using a JavaScript API. For information, [open the "Implementation"
-          tab under Standard
-          expandable](https://cfpb.github.io/design-system/components/expandables#standard-expandables).
-      - variation_name: Header elements
-        variation_description: >
-
-          These additional elements are useful for more complicated expandables that need to convey more information than just ‘Show/Hide’ before the user expands it.
-
-
-          #### Header
-
-
-          Creates a full-width container to house information that is always visible. Combine `.o-expandable_header` with `.o-expandable_target` for a full-width trigger.
-
-
-          ```
-
-          .o-expandable_header
-
-          ```
-
-
-          #### Header left/right
-
-
-          Allows you to float information left and right.
-
-
-          ```
-
-          .o-expandable_header-left
-
-          .o-expandable_header-right
-
-          ```
-        variation_implementation:
-          A new array of Expandable instances can be created
-          using a JavaScript API. For information, [open the "Implementation"
-          tab under Standard
-          expandable](https://cfpb.github.io/design-system/components/expandables#standard-expandables).
-guidelines: ''
+    variation_group_description: Should you need an expandable thing that is not
+      covered by the expandables above, see the [Transition
+      Patterns](https://cfpb.github.io/design-system/patterns/transition-patterns)
+      for making a component with expandable-like behavior.
+    variations: []
+guidelines: ""
 eyebrow: Behavior
 title: Expandables
 description: Expandables are components that have additional content that can be
   opened (expanded) and closed (collapsed). They can appear on their own or in
   groups. They may be helpful for FAQ sections, schedules, and for conserving
   vertical space by collapsing secondary information on mobile devices.
-use_cases: ''
+use_cases: ""
 behavior: >
   ### Collapsed
 

--- a/test/unit-test/src/cfpb-expandables/src/Expandable.spec.js
+++ b/test/unit-test/src/cfpb-expandables/src/Expandable.spec.js
@@ -8,7 +8,7 @@ const HTML_SNIPPET = `
     <div class="o-expandable o-expandable__padded" id="test-subject-one">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
-            <span class="o-expandable_header-left o-expandable_label">
+            <span class="o-expandable_label">
                 Expandable Header 1
             </span>
             <span class="o-expandable_link">
@@ -34,7 +34,7 @@ const HTML_SNIPPET = `
     <div class="o-expandable o-expandable__padded" id="test-subject-two">
         <button class="o-expandable_header o-expandable_target"
                 title="Expand content">
-            <span class="o-expandable_header-left o-expandable_label">
+            <span class="o-expandable_label">
                 Expandable Header 2
             </span>
             <span class="o-expandable_link">


### PR DESCRIPTION
Removes whole "variations" section of the expandable. We should not follow this pattern of making arbitrary modifications to expandables. The "expanded" modifier is already covered in the page's second example. The "padded" modifier is covered in the first and subsequent examples on the page (this should probably be merged into the default expandable styles). Text and header elements are covered in the standard examples. `o-expandable_header-left` and `o-expandable_header-right` appear to be unused in the codebase and should be removed.