### PR TITLE
Remove expandable labels and `.u-visually-hidden-on-mobile` class

### DIFF
--- a/docs/pages/expandables.md
+++ b/docs/pages/expandables.md
@@ -19,11 +19,11 @@ variation_groups:
                   </h3>
                   <span class="o-expandable_link">
                       <span class="o-expandable_cue o-expandable_cue-open">
-                          <span class="u-visually-hidden-on-mobile">Show</span>
+                          <span class="u-visually-hidden">Show</span>
                           {% include icons/plus-round.svg %}
                       </span>
                       <span class="o-expandable_cue o-expandable_cue-close">
-                          <span class="u-visually-hidden-on-mobile">Hide</span>
+                          <span class="u-visually-hidden">Hide</span>
                           {% include icons/minus-round.svg %}
                       </span>
                   </span>
@@ -124,11 +124,11 @@ variation_groups:
                   </h3>
                   <span class="o-expandable_link">
                       <span class="o-expandable_cue o-expandable_cue-open">
-                          <span class="u-visually-hidden-on-mobile">Show</span>
+                          <span class="u-visually-hidden">Show</span>
                           {% include icons/plus-round.svg %}
                       </span>
                       <span class="o-expandable_cue o-expandable_cue-close">
-                          <span class="u-visually-hidden-on-mobile">Hide</span>
+                          <span class="u-visually-hidden">Hide</span>
                           {% include icons/minus-round.svg %}
                       </span>
                   </span>
@@ -166,11 +166,11 @@ variation_groups:
                       </h3>
                       <span class="o-expandable_link">
                           <span class="o-expandable_cue o-expandable_cue-open">
-                              <span class="u-visually-hidden-on-mobile">Show</span>
+                              <span class="u-visually-hidden">Show</span>
                               {% include icons/plus-round.svg %}
                           </span>
                           <span class="o-expandable_cue o-expandable_cue-close">
-                              <span class="u-visually-hidden-on-mobile">Hide</span>
+                              <span class="u-visually-hidden">Hide</span>
                               {% include icons/minus-round.svg %}
                           </span>
                       </span>
@@ -194,11 +194,11 @@ variation_groups:
                       </h3>
                       <span class="o-expandable_link">
                           <span class="o-expandable_cue o-expandable_cue-open">
-                              <span class="u-visually-hidden-on-mobile">Show</span>
+                              <span class="u-visually-hidden">Show</span>
                               {% include icons/plus-round.svg %}
                           </span>
                           <span class="o-expandable_cue o-expandable_cue-close">
-                              <span class="u-visually-hidden-on-mobile">Hide</span>
+                              <span class="u-visually-hidden">Hide</span>
                               {% include icons/minus-round.svg %}
                           </span>
                       </span>
@@ -222,11 +222,11 @@ variation_groups:
                       </h3>
                       <span class="o-expandable_link">
                           <span class="o-expandable_cue o-expandable_cue-open">
-                              <span class="u-visually-hidden-on-mobile">Show</span>
+                              <span class="u-visually-hidden">Show</span>
                               {% include icons/plus-round.svg %}
                           </span>
                           <span class="o-expandable_cue o-expandable_cue-close">
-                              <span class="u-visually-hidden-on-mobile">Hide</span>
+                              <span class="u-visually-hidden">Hide</span>
                               {% include icons/minus-round.svg %}
                           </span>
                       </span>
@@ -291,11 +291,11 @@ variation_groups:
                       </h3>
                       <span class="o-expandable_link">
                           <span class="o-expandable_cue o-expandable_cue-open">
-                              <span class="u-visually-hidden-on-mobile">Show</span>
+                              <span class="u-visually-hidden">Show</span>
                               {% include icons/plus-round.svg %}
                           </span>
                           <span class="o-expandable_cue o-expandable_cue-close">
-                              <span class="u-visually-hidden-on-mobile">Hide</span>
+                              <span class="u-visually-hidden">Hide</span>
                               {% include icons/minus-round.svg %}
                           </span>
                       </span>
@@ -319,11 +319,11 @@ variation_groups:
                       </h3>
                       <span class="o-expandable_link">
                           <span class="o-expandable_cue o-expandable_cue-open">
-                              <span class="u-visually-hidden-on-mobile">Show</span>
+                              <span class="u-visually-hidden">Show</span>
                               {% include icons/plus-round.svg %}
                           </span>
                           <span class="o-expandable_cue o-expandable_cue-close">
-                              <span class="u-visually-hidden-on-mobile">Hide</span>
+                              <span class="u-visually-hidden">Hide</span>
                               {% include icons/minus-round.svg %}
                           </span>
                       </span>
@@ -383,11 +383,11 @@ variation_groups:
                       </h3>
                       <span class="o-expandable_link">
                           <span class="o-expandable_cue o-expandable_cue-open">
-                              <span class="u-visually-hidden-on-mobile">Show</span>
+                              <span class="u-visually-hidden">Show</span>
                               {% include icons/plus-round.svg %}
                           </span>
                           <span class="o-expandable_cue o-expandable_cue-close">
-                              <span class="u-visually-hidden-on-mobile">Hide</span>
+                              <span class="u-visually-hidden">Hide</span>
                               {% include icons/minus-round.svg %}
                           </span>
                       </span>

