### PR TITLE
Remove o-expandable_target, o-expandable_header-left, o-expandable_header-right CSS classes

### DIFF
--- a/docs/pages/expandables.md
+++ b/docs/pages/expandables.md
@@ -12,7 +12,7 @@ variation_groups:
                       o-expandable__padded
                       o-expandable__background
                       o-expandable__border">
-              <button class="o-expandable_header o-expandable_target"
+              <button class="o-expandable_header"
                       title="Expand content">
                   <h3 class="h4 o-expandable_label">
                       Expandable Header
@@ -79,7 +79,7 @@ variation_groups:
 
           ```
 
-          const element = document.querySelector( '.o-expandable_target' );
+          const element = document.querySelector( '.o-expandable_header' );
 
           expandables[0].toggleTargetState( element );
 
@@ -117,7 +117,7 @@ variation_groups:
                       o-expandable__background
                       o-expandable__border
                       o-expandable__onload-open">
-              <button class="o-expandable_header o-expandable_target"
+              <button class="o-expandable_header"
                       title="Expand content">
                   <h3 class="h4 o-expandable_label">
                       Expandable Header
@@ -157,7 +157,7 @@ variation_groups:
       - variation_code_snippet: >-
           <div class="o-expandable-group">
               <div class="o-expandable o-expandable__padded">
-                  <button class="o-expandable_header o-expandable_target"
+                  <button class="o-expandable_header"
                           title="Expand content">
                       <h3 class="h4 o-expandable_label">
                           Expandable Header 1
@@ -183,7 +183,7 @@ variation_groups:
                   </div>
               </div>
               <div class="o-expandable o-expandable__padded">
-                  <button class="o-expandable_header o-expandable_target"
+                  <button class="o-expandable_header"
                           title="Expand content">
                       <h3 class="h4 o-expandable_label">
                           Expandable Header 2
@@ -209,7 +209,7 @@ variation_groups:
                   </div>
               </div>
               <div class="o-expandable o-expandable__padded">
-                  <button class="o-expandable_header o-expandable_target"
+                  <button class="o-expandable_header"
                           title="Expand content">
                       <h3 class="h4 o-expandable_label">
                           Expandable Header 3
@@ -276,7 +276,7 @@ variation_groups:
       - variation_code_snippet: >-
           <div class="o-expandable-group o-expandable-group__accordion">
               <div class="o-expandable o-expandable__padded">
-                  <button class="o-expandable_header o-expandable_target"
+                  <button class="o-expandable_header"
                           title="Expand content">
                       <h3 class="h4 o-expandable_label">
                           Expandable Header 1
@@ -302,7 +302,7 @@ variation_groups:
                   </div>
               </div>
               <div class="o-expandable o-expandable__padded">
-                  <button class="o-expandable_header o-expandable_target"
+                  <button class="o-expandable_header"
                           title="Expand content">
                       <h3 class="h4 o-expandable_label">
                           Expandable Header 2
@@ -364,7 +364,7 @@ variation_groups:
                   </div>
               </div>
               <div class="o-expandable o-expandable__padded">
-                  <button class="o-expandable_header o-expandable_target"
+                  <button class="o-expandable_header"
                           title="Expand content">
                       <h3 class="h4 o-expandable_label">
                           Expandable Header 3
@@ -462,7 +462,7 @@ research: >-
   var elem = {{element}};
 
 
-  var closestElem = closest(elem, '.o-expandable_target');
+  var closestElem = closest(elem, '.o-expandable_header');
 
   var textElem = closestElem.querySelector('.o-expandable_label');
 
@@ -480,7 +480,7 @@ research: >-
 
   var elem = {{element}};
 
-  var closestElem = closest(elem, '.expandable_target');
+  var closestElem = closest(elem, '.expandable_header');
 
   var text = closestElem.querySelector('.expandable_label').textContent.trim();
 

--- a/docs/pages/filterable-list-control-panels.md
+++ b/docs/pages/filterable-list-control-panels.md
@@ -17,7 +17,7 @@ variation_groups:
                   o-expandable__background
                   o-expandable__border
                   o-expandable__onload-open">
-                  <button class="o-expandable_header o-expandable_target" type="button">
+                  <button class="o-expandable_header" type="button">
                       <span class="h4 o-expandable_label">
                       Filter posts
                       </span>

--- a/docs/special-pages/updating-this-website.md
+++ b/docs/special-pages/updating-this-website.md
@@ -32,7 +32,7 @@ description: >-
 
   <div class="o-expandable-group o-expandable-group__accordion">
       <div class="o-expandable o-expandable__padded">
-          <button class="o-expandable_header o-expandable_target"
+          <button class="o-expandable_header"
                   title="Expand content">
               <h3 class="h4 o-expandable_label">
                   Step 1. Click a page's "Edit this page" pencil icon.
@@ -56,7 +56,7 @@ description: >-
           </div>
       </div>
       <div class="o-expandable o-expandable__padded">
-          <button class="o-expandable_header o-expandable_target"
+          <button class="o-expandable_header"
                   title="Expand content">
               <h3 class="h4 o-expandable_label">
                   Step 2. Log into the CMS
@@ -83,7 +83,7 @@ description: >-
           </div>
       </div>
       <div class="o-expandable o-expandable__padded">
-          <button class="o-expandable_header o-expandable_target"
+          <button class="o-expandable_header"
                   title="Expand content">
               <h3 class="h4 o-expandable_label">
                   Step 3. Edit a page's content
@@ -107,7 +107,7 @@ description: >-
           </div>
       </div>
       <div class="o-expandable o-expandable__padded">
-          <button class="o-expandable_header o-expandable_target"
+          <button class="o-expandable_header"
                   title="Expand content">
               <h3 class="h4 o-expandable_label">
                   Step 4. Save your changes
@@ -136,7 +136,7 @@ description: >-
           </div>
       </div>
       <div class="o-expandable o-expandable__padded">
-          <button class="o-expandable_header o-expandable_target"
+          <button class="o-expandable_header"
                   title="Expand content">
               <h3 class="h4 o-expandable_label">
                   Step 5. Preview your changes
@@ -163,7 +163,7 @@ description: >-
           </div>
       </div>
       <div class="o-expandable o-expandable__padded">
-          <button class="o-expandable_header o-expandable_target"
+          <button class="o-expandable_header"
                   title="Expand content">
               <h3 class="h4 o-expandable_label">
                   Step 6. Publish your changes

--- a/packages/cfpb-expandables/src/Expandable.js
+++ b/packages/cfpb-expandables/src/Expandable.js
@@ -44,7 +44,7 @@ function Expandable(element) {
       return this;
     }
 
-    _targetDom = _dom.querySelector(`.${BASE_CLASS}_target`);
+    _targetDom = _dom.querySelector(`.${BASE_CLASS}_header`);
     _contentDom = _dom.querySelector(`.${BASE_CLASS}_content`);
     _labelDom = _dom.querySelector(`.${BASE_CLASS}_label`);
 

--- a/packages/cfpb-expandables/src/expandable.less
+++ b/packages/cfpb-expandables/src/expandable.less
@@ -18,7 +18,7 @@
 .o-expandable {
   position: relative;
 
-  &_target {
+  &_header {
     padding: 0;
     border: 0;
     background-color: transparent;
@@ -145,8 +145,8 @@
 
   .respond-to-print( {
     // Hide the interactive expandable cues when printing
-    &_target[aria-expanded='true'] &_cue-close,
-    &_target[aria-expanded='false'] &_cue-open {
+    &_header[aria-expanded='true'] &_cue-close,
+    &_header[aria-expanded='false'] &_cue-open {
       display: none;
     }
 

--- a/packages/cfpb-expandables/usage.md
+++ b/packages/cfpb-expandables/usage.md
@@ -80,31 +80,6 @@ _Note: only use this in the expandable header_
 </span>
 ```
 
