### PR TITLE
Strikethrough aliases in iconography table

### DIFF
--- a/docs/assets/css/main-content.less
+++ b/docs/assets/css/main-content.less
@@ -31,8 +31,10 @@
     width: 26%;
   }
 
+  // Aliases table.
   td:nth-child(4) {
     width: 46%;
+    text-decoration: @red solid line-through;
   }
 }
 

--- a/docs/pages/iconography.md
+++ b/docs/pages/iconography.md
@@ -4,7 +4,7 @@ section: foundation
 variation_groups:
   - variation_group_name: Icon library
     variations:
-      - variation_code_snippet: ""
+      - variation_code_snippet: ''
         variation_description: >-
           Use the canonical icon name when referencing the icons in code,
           however, "aliases" are provided in the table below to help you search
@@ -30,7 +30,7 @@ variation_groups:
           ### Navigation icons
 
 
-          | icon | icon-round | canonical name | aliases |
+          | icon | icon-round | canonical name | aliases (for searchability only)  |
 
           | ---- | ---------- | -------------- | ------- |
 
@@ -60,7 +60,7 @@ variation_groups:
           ### Status icons
 
 
-          | icon | icon-round | canonical name | aliases |
+          | icon | icon-round | canonical name | aliases (for searchability only)  |
 
           | ---- | ---------- | -------------- | ------- |
 
@@ -96,7 +96,7 @@ variation_groups:
           ### Social/sharing icons
 
 
-          | icon | icon-square | canonical name | aliases |
+          | icon | icon-square | canonical name | aliases (for searchability only) |
 
           | ---- | ----------- | -------------- | ------- |
 
@@ -122,7 +122,7 @@ variation_groups:
           ### Communications icons
 
 
-          | icon | icon-round | canonical name | aliases |
+          | icon | icon-round | canonical name | aliases (for searchability only)  |
 
           | ---- | ---------- | -------------- | ------- |
 
@@ -150,7 +150,7 @@ variation_groups:
           ### Document icons
 
 
-          | icon | icon-round | canonical name | aliases |
+          | icon | icon-round | canonical name | aliases (for searchability only)  |
 
           | ---- | ---------- | -------------- | ------- |
 
@@ -194,7 +194,7 @@ variation_groups:
           ### Financial products, services, and concepts
 
 
-          | icon | icon-round | canonical name | aliases |
+          | icon | icon-round | canonical name | aliases (for searchability only)  |
 
           | ---- | ---------- | -------------- | ------- |
 
@@ -268,7 +268,7 @@ variation_groups:
           ### Expense icons
 
 
-          | icon | icon-round | canonical name | aliases |
+          | icon | icon-round | canonical name | aliases (for searchability only)  |
 
           | ---- | ---------- | -------------- | ------- |
 
@@ -326,7 +326,7 @@ variation_groups:
           ### Web application icons
 
 
-          | icon | icon-round | canonical name | aliases |
+          | icon | icon-round | canonical name | aliases (for searchability only)  |
 
           | ---- | ---------- | -------------- | ------- |
 
@@ -425,20 +425,23 @@ variation_groups:
           | {% include icons/wifi.svg %} | {% include icons/wifi-round.svg %} | wifi | wi-fi, wireless, signal |
 
           {: class="icon-table"}
-        variation_name: ""
-        variation_implementation: Each icon has a circled variant shown in the second
+        variation_name: ''
+        variation_implementation:
+          Each icon has a circled variant shown in the second
           column (or square, in the case of the social media icons) that can be
           accessed by appending `-round` (or `-square`) to the canonical name.
   - variation_group_name: Animated icon
-    variation_group_description: ""
+    variation_group_description: ''
     variations:
       - variation_code_snippet: >
