### PR TITLE
FlyoutMenu: Add missing hidden condition

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
+++ b/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
@@ -130,7 +130,7 @@ function FlyoutMenu(element, autoHideContent = true) {
     });
 
     _contentDom.setAttribute('data-open', isExpanded ? 'true' : 'false');
-    if (autoHideContent) _contentDom.setAttribute('hidden', '');
+    if (autoHideContent && !isExpanded) _contentDom.setAttribute('hidden', '');
 
     resume();
 


### PR DESCRIPTION
FlyoutMenu should not add `hidden` attribute when it is initially open.

## Changes

- Bugfix for not adding `hidden` attribute when flyout menu is initially open.

## Testing

1. PR checks should pas..