-### Header elements
-
-These additional elements are useful for more complicated expandables that need
-to convey more information than just 'Show/Hide' before the user expands it.
-
-#### Header
-
-Creates a full-width container to house information that is always visible.
-
-Combine `.o-expandable_header` with `.o-expandable_target` for a full-width
-trigger.
-
-```
-.o-expandable_header
-```
-
-#### Header left/right
-
-Allows you to float information left and right.
-
-```
-.o-expandable_header-left
-.o-expandable_header-right
-```
-
 ## Recommended expandable pattern
 
 Expandables can be built by combining the basic barebones structure described
@@ -119,7 +94,7 @@ The following combination is our recommended go-to expandable pattern.
             o-expandable__padded
             o-expandable__background
             o-expandable__border">
-    <button class="o-expandable_header o-expandable_target"
+    <button class="o-expandable_header"
             title="Expand content">
         <h3 class="h4 o-expandable_label">
             Expandable Header
@@ -149,7 +124,7 @@ The following combination is our recommended go-to expandable pattern.
             o-expandable__padded
             o-expandable__background
             o-expandable__border">
-    <button class="o-expandable_header o-expandable_target"
+    <button class="o-expandable_header"
             title="Expand content">
         <h3 class="h4 o-expandable_label">
             Expandable Header