-          
+
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 19" class="cf-icon-svg cf-icon-svg__updating"><path d="M5.857 3.882v3.341a1.03 1.03 0 0 1-2.058 0v-.97a5.401 5.401 0 0 0-1.032 2.27 1.03 1.03 0 1 1-2.02-.395A7.462 7.462 0 0 1 2.235 4.91h-.748a1.03 1.03 0 1 1 0-2.058h3.34a1.03 1.03 0 0 1 1.03 1.03zm-3.25 9.237a1.028 1.028 0 0 1-1.358-.523 7.497 7.497 0 0 1-.37-1.036 1.03 1.03 0 1 1 1.983-.55 5.474 5.474 0 0 0 .269.751 1.029 1.029 0 0 1-.524 1.358zm2.905 2.439a1.028 1.028 0 0 1-1.42.322 7.522 7.522 0 0 1-.885-.652 1.03 1.03 0 0 1 1.34-1.563 5.435 5.435 0 0 0 .643.473 1.03 1.03 0 0 1 .322 1.42zm3.68.438a1.03 1.03 0 0 1-1.014 1.044h-.106a7.488 7.488 0 0 1-.811-.044 1.03 1.03 0 0 1 .224-2.046 5.41 5.41 0 0 0 .664.031h.014a1.03 1.03 0 0 1 1.03 1.015zm.034-12.847a1.03 1.03 0 0 1-1.029 1.01h-.033a1.03 1.03 0 0 1 .017-2.06h.017l.019.001A1.03 1.03 0 0 1 9.226 3.15zm3.236 11.25a1.029 1.029 0 0 1-.3 1.425 7.477 7.477 0 0 1-.797.453 1.03 1.03 0 1 1-.905-1.849 5.479 5.479 0 0 0 .578-.328 1.03 1.03 0 0 1 1.424.3zM10.475 3.504a1.029 1.029 0 0 1 1.41-.359l.018.011a1.03 1.03 0 1 1-1.06 1.764l-.01-.006a1.029 1.029 0 0 1-.358-1.41zm4.26 9.445c-.096.19-.203.379-.315.56a1.03 1.03 0 1 1-1.749-1.086c.082-.13.158-.267.228-.405a1.03 1.03 0 1 1 1.836.93zm-1.959-6.052a1.03 1.03 0 0 1 1.79-1.016l.008.013a1.03 1.03 0 1 1-1.79 1.017zm2.764 2.487a9.327 9.327 0 0 1 0 .366 1.03 1.03 0 0 1-1.029 1.005h-.025A1.03 1.03 0 0 1 13.482 9.7a4.625 4.625 0 0 0 0-.266 1.03 1.03 0 0 1 1.003-1.055h.026a1.03 1.03 0 0 1 1.029 1.004z"/></svg>
-        variation_description: In certain instances, icons can be animated to aid
+        variation_description:
+          In certain instances, icons can be animated to aid
           communication or to reassure the user that an action is functioning as
           intended. Examples include saving or loading content.
-        variation_implementation: Our previous font icon system provided modifiers to
+        variation_implementation:
+          Our previous font icon system provided modifiers to
           rotate any icon. We found in reality this wasn’t practical and only
           one icon is ever animated, `update`. We’ve provided `updating` to be
           used within the UI when a user needs to be made aware that the website
@@ -577,7 +580,7 @@ description: >-
 
 
   </div>
-use_cases: ""
+use_cases: ''
 behavior: >-
   ### SVG icon basics
 
@@ -637,5 +640,5 @@ behavior: >-
 
 
   In some cases we embed an SVG as a background image. To accomplish this, a custom Less plugin is used to inject the SVG icon source file inline into the CSS `background-image` property. This is exposed via a mixin, `.u-svg-inline-bg( @name, @color: @black )`, where `@name` is the SVG icon canonical name and `@color` is the SVG fill color (which defaults to black).
-related_items: ""
+related_items: ''
 ---

--- a/packages/cfpb-icons/usage.md
+++ b/packages/cfpb-icons/usage.md
@@ -165,24 +165,24 @@ search this page for a particular icon.
 
 ### Navigation icons
 
