### PR TITLE
Fix simulate-event helper

### DIFF
--- a/test/util/simulate-event.js
+++ b/test/util/simulate-event.js
@@ -21,24 +21,23 @@ function simulateEvent(eventType, target, eventOption = {}) {
     case 'keypress':
     case 'keydown':
     case 'keyup':
-      event = new KeyboardEvent(eventType, {
+      const opts = {
         bubbles: true,
         cancelable: true,
-      });
+      };
 
       if (eventOption && eventOption.key) {
-        event.key = eventOption.key;
+        opts.key = eventOption.key;
       }
+
+      event = new KeyboardEvent(eventType, opts);
+
       break;
     default:
       event = new Event(eventType, {
         bubbles: true,
         cancelable: true,
       });
-
-      if (eventOption && eventOption.key) {
-        event.key = eventOption.key;
-      }
   }
 
   return target.dispatchEvent(event);


### PR DESCRIPTION
This helper wasn't able to set the `key` value on the event after KeyboardEvent instantiation, but it can at the time of instantiation. This PR fixes that.

## Testing

1. PR checks should pass.
