### PR TITLE
Convert visually hidden expandable labels to aria-labels

### DIFF
--- a/docs/pages/expandables.md
+++ b/docs/pages/expandables.md
@@ -18,11 +18,10 @@ variation_groups:
                       Expandable Header
                   </h3>
                   <span class="o-expandable_link">
-                      <span class="o-expandable_cue o-expandable_cue-open">
-                          <span class="u-visually-hidden">Show</span>
+                      <span class="o-expandable_cue-open" aria-label="Show">
                           {% include icons/plus-round.svg %}
                       </span>
-                      <span class="o-expandable_cue o-expandable_cue-close">
+                      <span class="o-expandable_cue-close" aria-label="Hide">
                           <span class="u-visually-hidden">Hide</span>
                           {% include icons/minus-round.svg %}
                       </span>
@@ -124,12 +123,10 @@ variation_groups:
                       Expandable Header
                   </h3>
                   <span class="o-expandable_link">
-                      <span class="o-expandable_cue o-expandable_cue-open">
-                          <span class="u-visually-hidden">Show</span>
+                      <span class="o-expandable_cue-open" aria-label="Show">
                           {% include icons/plus-round.svg %}
                       </span>
-                      <span class="o-expandable_cue o-expandable_cue-close">
-                          <span class="u-visually-hidden">Hide</span>
+                      <span class="o-expandable_cue-close" aria-label="Hide">
                           {% include icons/minus-round.svg %}
                       </span>
                   </span>
@@ -166,12 +163,10 @@ variation_groups:
                           Expandable Header 1
                       </h3>
                       <span class="o-expandable_link">
-                          <span class="o-expandable_cue o-expandable_cue-open">
-                              <span class="u-visually-hidden">Show</span>
+                          <span class="o-expandable_cue-open" aria-label="Show">
                               {% include icons/plus-round.svg %}
                           </span>
-                          <span class="o-expandable_cue o-expandable_cue-close">
-                              <span class="u-visually-hidden">Hide</span>
+                          <span class="o-expandable_cue-close" aria-label="Hide">
                               {% include icons/minus-round.svg %}
                           </span>
                       </span>
@@ -194,12 +189,10 @@ variation_groups:
                           Expandable Header 2
                       </h3>
                       <span class="o-expandable_link">
-                          <span class="o-expandable_cue o-expandable_cue-open">
-                              <span class="u-visually-hidden">Show</span>
+                          <span class="o-expandable_cue-open" aria-label="Show">
                               {% include icons/plus-round.svg %}
                           </span>
-                          <span class="o-expandable_cue o-expandable_cue-close">
-                              <span class="u-visually-hidden">Hide</span>
+                          <span class="o-expandable_cue-close" aria-label="Hide">
                               {% include icons/minus-round.svg %}
                           </span>
                       </span>
@@ -222,12 +215,10 @@ variation_groups:
                           Expandable Header 3
                       </h3>
                       <span class="o-expandable_link">
-                          <span class="o-expandable_cue o-expandable_cue-open">
-                              <span class="u-visually-hidden">Show</span>
+                          <span class="o-expandable_cue-open" aria-label="Show">
                               {% include icons/plus-round.svg %}
                           </span>
-                          <span class="o-expandable_cue o-expandable_cue-close">
-                              <span class="u-visually-hidden">Hide</span>
+                          <span class="o-expandable_cue-close" aria-label="Hide">
                               {% include icons/minus-round.svg %}
                           </span>
                       </span>
@@ -291,12 +282,10 @@ variation_groups:
                           Expandable Header 1
                       </h3>
                       <span class="o-expandable_link">
-                          <span class="o-expandable_cue o-expandable_cue-open">
-                              <span class="u-visually-hidden">Show</span>
+                          <span class="o-expandable_cue-open" aria-label="Show">
                               {% include icons/plus-round.svg %}
                           </span>
-                          <span class="o-expandable_cue o-expandable_cue-close">
-                              <span class="u-visually-hidden">Hide</span>
+                          <span class="o-expandable_cue-close" aria-label="Hide">
                               {% include icons/minus-round.svg %}
                           </span>
                       </span>
@@ -319,12 +308,10 @@ variation_groups:
                           Expandable Header 2
                       </h3>
                       <span class="o-expandable_link">
