### PR TITLE
Update deprecated Event.init to actual Event creation

### DIFF
--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -409,8 +409,7 @@ function Multiselect(element) {
         so we need to manually create an event and dispatch it from the input.
         */
         target.checked = !checked;
-        const evt = document.createEvent('HTMLEvents');
-        evt.initEvent('change', false, true);
+        const evt = new Event('change', { bubbles: false, cancelable: true });
         target.dispatchEvent(evt);
       } else if (key === KEY_ESCAPE) {
         _searchDom.focus();

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/behavior/FlyoutMenu.spec.js
@@ -84,11 +84,10 @@ describe('FlyoutMenu', () => {
     });
 
     it('should dispatch events when called by trigger click', () => {
-      /* TODO: Ideally this would use `new MouseEvent`,
-         but how do we import MouseEvent (or Event) into Jest.
-         Please investigate. */
-      const mouseEvent = document.createEvent('MouseEvents');
-      mouseEvent.initEvent('mouseover', true, true);
+      const mouseEvent = new MouseEvent('mouseover', {
+        bubbles: true,
+        cancelable: true,
+      });
       triggerDom.dispatchEvent(mouseEvent);
       triggerDom.click();
 
@@ -102,8 +101,10 @@ describe('FlyoutMenu', () => {
     });
 
     it('should dispatch events when called by alt trigger click', () => {
-      const mouseEvent = document.createEvent('MouseEvents');
-      mouseEvent.initEvent('mouseover', true, true);
+      const mouseEvent = new MouseEvent('mouseover', {
+        bubbles: true,
+        cancelable: true,
+      });
       altTriggerDom.dispatchEvent(mouseEvent);
       altTriggerDom.click();
 

--- a/test/util/simulate-event.js
+++ b/test/util/simulate-event.js
@@ -7,20 +7,34 @@
 function simulateEvent(eventType, target, eventOption = {}) {
   let event;
 
-  if (eventType === 'click') {
-    event = new MouseEvent('click', {
-      bubbles: true,
-      cancelable: true,
-      view: window,
-    });
-    // TODO: migrate to KeyBoardEvent, etc.
-  } else {
-    event = window.document.createEvent('Event', eventOption.currentTarget);
-    event.initEvent(eventType, true, true);
+  // Add more event types here as required by tests.
+  switch (eventType) {
+    case 'click' || 'mousedown' || 'mouseup':
+      event = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      });
+      break;
+    case 'keypress' || 'keydown' || 'keyup':
+      event = new KeyboardEvent(eventType, {
+        bubbles: true,
+        cancelable: true,
+      });
 
-    if (eventOption && eventOption.key) {
-      event.key = eventOption.key;
-    }
+      if (eventOption && eventOption.key) {
+        event.key = eventOption.key;
+      }
+      break;
+    default:
+      event = new Event(eventType, {
+        bubbles: true,
+        cancelable: true,
+      });
+
+      if (eventOption && eventOption.key) {
+        event.key = eventOption.key;
+      }
   }
 
   return target.dispatchEvent(event);


### PR DESCRIPTION
Event.init is deprecated and actual events should be created instead.

## Changes

- Update deprecated Event.init to actual Event creation.

## Testing

1. `yarn jest` should pass. 
2. Selecting five items in the multiselect should show the max selections message.