-| icon                                | icon-round                                | canonical name | aliases       |
-| ----------------------------------- | ----------------------------------------- | -------------- | ------------- |
-| {% include icons/up.svg %}          | {% include icons/up-round.svg %}          | up             | chevron-up    |
-| {% include icons/right.svg %}       | {% include icons/right-round.svg %}       | right          | chevron-right |
-| {% include icons/down.svg %}        | {% include icons/down-round.svg %}        | down           | chevron-down  |
-| {% include icons/left.svg %}        | {% include icons/left-round.svg %}        | left           | chevron-left  |
-| {% include icons/arrow-up.svg %}    | {% include icons/arrow-up-round.svg %}    | arrow-up       |               |
-| {% include icons/arrow-right.svg %} | {% include icons/arrow-right-round.svg %} | arrow-right    |               |
-| {% include icons/arrow-down.svg %}  | {% include icons/arrow-down-round.svg %}  | arrow-down     |               |
-| {% include icons/arrow-left.svg %}  | {% include icons/arrow-left-round.svg %}  | arrow-left     |               |
-| {% include icons/left-right.svg %}  | {% include icons/left-right-round.svg %}  | left-right     | horizontal    |
-| {% include icons/up-down.svg %}     | {% include icons/up-down-round.svg %}     | up-down        | vertical      |
+| icon                                | icon-round                                | canonical name | aliases (for searchability only) |
+| ----------------------------------- | ----------------------------------------- | -------------- | -------------------------------- |
+| {% include icons/up.svg %}          | {% include icons/up-round.svg %}          | up             | chevron-up                       |
+| {% include icons/right.svg %}       | {% include icons/right-round.svg %}       | right          | chevron-right                    |
+| {% include icons/down.svg %}        | {% include icons/down-round.svg %}        | down           | chevron-down                     |
+| {% include icons/left.svg %}        | {% include icons/left-round.svg %}        | left           | chevron-left                     |
+| {% include icons/arrow-up.svg %}    | {% include icons/arrow-up-round.svg %}    | arrow-up       |                                  |
+| {% include icons/arrow-right.svg %} | {% include icons/arrow-right-round.svg %} | arrow-right    |                                  |
+| {% include icons/arrow-down.svg %}  | {% include icons/arrow-down-round.svg %}  | arrow-down     |                                  |
+| {% include icons/arrow-left.svg %}  | {% include icons/arrow-left-round.svg %}  | arrow-left     |                                  |
+| {% include icons/left-right.svg %}  | {% include icons/left-right-round.svg %}  | left-right     | horizontal                       |
+| {% include icons/up-down.svg %}     | {% include icons/up-down-round.svg %}     | up-down        | vertical                         |
 
 {: class="icon-table"}
 
 ### Status icons
 
-| icon                               | icon-round                               | canonical name | aliases                                            |
+| icon                               | icon-round                               | canonical name | aliases (for searchability only)                   |
 | ---------------------------------- | ---------------------------------------- | -------------- | -------------------------------------------------- |
 | {% include icons/approved.svg %}   | {% include icons/approved-round.svg %}   | approved       | check, checkmark, success                          |
 | {% include icons/error.svg %}      | {% include icons/error-round.svg %}      | error          | delete, close, remove, multiply, multiplication, x |
@@ -202,62 +202,62 @@ search this page for a particular icon.
 
 ### Social/sharing icons
 
-| icon                              | icon-square                              | canonical name | aliases                 |
-| --------------------------------- | ---------------------------------------- | -------------- | ----------------------- |
-| {% include icons/email.svg %}     | {% include icons/email-square.svg %}     | email          | envelope, envelope-back |
-| {% include icons/facebook.svg %}  | {% include icons/facebook-square.svg %}  | facebook       |                         |
-| {% include icons/flickr.svg %}    | {% include icons/flickr-square.svg %}    | flickr         |                         |
-| {% include icons/github.svg %}    | {% include icons/github-square.svg %}    | github         |                         |
-| {% include icons/linkedin.svg %}  | {% include icons/linkedin-square.svg %}  | linkedin       |                         |
-| {% include icons/pinterest.svg %} | {% include icons/pinterest-square.svg %} | pinterest      |                         |
-| {% include icons/twitter.svg %}   | {% include icons/twitter-square.svg %}   | twitter        |                         |
-| {% include icons/youtube.svg %}   | {% include icons/youtube-square.svg %}   | youtube        |                         |
+| icon                              | icon-square                              | canonical name | aliases (for searchability only) |
+| --------------------------------- | ---------------------------------------- | -------------- | -------------------------------- |
+| {% include icons/email.svg %}     | {% include icons/email-square.svg %}     | email          | envelope, envelope-back          |
+| {% include icons/facebook.svg %}  | {% include icons/facebook-square.svg %}  | facebook       |                                  |
+| {% include icons/flickr.svg %}    | {% include icons/flickr-square.svg %}    | flickr         |                                  |
+| {% include icons/github.svg %}    | {% include icons/github-square.svg %}    | github         |                                  |
+| {% include icons/linkedin.svg %}  | {% include icons/linkedin-square.svg %}  | linkedin       |                                  |
+| {% include icons/pinterest.svg %} | {% include icons/pinterest-square.svg %} | pinterest      |                                  |
+| {% include icons/twitter.svg %}   | {% include icons/twitter-square.svg %}   | twitter        |                                  |
+| {% include icons/youtube.svg %}   | {% include icons/youtube-square.svg %}   | youtube        |                                  |
 
 {: class="icon-table"}
 
 ### Communications icons
 