-                          <span class="o-expandable_cue o-expandable_cue-open">
-                              <span class="u-visually-hidden">Show</span>
+                          <span class="o-expandable_cue-open" aria-label="Show">
                               {% include icons/plus-round.svg %}
                           </span>
-                          <span class="o-expandable_cue o-expandable_cue-close">
-                              <span class="u-visually-hidden">Hide</span>
+                          <span class="o-expandable_cue-close" aria-label="Hide">
                               {% include icons/minus-round.svg %}
                           </span>
                       </span>
@@ -383,12 +370,10 @@ variation_groups:
                           Expandable Header 3
                       </h3>
                       <span class="o-expandable_link">
-                          <span class="o-expandable_cue o-expandable_cue-open">
-                              <span class="u-visually-hidden">Show</span>
+                          <span class="o-expandable_cue-open" aria-label="Show">
                               {% include icons/plus-round.svg %}
                           </span>
-                          <span class="o-expandable_cue o-expandable_cue-close">
-                              <span class="u-visually-hidden">Hide</span>
+                          <span class="o-expandable_cue-close" aria-label="Hide">
                               {% include icons/minus-round.svg %}
                           </span>
                       </span>

--- a/docs/pages/expandables.md
+++ b/docs/pages/expandables.md
@@ -464,9 +464,7 @@ research: >-
 
   var closestElem = closest(elem, '.o-expandable_target');
 
-  var textElem = closestElem.querySelector('.o-expandable_label') || closestElem.querySelector('.o-expandable_cue')
-
-  ;
+  var textElem = closestElem.querySelector('.o-expandable_label');
 
   var text = textElem.textContent.trim();
 

--- a/docs/pages/filterable-list-control-panels.md
+++ b/docs/pages/filterable-list-control-panels.md
@@ -17,23 +17,15 @@ variation_groups:
                   o-expandable__background
                   o-expandable__border
                   o-expandable__onload-open">
-                  <button class="o-expandable_header o-expandable_target o-expandable_target__expanded" type="button">
+                  <button class="o-expandable_header o-expandable_target" type="button">
                       <span class="h4 o-expandable_label">
                       Filter posts
                       </span>
                       <span class="o-expandable_link">
-                          <span class="o-expandable_cue o-expandable_cue-open">
-                              <span class="u-visually-hidden">
-                              Show
-                              filters
-                              </span>
+                          <span class="o-expandable_cue-open" aria-label="Show filters">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="cf-icon-svg cf-icon-svg__plus-round" viewBox="0 0 17 20.4"><path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H9.284V6.12a.792.792 0 1 0-1.583 0V9.5H4.32a.792.792 0 0 0 0 1.584H7.7v3.382a.792.792 0 0 0 1.583 0v-3.382h3.382a.792.792 0 0 0 .792-.791z"/></svg>
                           </span>
-                          <span class="o-expandable_cue o-expandable_cue-close">
-                              <span class="u-visually-hidden">
-                              Hide
-                              filters
-                              </span>
+                          <span class="o-expandable_cue-close" aria-label="Hide filters">
                             <svg xmlns="http://www.w3.org/2000/svg" class="cf-icon-svg cf-icon-svg__minus-round" viewBox="0 0 17 20.4"><path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H4.32a.792.792 0 0 0 0 1.583h8.346a.792.792 0 0 0 .792-.791z"/></svg>
                           </span>
                       </span>

--- a/docs/special-pages/updating-this-website.md
+++ b/docs/special-pages/updating-this-website.md
@@ -38,12 +38,10 @@ description: >-
                   Step 1. Click a page's "Edit this page" pencil icon.
               </h3>
               <span class="o-expandable_link">
-                  <span class="o-expandable_cue o-expandable_cue-open">
-                      <span class="u-visually-hidden">Show</span>
+                  <span class="o-expandable_cue-open" aria-label="Show">
                       {% include icons/plus-round.svg %}
                   </span>
-                  <span class="o-expandable_cue o-expandable_cue-close">
-                      <span class="u-visually-hidden">Hide</span>
+                  <span class="o-expandable_cue-close" aria-label="Hide">
                       {% include icons/minus-round.svg %}
                   </span>
               </span>
@@ -64,12 +62,10 @@ description: >-
                   Step 2. Log into the CMS
               </h3>
               <span class="o-expandable_link">
