### PR TITLE
Bugfix: Add text alignment to email signup buttons

### DIFF
--- a/packages/cfpb-layout/src/organisms/email-signup.less
+++ b/packages/cfpb-layout/src/organisms/email-signup.less
@@ -17,6 +17,10 @@
     gap: unit((@grid_gutter-width / 2 / @base-font-size-px), em);
   }
 
+  .a-btn {
+    text-align: inherit;
+  }
+
   .respond-to-max( @bp-xs-max, {
     .a-label__heading {
       font-size: 1em;


### PR DESCRIPTION
Email signup buttons were getting centered by default, so this sets the text-alignment to inherit.

## Changes

- Bugfix: Add text alignment to email signup buttons.

## Testing

1. PR checks should pass.
