### PR TITLE
cfpb-forms: Add relative position to fieldset | fix/add some comments

### DIFF
--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -50,7 +50,7 @@ function Multiselect(element) {
   let _model;
   let _options;
 
-  // Markup elems, conver this to templating engine in the future.
+  // Markup elems, convert this to templating engine in the future.
   let _containerDom;
   let _selectionsDom;
   let _headerDom;
@@ -162,8 +162,8 @@ function Multiselect(element) {
 
   /**
    * Highlights an option in the list.
-   * @param {string} direction - Direction to highlight compared to the
-   *                           current focus.
+   * @param {string} direction
+   *   Direction to highlight compared to the current focus.
    */
   function _highlight(direction) {
     if (direction === DIR_NEXT) {

--- a/packages/cfpb-forms/src/organisms/multiselect.less
+++ b/packages/cfpb-forms/src/organisms/multiselect.less
@@ -67,6 +67,7 @@ select.o-multiselect {
     padding: 0;
 
     // Styles
+    position: relative;
     box-sizing: border-box;
     overflow-x: hidden;
     overflow-y: scroll;
@@ -89,6 +90,8 @@ select.o-multiselect {
   &.u-active {
     .o-multiselect_fieldset {
       margin-top: 0;
+      // This needs to match the value set in _bindEvents in Multiselect.js.
+      // See https://github.com/cfpb/design-system/blob/4d26d5af04317bcc00b4677aa866fe8d526e82e0/packages/cfpb-forms/src/organisms/Multiselect.js#L340
       max-height: 140px;
 
       border-color: @pacific;


### PR DESCRIPTION
When inside a filterable control, the multiselect was being cropped. Adding `position: relative` to the fieldset fixes this bug.

## Additions

- Add `position: relative` to the fieldset.

## Changes

- Fix/add some code comment formatting and typo.

## Testing

1. The difference to this won't be apparent till its in cfgov, but you can manually add `position:relative` to the multiselect fieldset in https://www.consumerfinance.gov/data-research/cfpb-researchers/