-                  <span class="o-expandable_cue o-expandable_cue-open">
-                      <span class="u-visually-hidden">Show</span>
+                  <span class="o-expandable_cue-open" aria-label="Show">
                       {% include icons/plus-round.svg %}
                   </span>
-                  <span class="o-expandable_cue o-expandable_cue-close">
-                      <span class="u-visually-hidden">Hide</span>
+                  <span class="o-expandable_cue-close" aria-label="Hide">
                       {% include icons/minus-round.svg %}
                   </span>
               </span>
@@ -93,12 +89,10 @@ description: >-
                   Step 3. Edit a page's content
               </h3>
               <span class="o-expandable_link">
-                  <span class="o-expandable_cue o-expandable_cue-open">
-                      <span class="u-visually-hidden">Show</span>
+                  <span class="o-expandable_cue-open" aria-label="Show">
                       {% include icons/plus-round.svg %}
                   </span>
-                  <span class="o-expandable_cue o-expandable_cue-close">
-                      <span class="u-visually-hidden">Hide</span>
+                  <span class="o-expandable_cue-close" aria-label="Hide">
                       {% include icons/minus-round.svg %}
                   </span>
               </span>
@@ -119,11 +113,11 @@ description: >-
                   Step 4. Save your changes
               </h3>
               <span class="o-expandable_link">
-                  <span class="o-expandable_cue o-expandable_cue-open">
+                  <span class="o-expandable_cue-open" aria-label="Show">
                       <span class="u-visually-hidden">Show</span>
                       {% include icons/plus-round.svg %}
                   </span>
-                  <span class="o-expandable_cue o-expandable_cue-close">
+                  <span class="o-expandable_cue-close" aria-label="Hide">
                       <span class="u-visually-hidden">Hide</span>
                       {% include icons/minus-round.svg %}
                   </span>
@@ -148,12 +142,10 @@ description: >-
                   Step 5. Preview your changes
               </h3>
               <span class="o-expandable_link">
-                  <span class="o-expandable_cue o-expandable_cue-open">
-                      <span class="u-visually-hidden">Show</span>
+                  <span class="o-expandable_cue-open" aria-label="Show">
                       {% include icons/plus-round.svg %}
                   </span>
-                  <span class="o-expandable_cue o-expandable_cue-close">
-                      <span class="u-visually-hidden">Hide</span>
+                  <span class="o-expandable_cue-close" aria-label="Hide">
                       {% include icons/minus-round.svg %}
                   </span>
               </span>
@@ -177,12 +169,10 @@ description: >-
                   Step 6. Publish your changes
               </h3>
               <span class="o-expandable_link">
-                  <span class="o-expandable_cue o-expandable_cue-open">
-                      <span class="u-visually-hidden">Show</span>
+                  <span class="o-expandable_cue-open" aria-label="Show">
                       {% include icons/plus-round.svg %}
                   </span>
-                  <span class="o-expandable_cue o-expandable_cue-close">
-                      <span class="u-visually-hidden">Hide</span>
+                  <span class="o-expandable_cue-close" aria-label="Hide">
                       {% include icons/minus-round.svg %}
                   </span>
               </span>

--- a/packages/cfpb-expandables/usage.md
+++ b/packages/cfpb-expandables/usage.md
@@ -125,12 +125,10 @@ The following combination is our recommended go-to expandable pattern.
             Expandable Header
         </h3>
         <span class="o-expandable_link">
-            <span class="o-expandable_cue o-expandable_cue-open">
-                <span class="u-visually-hidden">Show</span>
+            <span class="o-expandable_cue-open" aria-label="Show">
                 {% include icons/plus-round.svg %}
             </span>
-            <span class="o-expandable_cue o-expandable_cue-close">
-                <span class="u-visually-hidden">Hide</span>
+            <span class="o-expandable_cue-close" aria-label="Hide">
                 {% include icons/minus-round.svg %}
             </span>
         </span>
@@ -157,12 +155,10 @@ The following combination is our recommended go-to expandable pattern.
             Expandable Header
         </h3>
         <span class="o-expandable_link">
-            <span class="o-expandable_cue o-expandable_cue-open">
-                <span class="u-visually-hidden">Show</span>
+            <span class="o-expandable_cue-open" aria-label="Show">
                 {% raw %}{% include icons/plus-round.svg %}{% endraw %}
             </span>
