### PR TITLE
Break `update` and `updating` icons into two canonical icons

### DIFF
--- a/docs/pages/iconography.md
+++ b/docs/pages/iconography.md
@@ -117,7 +117,9 @@ variation_groups:
 
           | {% include icons/help.svg %} | {% include icons/help-round.svg %} | help | question, question-mark |
 
-          | {% include icons/update.svg %} | {% include icons/update-round.svg %} | update | spinner, updating _(used for animated state)_ |
+          | {% include icons/update.svg %} | {% include icons/update-round.svg %} | update | spinner |
+
+          | {% include icons/updating.svg %} | {% include icons/updating-round.svg %} | updating |
 
           | {% include icons/power.svg %} | {% include icons/power-round.svg %} | power | on-off |
 


### PR DESCRIPTION
## Changes

- Break `update` and `updating` icons into two canonical icons

## Testing

1. Breaks the `update` icon into two rows: the `update` and `updating` icons.

## Screenshots

<img width="398" alt="Screen Shot 2023-03-17 at 12 18 20 PM" src="https://user-images.githubusercontent.com/704760/225960963-455857e1-ccf2-4895-b72e-735f2fcf05e9.png">
