### PR TITLE
Netlify: Trim inputs on blur instead of change

### DIFF
--- a/docs/admin/src/widgets/StringTrimmed.js
+++ b/docs/admin/src/widgets/StringTrimmed.js
@@ -9,19 +9,18 @@ export const StringTrimmedControl = ({
   setActiveStyle,
   setInactiveStyle,
 }) => {
-  const handleChange = (event) => {
-    onChange(event.target.value.trim());
-  };
-
   return (
     <input
       type="text"
       id={forID}
       className={classNameWrapper}
       value={value}
-      onChange={handleChange}
+      onChange={(e) => onChange(e.target.value)}
       onFocus={setActiveStyle}
-      onBlur={setInactiveStyle}
+      onBlur={(e) => {
+        e.target.value.trim();
+        setInactiveStyle();
+      }}
     />
   );
 };


### PR DESCRIPTION
The `StringTrimmed` widget added in https://github.com/cfpb/design-system/pull/543 trimmed onChange, but at some point this led to disallowing spaces to be entered into input fields. This PR adjusts that plugin to work on blur.

## Changes

- Changes `StringTrimmed` to trim trailing whitespace on blur.

## Testing

1. Edit any page and enter multiple words in the page title and end with a trailing space or a few. Click out of the field and back into it and see that the trailing spaces are gone. Compare to a production page that won't let you enter multiple words separated by spaces.