-            <span class="o-expandable_cue o-expandable_cue-close">
-                <span class="u-visually-hidden">Hide</span>
+            <span class="o-expandable_cue-close" aria-label="Hide">
                 {% raw %}{% include icons/minus-round.svg %}{% endraw %}
             </span>
         </span>
@@ -192,12 +188,10 @@ The following combination is our recommended go-to expandable pattern.
             Expandable Header
         </h3>
         <span class="o-expandable_link">
-            <span class="o-expandable_cue o-expandable_cue-open">
-                <span class="u-visually-hidden">Show</span>
+            <span class="o-expandable_cue-open" aria-label="Show">
                 {% include icons/plus-round.svg %}
             </span>
-            <span class="o-expandable_cue o-expandable_cue-close">
-                <span class="u-visually-hidden">Hide</span>
+            <span class="o-expandable_cue-close" aria-label="Hide">
                 {% include icons/minus-round.svg %}
             </span>
         </span>
@@ -225,12 +219,10 @@ The following combination is our recommended go-to expandable pattern.
             Expandable Header
         </h3>
         <span class="o-expandable_link">
-            <span class="o-expandable_cue o-expandable_cue-open">
-                <span class="u-visually-hidden">Show</span>
+            <span class="o-expandable_cue-open" aria-label="Show">
                 {% raw %}{% include icons/plus-round.svg %}{% endraw %}
             </span>
-            <span class="o-expandable_cue o-expandable_cue-close">
-                <span class="u-visually-hidden">Hide</span>
+            <span class="o-expandable_cue-close" aria-label="Hide">
                 {% raw %}{% include icons/minus-round.svg %}{% endraw %}
             </span>
         </span>
