### PR TITLE
Add attributes to flyout content to specify if it's open and/or hidden

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
+++ b/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
@@ -30,9 +30,11 @@ const SEL_PREFIX = '[' + JS_HOOK + '=' + BASE_CLASS;
  * area, which may obscure the first trigger.
  * The flyout can be triggered through a click of either trigger.
  * @param {HTMLElement} element - The DOM element to attach FlyoutMenu behavior.
+ * @param {boolean} autoHideContent - Whether to add `hidden` attribute to
+ *   content when it is collapsed.
  * @returns {FlyoutMenu} An instance.
  */
-function FlyoutMenu(element) {
+function FlyoutMenu(element, autoHideContent = true) {
   // Verify that the expected dom attributes are present.
   const _dom = checkBehaviorDom(element, BASE_CLASS);
   const _triggerDoms = _findTriggers(element);
@@ -126,6 +128,9 @@ function FlyoutMenu(element) {
       triggerDom.addEventListener('mouseover', _handleTriggerOver.bind(this));
       triggerDom.addEventListener('mouseout', _handleTriggerOut.bind(this));
     });
+
+    _contentDom.setAttribute('data-open', isExpanded ? 'true' : 'false');
+    if (autoHideContent) _contentDom.setAttribute('hidden', '');
 
     resume();
 
@@ -228,6 +233,7 @@ function FlyoutMenu(element) {
     if (_state === EXPANDING || _state === EXPANDED) return this;
 
     _state = EXPANDING;
+    if (autoHideContent) _contentDom.removeAttribute('hidden');
     this.dispatchEvent('expandbegin', { target: this, type: 'expandbegin' });
 
     // Only use transitions if both expand and collapse are set.
@@ -302,6 +308,7 @@ function FlyoutMenu(element) {
    */
   function _expandEnd() {
     _state = EXPANDED;
+    _contentDom.setAttribute('data-open', 'true');
     if (_transition) {
       _transition.removeEventListener(
         BaseTransition.END_EVENT,
@@ -320,6 +327,9 @@ function FlyoutMenu(element) {
    */
   function _collapseEnd() {
     _state = COLLAPSED;
+    _contentDom.setAttribute('data-open', 'false');
+    if (autoHideContent) _contentDom.setAttribute('hidden', '');
+
     if (_transition) {
       _transition.removeEventListener(
         BaseTransition.END_EVENT,

--- a/packages/cfpb-atomic-component/src/utilities/behavior/behavior.js
+++ b/packages/cfpb-atomic-component/src/utilities/behavior/behavior.js
@@ -16,8 +16,9 @@
    to activate the menu, and (C) the content to show/hide when the trigger
    is clicked. So the markup looks something like:
    <div data-js-hook="behavior_flyout-menu">
-   <button data-js-hook="behavior_flyout-menu_trigger">
-   <div data-js-hook="behavior_flyout-menu_content">
+     <button data-js-hook="behavior_flyout-menu_trigger">
+     <div data-js-hook="behavior_flyout-menu_content">…</div>
+   </div>
    ========================================================================== */
 
 import {

--- a/packages/cfpb-expandables/src/Summary.js
+++ b/packages/cfpb-expandables/src/Summary.js
@@ -60,7 +60,7 @@ function Summary(element) {
   function _pageLoadHandler() {
     window.removeEventListener('load', _pageLoadHandler);
 
-    _flyout = new FlyoutMenu(_dom);
+    _flyout = new FlyoutMenu(_dom, false);
     _transition = new MaxHeightTransition(_contentDom);
     _transition.init(
       _suspended


### PR DESCRIPTION
https://github.com/cfpb/design-system/pull/1595/ removed the aria-expanded attribute on the flyout content. However, for styling purposes it would be helpful to have some kind of change when the content is expanded or collapsed. We can do this through adding and removing the native `hidden` attribute, however, this shouldn't be added to summaries, which show a truncated view of their content, so are never entirely hidden. Therefore, this PR also adds a `data-open` attribute, which was chosen to follow the `open` attribute that the native `dialog` element uses https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog, as well as the menu example on https://css-tricks.com/the-hidden-attribute-is-visibly-weak/

## Changes

- Add attributes to flyout content to specify if it's open and/or hidden.

## Testing

1. Visiting the transition patterns page, it shouldn't be possible to tab into the closed flyout menu example. 
2. Visiting the summary page, it should be possible to tab into the hidden summary content, which will then expand.