### PR TITLE
Add Summary Minimal component

### DIFF
--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -1,6 +1,11 @@
 import { toggleAllDetails, toggleDetails } from './toggle-details.js';
 import AnchorJS from 'anchor-js';
-import { Expandable, ExpandableGroup, Summary } from '@cfpb/cfpb-expandables';
+import {
+  Expandable,
+  ExpandableGroup,
+  Summary,
+  SummaryMinimal,
+} from '@cfpb/cfpb-expandables';
 import { Multiselect } from '@cfpb/cfpb-forms';
 import {
   FlyoutMenu,
@@ -29,6 +34,7 @@ anchors.remove(`
 `);
 
 Summary.init();
+SummaryMinimal.init();
 ExpandableGroup.init();
 Expandable.init();
 Multiselect.init();

--- a/docs/pages/summaries.md
+++ b/docs/pages/summaries.md
@@ -57,6 +57,27 @@ variation_groups:
         variation_description:
           Adding the `o-summary__mobile` modifier makes the summary
           behavior only show up on a mobile (narrow) page width.
+      - variation_name: Summary Minimal
+        variation_code_snippet: >-
+          <div class="o-summary-minimal">
+            <div class="o-summary-minimal_content">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </div>
+
+            <button class="o-summary-minimal_btn">
+                <span class="o-summary-minimal_cue-open">
+                    Show full list of relevant parties
+                    {% include icons/plus-round.svg %}
+                </span>
+                <span class="o-summary-minimal_cue-close">
+                    Hide full list of relevant parties
+                    {% include icons/minus-round.svg %}
+                </span>
+            </button>
+          </div>
+        variation_description:
+          This component provides a more inconspicous button, which stays
+          at the bottom of the summary when expanded.
 eyebrow: Behavior
 title: Summaries
 description: Summary components hides content over a certain height. When the

--- a/docs/pages/summaries.md
+++ b/docs/pages/summaries.md
@@ -66,11 +66,11 @@ variation_groups:
 
             <button class="o-summary-minimal_btn">
                 <span class="o-summary-minimal_cue-open">
-                    Show full list of relevant parties
+                    Show
                     {% include icons/plus-round.svg %}
                 </span>
                 <span class="o-summary-minimal_cue-close">
-                    Hide full list of relevant parties
+                    Hide
                     {% include icons/minus-round.svg %}
                 </span>
             </button>

--- a/packages/cfpb-expandables/src/SummaryMinimal.js
+++ b/packages/cfpb-expandables/src/SummaryMinimal.js
@@ -1,0 +1,121 @@
+/* eslint-disable no-use-before-define */
+import {
+  add as addDataHook,
+  checkDom,
+  instantiateAll,
+  setInitFlag,
+  FlyoutMenu,
+  MaxHeightTransition,
+  EventObserver,
+} from '@cfpb/cfpb-atomic-component';
+
+const BASE_CLASS = 'o-summary-minimal';
+
+/**
+ * SummaryMinimal
+ *
+ * @class
+ * @classdesc Initializes a new Summary organism.
+ * @param {HTMLElement} element - The DOM element within which to search
+ *   for the organism.
+ * @returns {Summary} An instance.
+ */
+function SummaryMinimal(element) {
+  const _dom = checkDom(element, BASE_CLASS);
+  const _contentDom = _dom.querySelector(`.${BASE_CLASS}_content`);
+  const _btnDom = _dom.querySelector(`.${BASE_CLASS}_btn`);
+  let _transition;
+  let _flyout;
+
+  /**
+   * @returns {Summary} An instance.
+   */
+  function init() {
+    if (!setInitFlag(_dom)) {
+      return this;
+    }
+
+    // Add FlyoutMenu behavior data-js-hooks.
+    addDataHook(_dom, 'behavior_flyout-menu');
+    addDataHook(_contentDom, 'behavior_flyout-menu_content');
+    addDataHook(_btnDom, 'behavior_flyout-menu_trigger');
+
+    // Don't initialize the Summary till the page has loaded, so we can have
+    // an accurate idea of its height.
+    window.addEventListener('load', _pageLoadHandler);
+
+    return this;
+  }
+
+  /**
+   * The page (content + CSS) has loaded.
+   */
+  function _pageLoadHandler() {
+    window.removeEventListener('load', _pageLoadHandler);
+
+    _flyout = new FlyoutMenu(_dom, false);
+    _transition = new MaxHeightTransition(_contentDom);
+    _transition.init(MaxHeightTransition.CLASSES.MH_SUMMARY);
+    _flyout.setTransition(
+      _transition,
+      _transition.maxHeightSummary,
+      _transition.maxHeightDefault
+    );
+    _flyout.init();
+
+    _dom.addEventListener('focusin', _focusInHandler);
+
+    /* When we click inside the content area we may be changing the size,
+       such as when a video player expands on being clicked.
+       So, let's refresh the transition to recalculate the max-height,
+       just in case. */
+    _contentDom.addEventListener('click', _contentClicked);
+
+    _flyout.collapse();
+    _transition.animateOn();
+  }
+
+  /**
+   * Handling tabbing into the content area that is hidden.
+   * If the focus goes onto a focusable element within the content area,
+   * we'll act like the summary expansion button was clicked.
+   *
+   * @param {Event} evt - The focus event.
+   */
+  function _focusInHandler(evt) {
+    if (evt.target !== _btnDom) {
+      _btnDom.click();
+      _dom.removeEventListener('focusin', _focusInHandler);
+    }
+  }
+
+  /**
+   * Handler for when the content area is clicked.
+   * Refresh the transition to recalculate the max-height.
+   *
+   * @param {MouseEvent} evt - the mouse event object.
+   */
+  function _contentClicked(evt) {
+    /* We don't need to refresh if a link was clicked as we'll be navigating
+       to another page. */
+    if (evt.target.tagName !== 'A' && _flyout.isExpanded()) {
+      _transition.refresh();
+    }
+  }
+
+  // Attach public events.
+  const eventObserver = new EventObserver();
+  this.addEventListener = eventObserver.addEventListener;
+  this.removeEventListener = eventObserver.removeEventListener;
+  this.dispatchEvent = eventObserver.dispatchEvent;
+
+  this.init = init;
+
+  return this;
+}
+
+SummaryMinimal.BASE_CLASS = BASE_CLASS;
+SummaryMinimal.init = (scope) =>
+  instantiateAll(`.${BASE_CLASS}`, SummaryMinimal, scope);
+
+export { SummaryMinimal };

--- a/packages/cfpb-expandables/src/cfpb-expandables.less
+++ b/packages/cfpb-expandables/src/cfpb-expandables.less
@@ -1,3 +1,4 @@
 // Import external dependencies
 @import (less) './expandable.less';
 @import (less) './summary.less';
+@import (less) './summary-minimal.less';

--- a/packages/cfpb-expandables/src/index.js
+++ b/packages/cfpb-expandables/src/index.js
@@ -6,3 +6,4 @@
 export { Expandable } from './Expandable.js';
 export { ExpandableGroup } from './ExpandableGroup.js';
 export { Summary } from './Summary.js';
+export { SummaryMinimal } from './SummaryMinimal.js';

--- a/packages/cfpb-expandables/src/summary-minimal.less
+++ b/packages/cfpb-expandables/src/summary-minimal.less
@@ -1,0 +1,88 @@
+@import (reference) '@cfpb/cfpb-core/src/cfpb-core.less';
+
+/* topdoc
+  name: Summary Minimal
+  family: cf-organisms
+  notes:
+    - "Styles a two-way Expandable-like organism that previews content."
+  patterns:
+  - name: Summary Minimal organism
+    markup: |
+      <div class="o-summary-minimal">
+          <div class="o-summary_content">
+               Content
+          </div>
+          <button class="o-summary_btn">
+            <span class="o-summary-minimal_cue-open">
+                Show full list of relevant parties
+                {% include icons/plus-round.svg %}
+            </span>
+            <span class="o-summary-minimal_cue-close">
+                Hide full list of relevant parties
+                {% include icons/minus-round.svg %}
+            </span>
+          </button>
+      </div>
+    codenotes:
+      - |
+        Pattern structure
+        -----------------
+        .o-summary-minimal
+          .o-summary-minimal_content
+          .o-summary-minimal_btn
+            .o-summary-minimal_cue-open
+            .o-summary-minimal_cue-close
+
+    notes:
+      - "Two-way expandable. Displays an approximately 4-line
+         preview of content."
+  tags:
+  - cf-organisms
+*/
+
+.o-summary-minimal {
+  &_content {
+    overflow-y: hidden;
+
+    // Move the bounding box 2 pixels to avoid clipping link focus boxes.
+    padding: 2px;
+    left: -2px;
+    top: -2px;
+
+    position: relative;
+  }
+
+  &_btn {
+    // Hide button in no-js state.
+    .no-js & {
+      display: none;
+    }
+
+    margin-top: 5px;
+    padding-left: 0;
+    padding-right: 0;
+    display: block;
+    border: none;
+    background: none;
+    text-align: left;
+    color: @pacific;
+
+    &:focus {
+      outline: 1px dotted @pacific;
+      outline-offset: 2px;
+    }
+
+    .o-summary-minimal_cue-close,
+    .o-summary-minimal_cue-open {
+      display: none;
+    }
+
+    &[aria-expanded='false'] .o-summary-minimal_cue-open {
+      display: block;
+    }
+
+    &[aria-expanded='true'] .o-summary-minimal_cue-close {
+      display: block;
+    }
+  }
+}

--- a/packages/cfpb-expandables/src/summary-minimal.less
+++ b/packages/cfpb-expandables/src/summary-minimal.less
@@ -14,11 +14,11 @@
           </div>
           <button class="o-summary_btn">
             <span class="o-summary-minimal_cue-open">
-                Show full list of relevant parties
+                Show
                 {% include icons/plus-round.svg %}
             </span>
             <span class="o-summary-minimal_cue-close">
-                Hide full list of relevant parties
+                Hide
                 {% include icons/minus-round.svg %}
             </span>
           </button>

--- a/packages/cfpb-expandables/src/summary.less
+++ b/packages/cfpb-expandables/src/summary.less
@@ -8,14 +8,11 @@
   patterns:
   - name: Summary Mobile organism
     markup: |
-      <div class="o-summary o-summary__mobile"
-           data-js-hook="behavior_flyout-menu">
-          <div class="o-summary_content"
-               data-js-hook="behavior_flyout-menu_content">
+      <div class="o-summary o-summary__mobile">
+          <div class="o-summary_content">
                Content
           </div>
-          <button class="o-summary_btn u-hidden"
-                  data-js-hook="behavior_flyout-menu_trigger">
+          <button class="o-summary_btn u-hidden">
             Read full description
           </button>
       </div>


### PR DESCRIPTION
This component is used in the prepaid credit card database, see https://www.consumerfinance.gov/data-research/prepaid-accounts/search-agreements/detail/171172/

It has an existing issue where it appears to have been authored with the intention of having a summary, but it actually doesn't. See [GHE]/CFGOV/platform/issues/3980

## Additions

- Add Summary Minimal component

## Testing

1. Visit https://deploy-preview-1634--cfpb-design-system.netlify.app/design-system/components/summaries and view the summary at the bottom of the page.

## Screenshots

<img width="825" alt="Screen Shot 2023-04-19 at 8 37 56 PM" src="https://user-images.githubusercontent.com/704760/233228225-e6f28635-f295-42b2-977e-e1d17b7fb1ba.png">

<img width="826" alt="Screen Shot 2023-04-19 at 8 38 03 PM" src="https://user-images.githubusercontent.com/704760/233228228-b3073b03-6dc5-4ef1-86f9-de0c18ef0ced.png">