@@ -247,54 +239,9 @@ The following combination is our recommended go-to expandable pattern.
 </div>
 ```
 
-### Barebones expandable
+### Variations
 
-This is the barebones structure for expandables that can be used (along with
-other expanable elements and modifiers) to create custom expandable patterns.
-
-In this barebones example there are no visual styles.
-
-<div class="o-expandable">
-    <button class="o-expandable_target" title="Expand content">
-        <span class="o-expandable_cue o-expandable_cue-open">
-            <span class="u-visually-hidden">Show</span>
-        </span>
-        <span class="o-expandable_cue o-expandable_cue-close">
-            <span class="u-visually-hidden">Hide</span>
-        </span>
-    </button>
-    <div class="o-expandable_content">
-        <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing
-            elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-            temporibus magnam debitis quidem. Ducimus ratione
-            corporis nesciunt earum vel est quaerat blanditiis
-            dolore ipsa?
-        </p>
-    </div>
-</div>
-
-```
-<div class="o-expandable">
-    <button class="o-expandable_target" title="Expand content">
-        <span class="o-expandable_cue o-expandable_cue-open">
-            <span class="u-visually-hidden">Show</span>
-        </span>
-        <span class="o-expandable_cue o-expandable_cue-close">
-            <span class="u-visually-hidden">Hide</span>
-        </span>
-    </button>
-    <div class="o-expandable_content">
-        <p>
-            Lorem ipsum dolor sit amet, consectetur adipisicing
-            elit. Neque ipsa voluptatibus soluta nobis unde quisquam
-            temporibus magnam debitis quidem. Ducimus ratione
-            corporis nesciunt earum vel est quaerat blanditiis
-            dolore ipsa?
-        </p>
-    </div>
-</div>
-```
+Should you need an expandable thing that is not covered by the expandables above, see the [Transition Patterns](https://cfpb.github.io/design-system/patterns/transition-patterns) for making a component with expandable-like behavior.
 
 ## Expandable groups
 
@@ -306,12 +253,10 @@ In this barebones example there are no visual styles.
                 Expandable Header 1
             </h3>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue o-expandable_cue-open">
-                    <span class="u-visually-hidden">Show</span>
+                <span class="o-expandable_cue-open" aria-label="Show">
                     {% include icons/plus-round.svg %}
                 </span>
-                <span class="o-expandable_cue o-expandable_cue-close">
-                    <span class="u-visually-hidden">Hide</span>
+                <span class="o-expandable_cue-close" aria-label="Hide">
                     {% include icons/minus-round.svg %}
                 </span>
             </span>
@@ -333,12 +278,10 @@ In this barebones example there are no visual styles.
                 Expandable Header 2
             </h3>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue o-expandable_cue-open">
-                    <span class="u-visually-hidden">Show</span>
+                <span class="o-expandable_cue-open" aria-label="Show">
                     {% include icons/plus-round.svg %}
                 </span>
-                <span class="o-expandable_cue o-expandable_cue-close">
-                    <span class="u-visually-hidden">Hide</span>
+                <span class="o-expandable_cue-close" aria-label="Hide">
                     {% include icons/minus-round.svg %}
                 </span>
             </span>
@@ -360,12 +303,10 @@ In this barebones example there are no visual styles.
                 Expandable Header 3
             </h3>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue o-expandable_cue-open">
-                    <span class="u-visually-hidden">Show</span>
+                <span class="o-expandable_cue-open" aria-label="Show">
                     {% include icons/plus-round.svg %}
                 </span>
-                <span class="o-expandable_cue o-expandable_cue-close">
-                    <span class="u-visually-hidden">Hide</span>
+                <span class="o-expandable_cue-close" aria-label="Hide">
                     {% include icons/minus-round.svg %}
                 </span>
             </span>
@@ -391,12 +332,10 @@ In this barebones example there are no visual styles.
                 Expandable Header 1
             </h3>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue o-expandable_cue-open">
-                    <span class="u-visually-hidden">Show</span>
+                <span class="o-expandable_cue-open" aria-label="Show">
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
-                <span class="o-expandable_cue o-expandable_cue-close">
-                    <span class="u-visually-hidden">Hide</span>
+                <span class="o-expandable_cue-close" aria-label="Hide">
                     {% raw %}{% include icons/minus-round.svg %}{% endraw %}
                 </span>
             </span>
@@ -418,12 +357,10 @@ In this barebones example there are no visual styles.
                 Expandable Header 2
             </h3>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue o-expandable_cue-open">
-                    <span class="u-visually-hidden">Show</span>
+                <span class="o-expandable_cue-open" aria-label="Show">
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
-                <span class="o-expandable_cue o-expandable_cue-close">
-                    <span class="u-visually-hidden">Hide</span>
+                <span class="o-expandable_cue-close" aria-label="Hide">
                     {% raw %}{% include icons/minus-round.svg %}{% endraw %}
                 </span>
             </span>
@@ -445,12 +382,10 @@ In this barebones example there are no visual styles.
                 Expandable Header 3
             </h3>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue o-expandable_cue-open">
-                    <span class="u-visually-hidden">Show</span>
+                <span class="o-expandable_cue-open" aria-label="Show">
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
-                <span class="o-expandable_cue o-expandable_cue-close">
-                    <span class="u-visually-hidden">Hide</span>
+                <span class="o-expandable_cue-close" aria-label="Hide">
                     {% raw %}{% include icons/minus-round.svg %}{% endraw %}
                 </span>
             </span>
@@ -482,12 +417,10 @@ to activate the accordion mode.
                 Expandable Header 1
             </h3>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue o-expandable_cue-open">
-                    <span class="u-visually-hidden">Show</span>
+                <span class="o-expandable_cue-open" aria-label="Show">
                     {% include icons/plus-round.svg %}
                 </span>
-                <span class="o-expandable_cue o-expandable_cue-close">
-                    <span class="u-visually-hidden">Hide</span>
+                <span class="o-expandable_cue-close" aria-label="Hide">
                     {% include icons/minus-round.svg %}
                 </span>
             </span>
@@ -509,12 +442,10 @@ to activate the accordion mode.
                 Expandable Header 2
             </h3>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue o-expandable_cue-open">
-                    <span class="u-visually-hidden">Show</span>
+                <span class="o-expandable_cue-open" aria-label="Show">
                     {% include icons/plus-round.svg %}
                 </span>
-                <span class="o-expandable_cue o-expandable_cue-close">
-                    <span class="u-visually-hidden">Hide</span>
+                <span class="o-expandable_cue-close" aria-label="Hide">
                     {% include icons/minus-round.svg %}
                 </span>
             </span>
@@ -536,12 +467,10 @@ to activate the accordion mode.
                 Expandable Header 3
             </h3>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue o-expandable_cue-open">
-                    <span class="u-visually-hidden">Show</span>
+                <span class="o-expandable_cue-open" aria-label="Show">
                     {% include icons/plus-round.svg %}
                 </span>
-                <span class="o-expandable_cue o-expandable_cue-close">
-                    <span class="u-visually-hidden">Hide</span>
+                <span class="o-expandable_cue-close" aria-label="Hide">
                     {% include icons/minus-round.svg %}
                 </span>
             </span>
@@ -567,12 +496,10 @@ to activate the accordion mode.
                 Expandable Header 1
             </h3>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue o-expandable_cue-open">
-                    <span class="u-visually-hidden">Show</span>
+                <span class="o-expandable_cue-open" aria-label="Show">
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
-                <span class="o-expandable_cue o-expandable_cue-close">
-                    <span class="u-visually-hidden">Hide</span>
+                <span class="o-expandable_cue-close" aria-label="Hide">
                     {% raw %}{% include icons/minus-round.svg %}{% endraw %}
                 </span>
             </span>
@@ -594,12 +521,10 @@ to activate the accordion mode.
                 Expandable Header 2
             </h3>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue o-expandable_cue-open">
-                    <span class="u-visually-hidden">Show</span>
+                <span class="o-expandable_cue-open" aria-label="Show">
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
-                <span class="o-expandable_cue o-expandable_cue-close">
-                    <span class="u-visually-hidden">Hide</span>
+                <span class="o-expandable_cue-close" aria-label="Hide">
                     {% raw %}{% include icons/minus-round.svg %}{% endraw %}
                 </span>
             </span>
@@ -621,12 +546,10 @@ to activate the accordion mode.
                 Expandable Header 3
             </h3>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue o-expandable_cue-open">
-                    <span class="u-visually-hidden">Show</span>
+                <span class="o-expandable_cue-open" aria-label="Show">
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
-                <span class="o-expandable_cue o-expandable_cue-close">
-                    <span class="u-visually-hidden">Hide</span>
+                <span class="o-expandable_cue-close" aria-label="Hide">
                     {% raw %}{% include icons/minus-round.svg %}{% endraw %}
                 </span>
             </span>

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/atomic-helpers.spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/atomic-helpers.spec.js
@@ -16,10 +16,10 @@ const HTML_SNIPPET = `
               Expandable Header 3
           </span>
           <span class="o-expandable_link">