@@ -182,7 +157,7 @@ The following combination is our recommended go-to expandable pattern.
             o-expandable__background
             o-expandable__border
             o-expandable__onload-open">
-    <button class="o-expandable_header o-expandable_target"
+    <button class="o-expandable_header"
             title="Expand content">
         <h3 class="h4 o-expandable_label">
             Expandable Header
@@ -213,7 +188,7 @@ The following combination is our recommended go-to expandable pattern.
             o-expandable__background
             o-expandable__border
             o-expandable__onload-open">
-    <button class="o-expandable_header o-expandable_target"
+    <button class="o-expandable_header"
             title="Expand content">
         <h3 class="h4 o-expandable_label">
             Expandable Header
@@ -247,7 +222,7 @@ Should you need an expandable thing that is not covered by the expandables above
 
 <div class="o-expandable-group">
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target"
+        <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
                 Expandable Header 1
@@ -272,7 +247,7 @@ Should you need an expandable thing that is not covered by the expandables above
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target"
+        <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
                 Expandable Header 2
@@ -297,7 +272,7 @@ Should you need an expandable thing that is not covered by the expandables above
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target"
+        <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
                 Expandable Header 3
@@ -326,7 +301,7 @@ Should you need an expandable thing that is not covered by the expandables above
 ```
 <div class="o-expandable-group">
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target"
+        <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
                 Expandable Header 1
@@ -351,7 +326,7 @@ Should you need an expandable thing that is not covered by the expandables above
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target"
+        <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
                 Expandable Header 2
@@ -376,7 +351,7 @@ Should you need an expandable thing that is not covered by the expandables above
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target"
+        <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
                 Expandable Header 3
@@ -411,7 +386,7 @@ to activate the accordion mode.
 
 <div class="o-expandable-group o-expandable-group__accordion">
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target"
+        <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
                 Expandable Header 1
@@ -436,7 +411,7 @@ to activate the accordion mode.
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target"
+        <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
                 Expandable Header 2
@@ -461,7 +436,7 @@ to activate the accordion mode.
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target"
+        <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
                 Expandable Header 3
@@ -490,7 +465,7 @@ to activate the accordion mode.
 ```
 <div class="o-expandable-group o-expandable-group__accordion">
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target"
+        <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
                 Expandable Header 1
@@ -515,7 +490,7 @@ to activate the accordion mode.
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target"
+        <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
                 Expandable Header 2
@@ -540,7 +515,7 @@ to activate the accordion mode.
         </div>
     </div>
     <div class="o-expandable o-expandable__padded">
-        <button class="o-expandable_header o-expandable_target"
+        <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
                 Expandable Header 3
@@ -573,18 +548,37 @@ A new array of Expandable instances can be created with
 `const expandables = Expandable.init();`.
 Each instance has the following methods for public consumption:
 
-### toggleTargetState( element )
+### expand()
 
 ```js
-const element = document.querySelector('.o-expandable_target');
-expandables[0].toggleTargetState(element);
+expandables[0].expand();
 ```
 
-Toggle an expandable to open or closed.
+Expand the expandable open.
 
-Parameters:
+### collapse()
 
