### PR TITLE
Move `__onload-open` modifier to the parent component class

### DIFF
--- a/docs/pages/expandables.md
+++ b/docs/pages/expandables.md
@@ -116,7 +116,8 @@ variation_groups:
           <div class="o-expandable
                       o-expandable__padded
                       o-expandable__background
-                      o-expandable__border">
+                      o-expandable__border
+                      o-expandable__onload-open">
               <button class="o-expandable_header o-expandable_target"
                       title="Expand content">
                   <h3 class="h4 o-expandable_label">
@@ -133,7 +134,7 @@ variation_groups:
                       </span>
                   </span>
               </button>
-              <div class="o-expandable_content o-expandable_content__onload-open">
+              <div class="o-expandable_content">
                   <p>
                       Lorem ipsum dolor sit amet, consectetur adipisicing
                       elit. Neque ipsa voluptatibus soluta nobis unde quisquam
@@ -147,8 +148,8 @@ variation_groups:
         variation_description:
           Sometimes you may want the expandable to be open by
           default. This is as easy as adding the
-          `.o-expandable_content__onload-open` modifier to the
-          `.o-expandable_content` block.
+          `.o-expandable__onload-open` modifier to the
+          `.o-expandable` block.
         variation_implementation:
           A new array of Expandable instances can be created
           using a JavaScript API. For information, [open the "Implementation"

--- a/docs/pages/filterable-list-control-panels.md
+++ b/docs/pages/filterable-list-control-panels.md
@@ -15,7 +15,8 @@ variation_groups:
               <div class="o-expandable
                   o-expandable__padded
                   o-expandable__background
-                  o-expandable__border">
+                  o-expandable__border
+                  o-expandable__onload-open">
                   <button class="o-expandable_header o-expandable_target o-expandable_target__expanded" type="button">
                       <span class="h4 o-expandable_label">
                       Filter posts
@@ -37,7 +38,7 @@ variation_groups:
                           </span>
                       </span>
                   </button>
-                  <div class="o-expandable_content o-expandable_content__onload-open">
+                  <div class="o-expandable_content">
                       <form method="get" action="#">
                           <div class="content-l">
                               <div class="content-l_col

--- a/packages/cfpb-expandables/src/Expandable.js
+++ b/packages/cfpb-expandables/src/Expandable.js
@@ -48,9 +48,7 @@ function Expandable(element) {
     _contentDom = _dom.querySelector(`.${BASE_CLASS}_content`);
     _labelDom = _dom.querySelector(`.${BASE_CLASS}_label`);
 
-    const isExpanded = _contentDom.classList.contains(
-      `${BASE_CLASS}_content__onload-open`
-    );
+    const isExpanded = _dom.classList.contains(`${BASE_CLASS}__onload-open`);
 
     // Add behavior hooks.
     addDataHook(_dom, 'behavior_flyout-menu');

--- a/packages/cfpb-expandables/usage.md
+++ b/packages/cfpb-expandables/usage.md
@@ -27,11 +27,11 @@ components are dependencies of this component.
 ### Expanded
 
 Sometimes you may want the expandable to be open by default.
-This is as easy as adding the `.o-expandable_content__onload-open` modifier
-to the `.o-expandable_content` block.
+This is as easy as adding the `.o-expandable__onload-open` modifier
+to the `.o-expandable` block.
 
 ```
-.o-expandable_content__onload-open
+.o-expandable__onload-open
 ```
 
 ### Padded
@@ -184,7 +184,8 @@ The following combination is our recommended go-to expandable pattern.
 <div class="o-expandable
             o-expandable__padded
             o-expandable__background
-            o-expandable__border">
+            o-expandable__border
+            o-expandable__onload-open">
     <button class="o-expandable_header o-expandable_target"
             title="Expand content">
         <h3 class="h4 o-expandable_label">
@@ -201,7 +202,7 @@ The following combination is our recommended go-to expandable pattern.
             </span>
         </span>
     </button>
-    <div class="o-expandable_content o-expandable_content__onload-open">
+    <div class="o-expandable_content">
         <p>
             Lorem ipsum dolor sit amet, consectetur adipisicing
             elit. Neque ipsa voluptatibus soluta nobis unde quisquam
@@ -216,7 +217,8 @@ The following combination is our recommended go-to expandable pattern.
 <div class="o-expandable
             o-expandable__padded
             o-expandable__background
-            o-expandable__border">
+            o-expandable__border
+            o-expandable__onload-open">
     <button class="o-expandable_header o-expandable_target"
             title="Expand content">
         <h3 class="h4 o-expandable_label">
@@ -233,7 +235,7 @@ The following combination is our recommended go-to expandable pattern.
             </span>
         </span>
     </button>
-    <div class="o-expandable_content o-expandable_content__onload-open">
+    <div class="o-expandable_content">
         <p>
             Lorem ipsum dolor sit amet, consectetur adipisicing
             elit. Neque ipsa voluptatibus soluta nobis unde quisquam

--- a/test/unit-test/src/cfpb-expandables/src/Expandable.spec.js
+++ b/test/unit-test/src/cfpb-expandables/src/Expandable.spec.js
@@ -1,4 +1,7 @@
-import { Expandable, ExpandableGroup } from '../../../../../packages/cfpb-expandables';
+import {
+  Expandable,
+  ExpandableGroup,
+} from '../../../../../packages/cfpb-expandables';
 import { simulateEvent } from '../../../../util/simulate-event.js';
 
 const HTML_SNIPPET = `
@@ -103,7 +106,7 @@ describe('standard Expandable', () => {
     targetDom2 = expandableDom2.querySelector('.o-expandable_target');
     contentDom1 = expandableDom1.querySelector('.o-expandable_content');
     contentDom2 = expandableDom2.querySelector('.o-expandable_content');
-    contentDom2.classList.add('o-expandable_content__onload-open');
+    expandableDom2.classList.add('o-expandable__onload-open');
 
     ExpandableGroup.init();
     expandable = Expandable.init()[0];
@@ -121,10 +124,12 @@ describe('standard Expandable', () => {
 
     it('should be collapsed when the OPEN_DEFAULT class is not present', () => {
       expect(targetDom1.getAttribute('aria-expanded')).toBe('false');
+      expect(contentDom1.getAttribute('data-open')).toBe('false');
     });
 
     it('should be expanded when the OPEN_DEFAULT class is present', () => {
       expect(targetDom2.getAttribute('aria-expanded')).toBe('true');
+      expect(contentDom2.getAttribute('data-open')).toBe('true');
     });
 
     it('should return label text', () => {


### PR DESCRIPTION
Doesn't make sense to put a modifier inside the component, it should be a modifier overall on `o-expandable`. This moves the modifier to the component from `content`.

## Changes

- Move `__onload-open` modifier to the parent component class

## Testing

1. PR preview expandable should work as before.
