### PR TITLE
Bugfix: fix order at which data-open closes

### DIFF
--- a/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
+++ b/packages/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.js
@@ -272,6 +272,8 @@ function FlyoutMenu(element, autoHideContent = true) {
       _setAriaAttr('expanded', _triggerDoms[i], false);
     }
 
+    _contentDom.setAttribute('data-open', 'false');
+
     _state = COLLAPSING;
     this.dispatchEvent('collapsebegin', {
       target: this,
@@ -327,7 +329,7 @@ function FlyoutMenu(element, autoHideContent = true) {
    */
   function _collapseEnd() {
     _state = COLLAPSED;
-    _contentDom.setAttribute('data-open', 'false');
+
     if (autoHideContent) _contentDom.setAttribute('hidden', '');
 
     if (_transition) {


### PR DESCRIPTION
`data-open` was being set `false` after collapsing had completed, but it should happen at the beginning.

## Changes

- Bugfix: fix order at which data-open closes

## Testing

1. PR checks should pass.
