### PR TITLE
cfpb-typography: Remove text-align: left from `u-block-link`

### DIFF
--- a/packages/cfpb-typography/src/atoms/links.less
+++ b/packages/cfpb-typography/src/atoms/links.less
@@ -100,7 +100,6 @@
   border-bottom-width: 1px;
   // 100% width is needed when block or jump link are applied to a <button>
   width: 100%;
-  text-align: left;
 
   .a-link_text {
     border-bottom-width: 0;


### PR DESCRIPTION
If we explicitly set a `text-align: left` on the jumplinks they won't align to the right by default on right-to-left (RTL) languages. By default in LTR languages it should be aligned left anyway.

## Changes

- cfpb-typography: Remove text-align: left from `u-block-link`.

## Testing

1. PR preview in https://cfpb.github.io/design-system/components/lists should be unchanged.