-- element {HTMLElement} The expandable target HTML DOM element.
+```js
+expandables[0].collapse();
+```
+
+Collapse the expandable closed.
+
+### isExpanded()
+
+```js
+expandables[0].isExpanded();
+```
+
+Whether the expandable is open or closed.
+
+### refresh()
+
+```js
+expandables[0].refresh();
+```
+
+Refresh the height of the expandable when the internal content height changes.
 
 ### getLabelText()
 

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/atomic-helpers.spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/atomic-helpers.spec.js
@@ -10,9 +10,9 @@ let componentDom;
 const testClass = 'o-footer';
 const HTML_SNIPPET = `
   <div class="o-expandable o-expandable__padded" id="test-subject-two">
-      <button class="o-expandable_header o-expandable_target"
+      <button class="o-expandable_header"
               title="Expand content">
-          <span class="o-expandable_header-left o-expandable_label">
+          <span class="o-expandable_label">
               Expandable Header 3
           </span>
           <span class="o-expandable_link">

--- a/test/unit-test/src/cfpb-expandables/src/Expandable.spec.js
+++ b/test/unit-test/src/cfpb-expandables/src/Expandable.spec.js
@@ -9,7 +9,7 @@ const HTML_SNIPPET = `
      id="test-group-one">
 
     <div class="o-expandable o-expandable__padded" id="test-subject-one">
-        <button class="o-expandable_header o-expandable_target"
+        <button class="o-expandable_header"
                 title="Expand content">
             <span class="o-expandable_label">
                 Expandable Header 1
@@ -35,7 +35,7 @@ const HTML_SNIPPET = `
     </div>
 
     <div class="o-expandable o-expandable__padded" id="test-subject-two">
-        <button class="o-expandable_header o-expandable_target"
+        <button class="o-expandable_header"
                 title="Expand content">
             <span class="o-expandable_label">
                 Expandable Header 2
@@ -62,9 +62,9 @@ const HTML_SNIPPET = `
 </div>
 
 <div class="o-expandable o-expandable__padded" id="test-subject-two">
-    <button class="o-expandable_header o-expandable_target"
+    <button class="o-expandable_header"
             title="Expand content">
-        <span class="o-expandable_header-left o-expandable_label">
+        <span class="o-expandable_label">
             Expandable Header 3
         </span>
         <span class="o-expandable_link">
@@ -102,8 +102,8 @@ describe('standard Expandable', () => {
     document.body.innerHTML = HTML_SNIPPET;
     expandableDom1 = document.querySelector('#test-subject-one');
     expandableDom2 = document.querySelector('#test-subject-two');
-    targetDom1 = expandableDom1.querySelector('.o-expandable_target');
-    targetDom2 = expandableDom2.querySelector('.o-expandable_target');
+    targetDom1 = expandableDom1.querySelector('.o-expandable_header');
+    targetDom2 = expandableDom2.querySelector('.o-expandable_header');
     contentDom1 = expandableDom1.querySelector('.o-expandable_content');
     contentDom2 = expandableDom2.querySelector('.o-expandable_content');
     expandableDom2.classList.add('o-expandable__onload-open');
@@ -178,8 +178,8 @@ describe('accordion Expandables', () => {
     expandableDom2 = document.querySelector('#test-subject-two');
     contentDom1 = expandableDom1.querySelector('.o-expandable_content');
     contentDom2 = expandableDom2.querySelector('.o-expandable_content');
-    targetDom1 = expandableDom1.querySelector('.o-expandable_target');
-    targetDom2 = expandableDom2.querySelector('.o-expandable_target');
+    targetDom1 = expandableDom1.querySelector('.o-expandable_header');
+    targetDom2 = expandableDom2.querySelector('.o-expandable_header');
 
     ExpandableGroup.init();
     expandable = Expandable.init()[1];


### PR DESCRIPTION
At one point there was a subtle difference between having `o-expandable_header` and `o-expandable_target`. However, in practice we appear to always use them together, so there is no point in having two separate classes.

Also, the `o-expandable_header-left` and `o-expandable_header-right` appears to be no longer implemented. 

## Removals

- Remove `o-expandable_target`.
- Remove `o-expandable_header-left`.
- Remove `o-expandable_header-right`.

## Changes

- Updates docs.

## Testing

1. PR checks should pass.