--- a/docs/pages/filterable-list-control-panels.md
+++ b/docs/pages/filterable-list-control-panels.md
@@ -22,14 +22,14 @@ variation_groups:
                       </span>
                       <span class="o-expandable_link">
                           <span class="o-expandable_cue o-expandable_cue-open">
-                              <span class="u-visually-hidden-on-mobile">
+                              <span class="u-visually-hidden">
                               Show
                               filters
                               </span>
                                 <svg xmlns="http://www.w3.org/2000/svg" class="cf-icon-svg cf-icon-svg__plus-round" viewBox="0 0 17 20.4"><path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H9.284V6.12a.792.792 0 1 0-1.583 0V9.5H4.32a.792.792 0 0 0 0 1.584H7.7v3.382a.792.792 0 0 0 1.583 0v-3.382h3.382a.792.792 0 0 0 .792-.791z"/></svg>
                           </span>
                           <span class="o-expandable_cue o-expandable_cue-close">
-                              <span class="u-visually-hidden-on-mobile">
+                              <span class="u-visually-hidden">
                               Hide
                               filters
                               </span>

--- a/docs/special-pages/updating-this-website.md
+++ b/docs/special-pages/updating-this-website.md
@@ -39,11 +39,11 @@ description: >-
               </h3>
               <span class="o-expandable_link">
                   <span class="o-expandable_cue o-expandable_cue-open">
-                      <span class="u-visually-hidden-on-mobile">Show</span>
+                      <span class="u-visually-hidden">Show</span>
                       {% include icons/plus-round.svg %}
                   </span>
                   <span class="o-expandable_cue o-expandable_cue-close">
-                      <span class="u-visually-hidden-on-mobile">Hide</span>
+                      <span class="u-visually-hidden">Hide</span>
                       {% include icons/minus-round.svg %}
                   </span>
               </span>
@@ -65,11 +65,11 @@ description: >-
               </h3>
               <span class="o-expandable_link">
                   <span class="o-expandable_cue o-expandable_cue-open">
-                      <span class="u-visually-hidden-on-mobile">Show</span>
+                      <span class="u-visually-hidden">Show</span>
                       {% include icons/plus-round.svg %}
                   </span>
                   <span class="o-expandable_cue o-expandable_cue-close">
-                      <span class="u-visually-hidden-on-mobile">Hide</span>
+                      <span class="u-visually-hidden">Hide</span>
                       {% include icons/minus-round.svg %}
                   </span>
               </span>
@@ -94,11 +94,11 @@ description: >-
               </h3>
               <span class="o-expandable_link">
                   <span class="o-expandable_cue o-expandable_cue-open">
-                      <span class="u-visually-hidden-on-mobile">Show</span>
+                      <span class="u-visually-hidden">Show</span>
                       {% include icons/plus-round.svg %}
                   </span>
                   <span class="o-expandable_cue o-expandable_cue-close">
-                      <span class="u-visually-hidden-on-mobile">Hide</span>
+                      <span class="u-visually-hidden">Hide</span>
                       {% include icons/minus-round.svg %}
                   </span>
               </span>
@@ -120,11 +120,11 @@ description: >-
               </h3>
               <span class="o-expandable_link">
                   <span class="o-expandable_cue o-expandable_cue-open">
-                      <span class="u-visually-hidden-on-mobile">Show</span>
+                      <span class="u-visually-hidden">Show</span>
                       {% include icons/plus-round.svg %}
                   </span>
                   <span class="o-expandable_cue o-expandable_cue-close">
-                      <span class="u-visually-hidden-on-mobile">Hide</span>
+                      <span class="u-visually-hidden">Hide</span>
                       {% include icons/minus-round.svg %}
                   </span>
               </span>
@@ -149,11 +149,11 @@ description: >-
               </h3>
               <span class="o-expandable_link">
                   <span class="o-expandable_cue o-expandable_cue-open">
-                      <span class="u-visually-hidden-on-mobile">Show</span>
+                      <span class="u-visually-hidden">Show</span>
                       {% include icons/plus-round.svg %}
                   </span>
                   <span class="o-expandable_cue o-expandable_cue-close">
-                      <span class="u-visually-hidden-on-mobile">Hide</span>
+                      <span class="u-visually-hidden">Hide</span>
                       {% include icons/minus-round.svg %}
                   </span>
               </span>
@@ -178,11 +178,11 @@ description: >-
               </h3>
               <span class="o-expandable_link">
                   <span class="o-expandable_cue o-expandable_cue-open">
-                      <span class="u-visually-hidden-on-mobile">Show</span>
+                      <span class="u-visually-hidden">Show</span>
                       {% include icons/plus-round.svg %}
                   </span>
                   <span class="o-expandable_cue o-expandable_cue-close">
-                      <span class="u-visually-hidden-on-mobile">Hide</span>
+                      <span class="u-visually-hidden">Hide</span>
                       {% include icons/minus-round.svg %}
                   </span>
               </span>

--- a/packages/cfpb-core/src/utilities.less
+++ b/packages/cfpb-core/src/utilities.less
@@ -44,12 +44,6 @@
   clip: rect(0 0 0 0);
 }
 
-.u-visually-hidden-on-mobile {
-  .respond-to-max( @bp-xs-max, {
-    .u-visually-hidden();
-  } );
-}
-
 //
 // Width-specific display
 //


### PR DESCRIPTION
## Removals

- Remove expandable labels and `.u-visually-hidden-on-mobile` class

## Testing

1. PR preview should show expandables without text labels.
