### PR TITLE
cfpb-expandables: Consolidate `o-expandable_header` rules

### DIFF
--- a/packages/cfpb-expandables/src/expandable.less
+++ b/packages/cfpb-expandables/src/expandable.less
@@ -18,7 +18,13 @@
 .o-expandable {
   position: relative;
 
+  //
+  // Header
+  //
+
   &_header {
+    display: flex;
+    justify-content: space-between;
     padding: 0;
     border: 0;
     background-color: transparent;
@@ -41,6 +47,18 @@
     &[aria-expanded='true'] .o-expandable_cue-close {
       display: block;
     }
+
+    // Using the button element with .o-expandable_header requires setting
+    // an explicit width.
+    button& {
+      width: 100%;
+      text-align: left;
+    }
+
+    .o-expandable_label {
+      // Grow to available width.
+      flex-grow: 1;
+    }
   }
 
   //
@@ -60,27 +78,6 @@
     color: @pacific;
     font-size: unit((@btn-font-size / @base-font-size-px), em);
     line-height: unit((@base-line-height-px / @btn-font-size));
-  }
-
-  //
-  // Header
-  //
-
-  &_header {
-    display: flex;
-    justify-content: space-between;
-
-    // Using the button element with .o-expandable_header requires setting
-    // an explicit width.
-    button& {
-      width: 100%;
-      text-align: left;
-    }
-
-    .o-expandable_label {
-      // Grow to available width.
-      flex-grow: 1;
-    }
   }
 
   //


### PR DESCRIPTION
There are two `o-expandable_header` rules that can be combined. This is a consequence of `o-expandable_target` being removed in https://github.com/cfpb/design-system/pull/1635

## Changes

- Consolidate `o-expandable_header` rules

## Testing

1. PR checks should pass. Expandables in PR preview should be unchanged.
