### PR TITLE
cfpb-core: Pulls in js-is-hidden utility from cf.gov

### DIFF
--- a/packages/cfpb-core/src/utilities.less
+++ b/packages/cfpb-core/src/utilities.less
@@ -18,7 +18,7 @@
 // And show it when JS is off
 //
 
-.js-is-hidden {
+.u-js-is-hidden {
   display: none !important;
   .no-js & {
     display: block !important;

--- a/packages/cfpb-core/src/utilities.less
+++ b/packages/cfpb-core/src/utilities.less
@@ -14,6 +14,18 @@
 }
 
 //
+// To hide an element when JS is on
+// And show it when JS is off
+//
+
+.js-is-hidden {
+  display: none !important;
+  .no-js & {
+    display: block !important;
+  }
+}
+
+//
 // Clearfix
 //
 

--- a/packages/cfpb-core/src/utilities.less
+++ b/packages/cfpb-core/src/utilities.less
@@ -18,7 +18,7 @@
 // And show it when JS is off
 //
 
-.u-js-is-hidden {
+.u-hide-if-js {
   display: none !important;
   .no-js & {
     display: block !important;


### PR DESCRIPTION
We have a utility for showing elements when js is enabled (`.u-js-only`) but the opposite utility [lives in cf.gov](https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/css/enhancements/utilities.less#L116-L121). This is silly!

I've brought the `.js-is-hidden` utility over here and renamed it to `.u-hide-if-js`, which seems clearer.