-| icon                                 | icon-round                                 | canonical name | aliases             |
-| ------------------------------------ | ------------------------------------------ | -------------- | ------------------- |
-| {% include icons/email.svg %}        | {% include icons/email-round.svg %}        | email          | envelope-back       |
-| {% include icons/fax.svg %}          | {% include icons/fax-round.svg %}          | fax            | fax-machine         |
-| {% include icons/mail.svg %}         | {% include icons/mail-round.svg %}         | mail           | envelope-front      |
-| {% include icons/phone.svg %}        | {% include icons/phone-round.svg %}        | phone          | telephone, handset  |
-| {% include icons/photo.svg %}        | {% include icons/photo-round.svg %}        | photo          | photography, camera |
-| {% include icons/presentation.svg %} | {% include icons/presentation-round.svg %} | presentation   | screen              |
-| {% include icons/technology.svg %}   | {% include icons/technology-round.svg %}   | technology     | cellphone, tablet   |
-| {% include icons/video.svg %}        | {% include icons/video-round.svg %}        | video          | movie, camcorder    |
-| {% include icons/web.svg %}          | {% include icons/web-round.svg %}          | web            | globe, world        |
+| icon                                 | icon-round                                 | canonical name | aliases (for searchability only) |
+| ------------------------------------ | ------------------------------------------ | -------------- | -------------------------------- |
+| {% include icons/email.svg %}        | {% include icons/email-round.svg %}        | email          | envelope-back                    |
+| {% include icons/fax.svg %}          | {% include icons/fax-round.svg %}          | fax            | fax-machine                      |
+| {% include icons/mail.svg %}         | {% include icons/mail-round.svg %}         | mail           | envelope-front                   |
+| {% include icons/phone.svg %}        | {% include icons/phone-round.svg %}        | phone          | telephone, handset               |
+| {% include icons/photo.svg %}        | {% include icons/photo-round.svg %}        | photo          | photography, camera              |
+| {% include icons/presentation.svg %} | {% include icons/presentation-round.svg %} | presentation   | screen                           |
+| {% include icons/technology.svg %}   | {% include icons/technology-round.svg %}   | technology     | cellphone, tablet                |
+| {% include icons/video.svg %}        | {% include icons/video-round.svg %}        | video          | movie, camcorder                 |
+| {% include icons/web.svg %}          | {% include icons/web-round.svg %}          | web            | globe, world                     |
 
 {: class="icon-table"}
 
 ### Document icons
 