-              <span class="o-expandable_cue o-expandable_cue-open">
+              <span class="o-expandable_cue-open">
                   Show
               </span>
-              <span class="o-expandable_cue o-expandable_cue-close">
+              <span class="o-expandable_cue-close">
                   Hide
               </span>
           </span>

--- a/test/unit-test/src/cfpb-expandables/src/Expandable.spec.js
+++ b/test/unit-test/src/cfpb-expandables/src/Expandable.spec.js
@@ -15,10 +15,10 @@ const HTML_SNIPPET = `
                 Expandable Header 1
             </span>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue o-expandable_cue-open">
+                <span class="o-expandable_cue-open">
                     Show
                 </span>
-                <span class="o-expandable_cue o-expandable_cue-close">
+                <span class="o-expandable_cue-close">
                     Hide
                 </span>
             </span>
@@ -41,10 +41,10 @@ const HTML_SNIPPET = `
                 Expandable Header 2
             </span>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue o-expandable_cue-open">
+                <span class="o-expandable_cue-open">
                     Show
                 </span>
-                <span class="o-expandable_cue o-expandable_cue-close">
+                <span class="o-expandable_cue-close">
                     Hide
                 </span>
             </span>
@@ -68,10 +68,10 @@ const HTML_SNIPPET = `
             Expandable Header 3
         </span>
         <span class="o-expandable_link">
-            <span class="o-expandable_cue o-expandable_cue-open">
+            <span class="o-expandable_cue-open">
                 Show
             </span>
-            <span class="o-expandable_cue o-expandable_cue-close">
+            <span class="o-expandable_cue-close">
                 Hide
             </span>
         </span>


### PR DESCRIPTION
## Changes

- Convert visually hidden expandable labels to aria-labels
- Remove unused `o-expandable_cue` class.

## Testing

1. Voicing over the PR preview expandables should still voice show/hide.

## Notes

`o-expandable_cue` would be useful if you want to target both the open and close cue, but we currently don't target that, and they both have an `o-expandable_link` parent container that could be targeted.