-| icon                                  | icon-round                                  | canonical name | aliases                 |
-| ------------------------------------- | ------------------------------------------- | -------------- | ----------------------- |
-| {% include icons/appendix.svg %}      | {% include icons/appendix-round.svg %}      | appendix       |                         |
-| {% include icons/book.svg %}          | {% include icons/book-round.svg %}          | book           |                         |
-| {% include icons/copy.svg %}          | {% include icons/copy-round.svg %}          | copy           | duplicate               |
-| {% include icons/document.svg %}      | {% include icons/document-round.svg %}      | document       | doc, pdf, page          |
-| {% include icons/download.svg %}      | {% include icons/download-round.svg %}      | download       | document-down           |
-| {% include icons/upload.svg %}        | {% include icons/upload-round.svg %}        | upload         | document-up             |
-| {% include icons/edit.svg %}          | {% include icons/edit-round.svg %}          | edit           | pencil, write           |
-| {% include icons/folder.svg %}        | {% include icons/folder-round.svg %}        | folder         |                         |
-| {% include icons/folder-add.svg %}    | {% include icons/folder-add-round.svg %}    | folder-add     | folder-plus             |
-| {% include icons/folder-delete.svg %} | {% include icons/folder-delete-round.svg %} | folder-delete  | folder-remove, folder-x |
-| {% include icons/folder-empty.svg %}  | {% include icons/folder-empty-round.svg %}  | folder-empty   |                         |
-| {% include icons/folder-save.svg %}   | {% include icons/folder-save-round.svg %}   | folder-save    | folder-check            |
-| {% include icons/paper-clip.svg %}    | {% include icons/paper-clip-round.svg %}    | paper-clip     | attach, attachment      |
-| {% include icons/print.svg %}         | {% include icons/print-round.svg %}         | print          | printer                 |
-| {% include icons/rss.svg %}           | {% include icons/rss-round.svg %}           | rss            | feed                    |
-| {% include icons/save.svg %}          | {% include icons/save-round.svg %}          | save           | disk, floppy-disk       |
-| {% include icons/supplement.svg %}    | {% include icons/supplement-round.svg %}    | supplement     | add-document, add-page  |
+| icon                                  | icon-round                                  | canonical name | aliases (for searchability only) |
+| ------------------------------------- | ------------------------------------------- | -------------- | -------------------------------- |
+| {% include icons/appendix.svg %}      | {% include icons/appendix-round.svg %}      | appendix       |                                  |
+| {% include icons/book.svg %}          | {% include icons/book-round.svg %}          | book           |                                  |
+| {% include icons/copy.svg %}          | {% include icons/copy-round.svg %}          | copy           | duplicate                        |
+| {% include icons/document.svg %}      | {% include icons/document-round.svg %}      | document       | doc, pdf, page                   |
+| {% include icons/download.svg %}      | {% include icons/download-round.svg %}      | download       | document-down                    |
+| {% include icons/upload.svg %}        | {% include icons/upload-round.svg %}        | upload         | document-up                      |
+| {% include icons/edit.svg %}          | {% include icons/edit-round.svg %}          | edit           | pencil, write                    |
+| {% include icons/folder.svg %}        | {% include icons/folder-round.svg %}        | folder         |                                  |
+| {% include icons/folder-add.svg %}    | {% include icons/folder-add-round.svg %}    | folder-add     | folder-plus                      |
+| {% include icons/folder-delete.svg %} | {% include icons/folder-delete-round.svg %} | folder-delete  | folder-remove, folder-x          |
+| {% include icons/folder-empty.svg %}  | {% include icons/folder-empty-round.svg %}  | folder-empty   |                                  |
+| {% include icons/folder-save.svg %}   | {% include icons/folder-save-round.svg %}   | folder-save    | folder-check                     |
+| {% include icons/paper-clip.svg %}    | {% include icons/paper-clip-round.svg %}    | paper-clip     | attach, attachment               |
+| {% include icons/print.svg %}         | {% include icons/print-round.svg %}         | print          | printer                          |
+| {% include icons/rss.svg %}           | {% include icons/rss-round.svg %}           | rss            | feed                             |
+| {% include icons/save.svg %}          | {% include icons/save-round.svg %}          | save           | disk, floppy-disk                |
+| {% include icons/supplement.svg %}    | {% include icons/supplement-round.svg %}    | supplement     | add-document, add-page           |
 
 {: class="icon-table"}
 
 ### Financial products, services, and concepts
 
-| icon                                          | icon-round                                          | canonical name        | aliases                                   |
+| icon                                          | icon-round                                          | canonical name        | aliases (for searchability only)          |
 | --------------------------------------------- | --------------------------------------------------- | --------------------- | ----------------------------------------- |
 | {% include icons/activity.svg %}              | {% include icons/activity-round.svg %}              | activity              | clipboard                                 |
 | {% include icons/bank.svg %}                  | {% include icons/bank-round.svg %}                  | bank                  | bank-account                              |
@@ -296,7 +296,7 @@ search this page for a particular icon.
 
 ### Expense icons
 
-| icon                                  | icon-round                                  | canonical name | aliases                              |
+| icon                                  | icon-round                                  | canonical name | aliases (for searchability only)     |
 | ------------------------------------- | ------------------------------------------- | -------------- | ------------------------------------ |
 | {% include icons/briefcase.svg %}     | {% include icons/briefcase-round.svg %}     | briefcase      |                                      |
 | {% include icons/bus.svg %}           | {% include icons/bus-round.svg %}           | bus            | public-transit                       |
@@ -327,7 +327,7 @@ search this page for a particular icon.
 
 ### Web application icons
 
-| icon                                   | icon-round                                   | canonical name | aliases                          |
+| icon                                   | icon-round                                   | canonical name | aliases (for searchability only) |
 | -------------------------------------- | -------------------------------------------- | -------------- | -------------------------------- |
 | {% include icons/agreement.svg %}      | {% include icons/agreement-round.svg %}      | agreement      | handshake                        |
 | {% include icons/audio-max.svg %}      | {% include icons/audio-max-round.svg %}      | audio-max      | audio-high                       |


### PR DESCRIPTION
We want it to be clearer that the icon aliases are not to be used, but still want them for searchability of the page.

## Changes

- Strikethrough aliases in iconography table

## Testing

1. PR preview of the iconography table should have strikethrough aliases.
