### PR TITLE
cfpb-icons: RTL certain icons

### DIFF
--- a/docs/pages/iconography.md
+++ b/docs/pages/iconography.md
@@ -27,30 +27,34 @@ variation_groups:
           - [Web application icons](#web-application-icons)
 
 
+          The RTL (right-to-left) column designates whether an icon will flip
+          on pages where the HTML element has its language set to an RTL-reading
+          language, such as arabic.
+
           ### Navigation icons
 
 
-          | icon | icon-round | canonical name | aliases (for searchability only)  |
+          | icon | icon-round | canonical name | aliases (for searchability only) | RTL? |
 
-          | ---- | ---------- | -------------- | ------- |
+          | ---- | ---------- | -------------- | ------- | ------ |
 
-          | {% include icons/up.svg %} | {% include icons/up-round.svg %} | up | chevron-up |
+          | {% include icons/up.svg %} | {% include icons/up-round.svg %} | up | chevron-up | |
 
-          | {% include icons/right.svg %} | {% include icons/right-round.svg %} | right | chevron-right |
+          | {% include icons/right.svg %} | {% include icons/right-round.svg %} | right | chevron-right | ✓ |
 
           | {% include icons/down.svg %} | {% include icons/down-round.svg %} | down | chevron-down |
 
-          | {% include icons/left.svg %} | {% include icons/left-round.svg %} | left | chevron-left |
+          | {% include icons/left.svg %} | {% include icons/left-round.svg %} | left | chevron-left | ✓ |
 
-          | {% include icons/arrow-up.svg %} | {% include icons/arrow-up-round.svg %} | arrow-up |  |
+          | {% include icons/arrow-up.svg %} | {% include icons/arrow-up-round.svg %} | arrow-up | | |
 
-          | {% include icons/arrow-right.svg %} | {% include icons/arrow-right-round.svg %} | arrow-right |  |
+          | {% include icons/arrow-right.svg %} | {% include icons/arrow-right-round.svg %} | arrow-right | | ✓ |
 
-          | {% include icons/arrow-down.svg %} | {% include icons/arrow-down-round.svg %} | arrow-down |  |
+          | {% include icons/arrow-down.svg %} | {% include icons/arrow-down-round.svg %} | arrow-down | | |
 
-          | {% include icons/arrow-left.svg %} | {% include icons/arrow-left-round.svg %} | arrow-left |  |
+          | {% include icons/arrow-left.svg %} | {% include icons/arrow-left-round.svg %} | arrow-left | | ✓ |
 
-          | {% include icons/left-right.svg %} | {% include icons/left-right-round.svg %} | left-right | horizontal |
+          | {% include icons/left-right.svg %} | {% include icons/left-right-round.svg %} | left-right | horizontal | |
 
           | {% include icons/up-down.svg %} | {% include icons/up-down-round.svg %} | up-down | vertical |
 
@@ -60,35 +64,35 @@ variation_groups:
           ### Status icons
 
 
-          | icon | icon-round | canonical name | aliases (for searchability only)  |
+          | icon | icon-round | canonical name | aliases (for searchability only) | RTL? |
 
-          | ---- | ---------- | -------------- | ------- |
+          | ---- | ---------- | -------------- | ------- | ------ |
 
-          | {% include icons/approved.svg %} | {% include icons/approved-round.svg %} | approved | check, checkmark, success |
+          | {% include icons/approved.svg %} | {% include icons/approved-round.svg %} | approved | check, checkmark, success | |
 
-          | {% include icons/error.svg %} | {% include icons/error-round.svg %} | error | delete, close, remove, multiply, multiplication, x |
+          | {% include icons/error.svg %} | {% include icons/error-round.svg %} | error | delete, close, remove, multiply, multiplication, x | |
 
-          | {% include icons/warning.svg %} | {% include icons/warning-round.svg %} | warning | alert, exclamation, exclamation-mark |
+          | {% include icons/warning.svg %} | {% include icons/warning-round.svg %} | warning | alert, exclamation, exclamation-mark | |
 
-          | {% include icons/help.svg %} | {% include icons/help-round.svg %} | help | question, question-mark |
+          | {% include icons/help.svg %} | {% include icons/help-round.svg %} | help | question, question-mark | ✓ |
 
-          | {% include icons/update.svg %} | {% include icons/update-round.svg %} | update |
+          | {% include icons/update.svg %} | {% include icons/update-round.svg %} | update | |
 
-          | {% include icons/updating.svg %} | {% include icons/updating-round.svg %} | updating | spinner |
+          | {% include icons/updating.svg %} | {% include icons/updating-round.svg %} | updating | spinner | |
 
-          | {% include icons/power.svg %} | {% include icons/power-round.svg %} | power | on-off |
+          | {% include icons/power.svg %} | {% include icons/power-round.svg %} | power | on-off | |
 
-          | {% include icons/dollar.svg %} | {% include icons/dollar-round.svg %} | dollar | dollar-sign, cost |
+          | {% include icons/dollar.svg %} | {% include icons/dollar-round.svg %} | dollar | dollar-sign, cost | |
 
-          | {% include icons/plus.svg %} | {% include icons/plus-round.svg %} | plus | add, addition, expand, show |
+          | {% include icons/plus.svg %} | {% include icons/plus-round.svg %} | plus | add, addition, expand, show | |
 
-          | {% include icons/minus.svg %} | {% include icons/minus-round.svg %} | minus | subtract, subtraction, collapse, hide |
+          | {% include icons/minus.svg %} | {% include icons/minus-round.svg %} | minus | subtract, subtraction, collapse, hide | |
 
-          | {% include icons/divide.svg %} | {% include icons/divide-round.svg %} | divide | division |
+          | {% include icons/divide.svg %} | {% include icons/divide-round.svg %} | divide | division | |
 
-          | {% include icons/equal.svg %} | {% include icons/equal-round.svg %} | equal | equals |
+          | {% include icons/equal.svg %} | {% include icons/equal-round.svg %} | equal | equals | |
 
-          | {% include icons/percentage.svg %} | {% include icons/percentage-round.svg %} | percentage | percent |
+          | {% include icons/percentage.svg %} | {% include icons/percentage-round.svg %} | percentage | percent | |
 
           {: class="icon-table"}
 
@@ -96,25 +100,25 @@ variation_groups:
           ### Social/sharing icons
 
 
-          | icon | icon-square | canonical name | aliases (for searchability only) |
+          | icon | icon-square | canonical name | aliases (for searchability only) | RTL? |
 
-          | ---- | ----------- | -------------- | ------- |
+          | ---- | ----------- | -------------- | ------- | ------ |
 
-          | {% include icons/email.svg %} | {% include icons/email-square.svg %} | email | envelope, envelope-back |
+          | {% include icons/email.svg %} | {% include icons/email-square.svg %} | email | envelope, envelope-back | |
 
-          | {% include icons/facebook.svg %} | {% include icons/facebook-square.svg %} | facebook |  |
+          | {% include icons/facebook.svg %} | {% include icons/facebook-square.svg %} | facebook | | |
 
-          | {% include icons/flickr.svg %} | {% include icons/flickr-square.svg %} | flickr |  |
+          | {% include icons/flickr.svg %} | {% include icons/flickr-square.svg %} | flickr | | |
 
-          | {% include icons/github.svg %} | {% include icons/github-square.svg %} | github |  |
+          | {% include icons/github.svg %} | {% include icons/github-square.svg %} | github | | |
 
-          | {% include icons/linkedin.svg %} | {% include icons/linkedin-square.svg %} | linkedin |  |
+          | {% include icons/linkedin.svg %} | {% include icons/linkedin-square.svg %} | linkedin | | |
 
-          | {% include icons/pinterest.svg %} | {% include icons/pinterest-square.svg %} | pinterest |  |
+          | {% include icons/pinterest.svg %} | {% include icons/pinterest-square.svg %} | pinterest | | |
 
-          | {% include icons/twitter.svg %} | {% include icons/twitter-square.svg %} | twitter |  |
+          | {% include icons/twitter.svg %} | {% include icons/twitter-square.svg %} | twitter | | |
 
-          | {% include icons/youtube.svg %} | {% include icons/youtube-square.svg %} | youtube |  |
+          | {% include icons/youtube.svg %} | {% include icons/youtube-square.svg %} | youtube | | |
 
           {: class="icon-table"}
 
@@ -122,27 +126,27 @@ variation_groups:
           ### Communications icons
 
 
-          | icon | icon-round | canonical name | aliases (for searchability only)  |
+          | icon | icon-round | canonical name | aliases (for searchability only) | RTL? |
 
-          | ---- | ---------- | -------------- | ------- |
+          | ---- | ---------- | -------------- | ------- | ------ |
 
-          | {% include icons/email.svg %} | {% include icons/email-round.svg %} | email | envelope-back |
+          | {% include icons/email.svg %} | {% include icons/email-round.svg %} | email | envelope-back | |
 
-          | {% include icons/fax.svg %} | {% include icons/fax-round.svg %} | fax | fax-machine |
+          | {% include icons/fax.svg %} | {% include icons/fax-round.svg %} | fax | fax-machine | |
 
-          | {% include icons/mail.svg %} | {% include icons/mail-round.svg %} | mail | envelope-front |
+          | {% include icons/mail.svg %} | {% include icons/mail-round.svg %} | mail | envelope-front | |
 
-          | {% include icons/phone.svg %} | {% include icons/phone-round.svg %} | phone | telephone, handset |
+          | {% include icons/phone.svg %} | {% include icons/phone-round.svg %} | phone | telephone, handset | |
 
-          | {% include icons/photo.svg %} | {% include icons/photo-round.svg %} | photo | photography, camera |
+          | {% include icons/photo.svg %} | {% include icons/photo-round.svg %} | photo | photography, camera | |
 
-          | {% include icons/presentation.svg %} | {% include icons/presentation-round.svg %} | presentation | screen |
+          | {% include icons/presentation.svg %} | {% include icons/presentation-round.svg %} | presentation | screen | |
 
-          | {% include icons/technology.svg %} | {% include icons/technology-round.svg %} | technology | cellphone, tablet |
+          | {% include icons/technology.svg %} | {% include icons/technology-round.svg %} | technology | cellphone, tablet | |
 
-          | {% include icons/video.svg %} | {% include icons/video-round.svg %} | video | movie, camcorder |
+          | {% include icons/video.svg %} | {% include icons/video-round.svg %} | video | movie, camcorder | |
 
-          | {% include icons/web.svg %} | {% include icons/web-round.svg %} | web | globe, world |
+          | {% include icons/web.svg %} | {% include icons/web-round.svg %} | web | globe, world | |
 
           {: class="icon-table"}
 
@@ -150,43 +154,43 @@ variation_groups:
           ### Document icons
 
 
-          | icon | icon-round | canonical name | aliases (for searchability only)  |
+          | icon | icon-round | canonical name | aliases (for searchability only) | RTL? |
 
-          | ---- | ---------- | -------------- | ------- |
+          | ---- | ---------- | -------------- | ------- | ------- |
 
-          | {% include icons/appendix.svg %} | {% include icons/appendix-round.svg %} | appendix |  |
+          | {% include icons/appendix.svg %} | {% include icons/appendix-round.svg %} | appendix | | |
 
-          | {% include icons/book.svg %} | {% include icons/book-round.svg %} | book |  |
+          | {% include icons/book.svg %} | {% include icons/book-round.svg %} | book | | ✓ |
 
-          | {% include icons/copy.svg %} | {% include icons/copy-round.svg %} | copy | duplicate |
+          | {% include icons/copy.svg %} | {% include icons/copy-round.svg %} | copy | duplicate | |
 
-          | {% include icons/document.svg %} | {% include icons/document-round.svg %} | document | doc, pdf, page |
+          | {% include icons/document.svg %} | {% include icons/document-round.svg %} | document | doc, pdf, page | ✓ |
 
-          | {% include icons/download.svg %} | {% include icons/download-round.svg %} | download | document-down |
+          | {% include icons/download.svg %} | {% include icons/download-round.svg %} | download | document-down | |
 
-          | {% include icons/upload.svg %} | {% include icons/upload-round.svg %} | upload | document-up |
+          | {% include icons/upload.svg %} | {% include icons/upload-round.svg %} | upload | document-up | |
 
-          | {% include icons/edit.svg %} | {% include icons/edit-round.svg %} | edit | pencil, write |
+          | {% include icons/edit.svg %} | {% include icons/edit-round.svg %} | edit | pencil, write | ✓ |
 
-          | {% include icons/folder.svg %} | {% include icons/folder-round.svg %} | folder |  |
+          | {% include icons/folder.svg %} | {% include icons/folder-round.svg %} | folder | | |
 
-          | {% include icons/folder-add.svg %} | {% include icons/folder-add-round.svg %} | folder-add | folder-plus |
+          | {% include icons/folder-add.svg %} | {% include icons/folder-add-round.svg %} | folder-add | folder-plus | |
 
-          | {% include icons/folder-delete.svg %} | {% include icons/folder-delete-round.svg %} | folder-delete | folder-remove, folder-x |
+          | {% include icons/folder-delete.svg %} | {% include icons/folder-delete-round.svg %} | folder-delete | folder-remove, folder-x | |
 
-          | {% include icons/folder-empty.svg %} | {% include icons/folder-empty-round.svg %} | folder-empty |  |
+          | {% include icons/folder-empty.svg %} | {% include icons/folder-empty-round.svg %} | folder-empty | | |
 
-          | {% include icons/folder-save.svg %} | {% include icons/folder-save-round.svg %} | folder-save | folder-check |
+          | {% include icons/folder-save.svg %} | {% include icons/folder-save-round.svg %} | folder-save | folder-check | |
 
-          | {% include icons/paper-clip.svg %} | {% include icons/paper-clip-round.svg %} | paper-clip | attach, attachment |
+          | {% include icons/paper-clip.svg %} | {% include icons/paper-clip-round.svg %} | paper-clip | attach, attachment | ✓ |
 
-          | {% include icons/print.svg %} | {% include icons/print-round.svg %} | print | printer |
+          | {% include icons/print.svg %} | {% include icons/print-round.svg %} | print | printer | |
 
-          | {% include icons/rss.svg %} | {% include icons/rss-round.svg %} | rss | feed |
+          | {% include icons/rss.svg %} | {% include icons/rss-round.svg %} | rss | feed | |
 
-          | {% include icons/save.svg %} | {% include icons/save-round.svg %} | save | disk, floppy-disk |
+          | {% include icons/save.svg %} | {% include icons/save-round.svg %} | save | disk, floppy-disk | |
 
-          | {% include icons/supplement.svg %} | {% include icons/supplement-round.svg %} | supplement | add-document, add-page |
+          | {% include icons/supplement.svg %} | {% include icons/supplement-round.svg %} | supplement | add-document, add-page | |
 
           {: class="icon-table"}
 
@@ -194,73 +198,73 @@ variation_groups:
           ### Financial products, services, and concepts
 
 
-          | icon | icon-round | canonical name | aliases (for searchability only)  |
+          | icon | icon-round | canonical name | aliases (for searchability only) | RTL? |
 
-          | ---- | ---------- | -------------- | ------- |
+          | ---- | ---------- | -------------- | ------- | ------ |
 
-          | {% include icons/activity.svg %} | {% include icons/activity-round.svg %} | activity | clipboard |
+          | {% include icons/activity.svg %} | {% include icons/activity-round.svg %} | activity | clipboard | |
 
-          | {% include icons/bank.svg %} | {% include icons/bank-round.svg %} | bank | bank-account |
+          | {% include icons/bank.svg %} | {% include icons/bank-round.svg %} | bank | bank-account | |
 
-          | {% include icons/building-credit.svg %} | {% include icons/building-credit-round.svg %} | building-credit | |
+          | {% include icons/building-credit.svg %} | {% include icons/building-credit-round.svg %} | building-credit | | |
 
-          | {% include icons/calculate.svg %} | {% include icons/calculate-round.svg %} | calculate | calculator |
+          | {% include icons/calculate.svg %} | {% include icons/calculate-round.svg %} | calculate | calculator | |
 
-          | {% include icons/car.svg %} | {% include icons/car-round.svg %} | car | car-loan, auto, auto-loan |
+          | {% include icons/car.svg %} | {% include icons/car-round.svg %} | car | car-loan, auto, auto-loan | |
 
-          | {% include icons/college.svg %} | {% include icons/college-round.svg %} | college | paying-for-college, grad-cap, mortarboard |
+          | {% include icons/college.svg %} | {% include icons/college-round.svg %} | college | paying-for-college, grad-cap, mortarboard | |
 
-          | {% include icons/complaint.svg %} | {% include icons/complaint-round.svg %} | complaint | |
+          | {% include icons/complaint.svg %} | {% include icons/complaint-round.svg %} | complaint | | |
 
-          | {% include icons/credit-card.svg %} | {% include icons/credit-card-round.svg %} | credit-card | |
+          | {% include icons/credit-card.svg %} | {% include icons/credit-card-round.svg %} | credit-card | | |
 
-          | {% include icons/credit-payment.svg %} | {% include icons/credit-payment-round.svg %} | credit-payment | credit-card-payment |
+          | {% include icons/credit-payment.svg %} | {% include icons/credit-payment-round.svg %} | credit-payment | credit-card-payment | |
 
-          | {% include icons/credit-repair.svg %} | {% include icons/credit-repair-round.svg %} | credit-repair |  |
+          | {% include icons/credit-repair.svg %} | {% include icons/credit-repair-round.svg %} | credit-repair | | |
 
-          | {% include icons/credit-report.svg %} | {% include icons/credit-report-round.svg %} | credit-report | document-check |
+          | {% include icons/credit-report.svg %} | {% include icons/credit-report-round.svg %} | credit-report | document-check | |
 
-          | {% include icons/debt-collection.svg %} | {% include icons/debt-collection-round.svg %} | debt-collection |  |
+          | {% include icons/debt-collection.svg %} | {% include icons/debt-collection-round.svg %} | debt-collection | | |
 
-          | {% include icons/debt.svg %} | {% include icons/debt-round.svg %} | debt |  |
+          | {% include icons/debt.svg %} | {% include icons/debt-round.svg %} | debt | | |
 
-          | {% include icons/foreclosure.svg %} | {% include icons/foreclosure-round.svg %} | foreclosure |  |
+          | {% include icons/foreclosure.svg %} | {% include icons/foreclosure-round.svg %} | foreclosure | | |
 
-          | {% include icons/fountain-pen.svg %} | {% include icons/fountain-pen-round.svg %} | fountain-pen | contract |
+          | {% include icons/fountain-pen.svg %} | {% include icons/fountain-pen-round.svg %} | fountain-pen | contract | |
 
-          | {% include icons/getting-a-credit-card.svg %} | {% include icons/getting-a-credit-card-round.svg %} | getting-a-credit-card | credit-card-contract |
+          | {% include icons/getting-a-credit-card.svg %} | {% include icons/getting-a-credit-card-round.svg %} | getting-a-credit-card | credit-card-contract | |
 
-          | {% include icons/health-insurance.svg %} | {% include icons/health-insurance-round.svg %} | health-insurance | medical |
+          | {% include icons/health-insurance.svg %} | {% include icons/health-insurance-round.svg %} | health-insurance | medical | |
 
-          | {% include icons/house.svg %} | {% include icons/house-round.svg %} | house | buying-a-house, owning-a-home, home |
+          | {% include icons/house.svg %} | {% include icons/house-round.svg %} | house | buying-a-house, owning-a-home, home | |
 
-          | {% include icons/insurance.svg %} | {% include icons/insurance-round.svg %} | insurance |  |
+          | {% include icons/insurance.svg %} | {% include icons/insurance-round.svg %} | insurance | | |
 
-          | {% include icons/loan.svg %} | {% include icons/loan-round.svg %} | loan |  |
+          | {% include icons/loan.svg %} | {% include icons/loan-round.svg %} | loan | | |
 
-          | {% include icons/money.svg %} | {% include icons/money-round.svg %} | money | dollar-bill, currency |
+          | {% include icons/money.svg %} | {% include icons/money-round.svg %} | money | dollar-bill, currency | |
 
-          | {% include icons/money-transfer.svg %} | {% include icons/money-transfer-round.svg %} | money-transfer |  |
+          | {% include icons/money-transfer.svg %} | {% include icons/money-transfer-round.svg %} | money-transfer | | |
 
-          | {% include icons/mortgage.svg %} | {% include icons/mortgage-round.svg %} | mortgage |  |
+          | {% include icons/mortgage.svg %} | {% include icons/mortgage-round.svg %} | mortgage | | |
 
-          | {% include icons/payday-loan.svg %} | {% include icons/payday-loan-round.svg %} | payday-loan |  |
+          | {% include icons/payday-loan.svg %} | {% include icons/payday-loan-round.svg %} | payday-loan | | |
 
-          | {% include icons/prepaid-cards.svg %} | {% include icons/prepaid-cards-round.svg %} | prepaid-cards | prepaid-card, prepaid |
+          | {% include icons/prepaid-cards.svg %} | {% include icons/prepaid-cards-round.svg %} | prepaid-cards | prepaid-card, prepaid | |
 
-          | {% include icons/quick-cash.svg %} | {% include icons/quick-cash-round.svg %} | quick-cash |  |
+          | {% include icons/quick-cash.svg %} | {% include icons/quick-cash-round.svg %} | quick-cash | | |
 
-          | {% include icons/piggy-bank.svg %} | {% include icons/piggy-bank-round.svg %} | piggy-bank | retirement, saving, savings |
+          | {% include icons/piggy-bank.svg %} | {% include icons/piggy-bank-round.svg %} | piggy-bank | retirement, saving, savings | |
 
-          | {% include icons/piggy-bank-check.svg %} | {% include icons/piggy-bank-check-round.svg %} | piggy-bank-check |  |
+          | {% include icons/piggy-bank-check.svg %} | {% include icons/piggy-bank-check-round.svg %} | piggy-bank-check | | |
 
-          | {% include icons/servicemembers.svg %} | {% include icons/servicemembers-round.svg %} | servicemembers | dog-tags |
+          | {% include icons/servicemembers.svg %} | {% include icons/servicemembers-round.svg %} | servicemembers | dog-tags | |
 
-          | {% include icons/sold.svg %} | {% include icons/sold-round.svg %} | sold |  |
+          | {% include icons/sold.svg %} | {% include icons/sold-round.svg %} | sold | | |
 
-          | {% include icons/split.svg %} | {% include icons/split-round.svg %} | split |  |
+          | {% include icons/split.svg %} | {% include icons/split-round.svg %} | split | | |
 
-          | {% include icons/toolbox.svg %} | {% include icons/toolbox-round.svg %} | toolbox |  |
+          | {% include icons/toolbox.svg %} | {% include icons/toolbox-round.svg %} | toolbox | | |
 
           {: class="icon-table"}
 
@@ -268,57 +272,57 @@ variation_groups:
           ### Expense icons
 
 
-          | icon | icon-round | canonical name | aliases (for searchability only)  |
+          | icon | icon-round | canonical name | aliases (for searchability only) | RTL? |
 
-          | ---- | ---------- | -------------- | ------- |
+          | ---- | ---------- | -------------- | ------- | ------- |
 
-          | {% include icons/briefcase.svg %} | {% include icons/briefcase-round.svg %} | briefcase |  |
+          | {% include icons/briefcase.svg %} | {% include icons/briefcase-round.svg %} | briefcase | | |
 
-          | {% include icons/bus.svg %} | {% include icons/bus-round.svg %} | bus | public-transit |
+          | {% include icons/bus.svg %} | {% include icons/bus-round.svg %} | bus | public-transit | |
 
-          | {% include icons/cart.svg %} | {% include icons/cart-round.svg %} | cart | groceries, shopping, shopping-cart |
+          | {% include icons/cart.svg %} | {% include icons/cart-round.svg %} | cart | groceries, shopping, shopping-cart | ✓ |
 
-          | {% include icons/childcare.svg %} | {% include icons/childcare-round.svg %} | childcare | baby-bottle |
+          | {% include icons/childcare.svg %} | {% include icons/childcare-round.svg %} | childcare | baby-bottle | |
 
-          | {% include icons/clothes.svg %} | {% include icons/clothes-round.svg %} | clothes | shirt |
+          | {% include icons/clothes.svg %} | {% include icons/clothes-round.svg %} | clothes | shirt | |
 
-          | {% include icons/court.svg %} | {% include icons/court-round.svg %} | court | gavel |
+          | {% include icons/court.svg %} | {% include icons/court-round.svg %} | court | gavel | |
 
-          | {% include icons/dine-out.svg %} | {% include icons/dine-out-round.svg %} | dine-out | dining-out, pizza, pizza-slice, food |
+          | {% include icons/dine-out.svg %} | {% include icons/dine-out-round.svg %} | dine-out | dining-out, pizza, pizza-slice, food | |
 
-          | {% include icons/disability.svg %} | {% include icons/disability-round.svg %} | disability | wheelchair |
+          | {% include icons/disability.svg %} | {% include icons/disability-round.svg %} | disability | wheelchair | ✓ |
 
-          | {% include icons/entertainment.svg %} | {% include icons/entertainment-round.svg %} | entertainment | ticket |
+          | {% include icons/entertainment.svg %} | {% include icons/entertainment-round.svg %} | entertainment | ticket | |
 
-          | {% include icons/equipment.svg %} | {% include icons/equipment-round.svg %} | equipment | hammer, tools |
+          | {% include icons/equipment.svg %} | {% include icons/equipment-round.svg %} | equipment | hammer, tools | |
 
-          | {% include icons/fall.svg %} | {% include icons/fall-round.svg %} | fall | autumn, leaf |
+          | {% include icons/fall.svg %} | {% include icons/fall-round.svg %} | fall | autumn, leaf | |
 
-          | {% include icons/flower.svg %} | {% include icons/flower-round.svg %} | flower | garden |
+          | {% include icons/flower.svg %} | {% include icons/flower-round.svg %} | flower | garden | |
 
-          | {% include icons/furniture.svg %} | {% include icons/furniture-round.svg %} | furniture | chair, sofa |
+          | {% include icons/furniture.svg %} | {% include icons/furniture-round.svg %} | furniture | chair, sofa | |
 
-          | {% include icons/gambling.svg %} | {% include icons/gambling-round.svg %} | gambling |  |
+          | {% include icons/gambling.svg %} | {% include icons/gambling-round.svg %} | gambling | | |
 
-          | {% include icons/gift.svg %} | {% include icons/gift-round.svg %} | gift | present, package |
+          | {% include icons/gift.svg %} | {% include icons/gift-round.svg %} | gift | present, package | |
 
-          | {% include icons/healthcare.svg %} | {% include icons/healthcare-round.svg %} | healthcare | doctor |
+          | {% include icons/healthcare.svg %} | {% include icons/healthcare-round.svg %} | healthcare | doctor | |
 
-          | {% include icons/monitor.svg %} | {% include icons/monitor-round.svg %} | monitor |  |
+          | {% include icons/monitor.svg %} | {% include icons/monitor-round.svg %} | monitor | | |
 
-          | {% include icons/pet.svg %} | {% include icons/pet-round.svg %} | pet | pets |
+          | {% include icons/pet.svg %} | {% include icons/pet-round.svg %} | pet | pets | |
 
-          | {% include icons/price-tag.svg %} | {% include icons/price-tag-round.svg %} | price-tag |  |
+          | {% include icons/price-tag.svg %} | {% include icons/price-tag-round.svg %} | price-tag | | |
 
-          | {% include icons/spring.svg %} | {% include icons/spring-round.svg %} | spring |  |
+          | {% include icons/spring.svg %} | {% include icons/spring-round.svg %} | spring | | |
 
-          | {% include icons/summer.svg %} | {% include icons/summer-round.svg %} | summer | sun |
+          | {% include icons/summer.svg %} | {% include icons/summer-round.svg %} | summer | sun | |
 
-          | {% include icons/taxes.svg %} | {% include icons/taxes-round.svg %} | taxes | government |
+          | {% include icons/taxes.svg %} | {% include icons/taxes-round.svg %} | taxes | government | |
 
-          | {% include icons/travel.svg %} | {% include icons/travel-round.svg %} | travel | airplane, flight |
+          | {% include icons/travel.svg %} | {% include icons/travel-round.svg %} | travel | airplane, flight | ✓ |
 
-          | {% include icons/winter.svg %} | {% include icons/winter-round.svg %} | winter | snow, snowflake |
+          | {% include icons/winter.svg %} | {% include icons/winter-round.svg %} | winter | snow, snowflake | |
 
           {: class="icon-table"}
 
@@ -326,103 +330,103 @@ variation_groups:
           ### Web application icons
 
 
-          | icon | icon-round | canonical name | aliases (for searchability only)  |
+          | icon | icon-round | canonical name | aliases (for searchability only) | RTL? |
 
-          | ---- | ---------- | -------------- | ------- |
+          | ---- | ---------- | -------------- | ------- | ------ |
 
-          | {% include icons/agreement.svg %} | {% include icons/agreement-round.svg %} | agreement | handshake |
+          | {% include icons/agreement.svg %} | {% include icons/agreement-round.svg %} | agreement | handshake | |
 
-          | {% include icons/audio-max.svg %} | {% include icons/audio-max-round.svg %} | audio-max | audio-high |
+          | {% include icons/audio-max.svg %} | {% include icons/audio-max-round.svg %} | audio-max | audio-high | |
 
-          | {% include icons/audio-medium.svg %} | {% include icons/audio-medium-round.svg %} | audio-medium |  |
+          | {% include icons/audio-medium.svg %} | {% include icons/audio-medium-round.svg %} | audio-medium | | |
 
-          | {% include icons/audio-low.svg %} | {% include icons/audio-low-round.svg %} | audio-low |  |
+          | {% include icons/audio-low.svg %} | {% include icons/audio-low-round.svg %} | audio-low | | |
 
-          | {% include icons/audio-mute.svg %} | {% include icons/audio-mute-round.svg %} | audio-mute | mute, audio-off |
+          | {% include icons/audio-mute.svg %} | {% include icons/audio-mute-round.svg %} | audio-mute | mute, audio-off | |
 
-          | {% include icons/bookmark.svg %} | {% include icons/bookmark-round.svg %} | bookmark |  |
+          | {% include icons/bookmark.svg %} | {% include icons/bookmark-round.svg %} | bookmark | | |
 
-          | {% include icons/unbookmark.svg %} | {% include icons/unbookmark-round.svg %} | unbookmark |  |
+          | {% include icons/unbookmark.svg %} | {% include icons/unbookmark-round.svg %} | unbookmark | | |
 
-          | {% include icons/broadcast.svg %} | {% include icons/broadcast-round.svg %} | broadcast | antenna, radio |
+          | {% include icons/broadcast.svg %} | {% include icons/broadcast-round.svg %} | broadcast | antenna, radio | |
 
-          | {% include icons/bullhorn.svg %} | {% include icons/bullhorn-round.svg %} | bullhorn | megaphone |
+          | {% include icons/bullhorn.svg %} | {% include icons/bullhorn-round.svg %} | bullhorn | megaphone | ✓ |
 
-          | {% include icons/chart.svg %} | {% include icons/chart-round.svg %} | chart | graph |
+          | {% include icons/chart.svg %} | {% include icons/chart-round.svg %} | chart | graph | ✓ |
 
-          | {% include icons/clock.svg %} | {% include icons/clock-round.svg %} | clock | time |
+          | {% include icons/clock.svg %} | {% include icons/clock-round.svg %} | clock | time | |
 
-          | {% include icons/compass.svg %} | {% include icons/compass-round.svg %} | compass |  |
+          | {% include icons/compass.svg %} | {% include icons/compass-round.svg %} | compass | | |
 
-          | {% include icons/date.svg %} | {% include icons/date-round.svg %} | date | calendar |
+          | {% include icons/date.svg %} | {% include icons/date-round.svg %} | date | calendar | |
 
-          | {% include icons/dialogue.svg %} | {% include icons/dialogue-round.svg %} | dialogue | dialog, chat, discussion |
+          | {% include icons/dialogue.svg %} | {% include icons/dialogue-round.svg %} | dialogue | dialog, chat, discussion | |
 
-          | {% include icons/disabled.svg %} | {% include icons/disabled-round.svg %} | disabled | no, disallowed |
+          | {% include icons/disabled.svg %} | {% include icons/disabled-round.svg %} | disabled | no, disallowed | |
 
-          | {% include icons/external-link.svg %} | {% include icons/external-link-round.svg %} | external-link |  |
+          | {% include icons/external-link.svg %} | {% include icons/external-link-round.svg %} | external-link | | ✓ |
 
-          | {% include icons/favorite.svg %} | {% include icons/favorite-round.svg %} | favorite | star, starred, fav, fave |
+          | {% include icons/favorite.svg %} | {% include icons/favorite-round.svg %} | favorite | star, starred, fav, fave | |
 
-          | {% include icons/unfavorite.svg %} | {% include icons/unfavorite-round.svg %} | unfavorite | unstar, unstarred, unfav, unfave |
+          | {% include icons/unfavorite.svg %} | {% include icons/unfavorite-round.svg %} | unfavorite | unstar, unstarred, unfav, unfave | |
 
-          | {% include icons/filter.svg %} | {% include icons/filter-round.svg %} | filter | sliders, controls |
+          | {% include icons/filter.svg %} | {% include icons/filter-round.svg %} | filter | sliders, controls | |
 
-          | {% include icons/flag.svg %} | {% include icons/flag-round.svg %} | flag |  |
+          | {% include icons/flag.svg %} | {% include icons/flag-round.svg %} | flag | | |
 
-          | {% include icons/history.svg %} | {% include icons/history-round.svg %} | history |  |
+          | {% include icons/history.svg %} | {% include icons/history-round.svg %} | history | | |
 
-          | {% include icons/information.svg %} | {% include icons/information-round.svg %} | information | info, i |
+          | {% include icons/information.svg %} | {% include icons/information-round.svg %} | information | info, i | |
 
-          | {% include icons/lightbulb.svg %} | {% include icons/lightbulb-round.svg %} | lightbulb | idea |
+          | {% include icons/lightbulb.svg %} | {% include icons/lightbulb-round.svg %} | lightbulb | idea | |
 
-          | {% include icons/link.svg %} | {% include icons/link-round.svg %} | link |  |
+          | {% include icons/link.svg %} | {% include icons/link-round.svg %} | link | | |
 
-          | {% include icons/list.svg %} | {% include icons/list-round.svg %} | list |  |
+          | {% include icons/list.svg %} | {% include icons/list-round.svg %} | list | | ✓ |
 
-          | {% include icons/lock.svg %} | {% include icons/lock-round.svg %} | lock | locked, padlock |
+          | {% include icons/lock.svg %} | {% include icons/lock-round.svg %} | lock | locked, padlock | |
 
-          | {% include icons/unlock.svg %} | {% include icons/unlock-round.svg %} | unlock | unlocked |
+          | {% include icons/unlock.svg %} | {% include icons/unlock-round.svg %} | unlock | unlocked | |
 
-          | {% include icons/map.svg %} | {% include icons/map-round.svg %} | map | location |
+          | {% include icons/map.svg %} | {% include icons/map-round.svg %} | map | location | |
 
-          | {% include icons/menu.svg %} | {% include icons/menu-round.svg %} | menu | hamburger |
+          | {% include icons/menu.svg %} | {% include icons/menu-round.svg %} | menu | hamburger | |
 
-          | {% include icons/microphone.svg %} | {% include icons/microphone-round.svg %} | microphone | mic |
+          | {% include icons/microphone.svg %} | {% include icons/microphone-round.svg %} | microphone | mic | |
 
-          | {% include icons/newspaper.svg %} | {% include icons/newspaper-round.svg %} | newspaper | news |
+          | {% include icons/newspaper.svg %} | {% include icons/newspaper-round.svg %} | newspaper | news | |
 
-          | {% include icons/open-quote.svg %} | {% include icons/open-quote-round.svg %} | open-quote |  |
+          | {% include icons/open-quote.svg %} | {% include icons/open-quote-round.svg %} | open-quote | | |
 
-          | {% include icons/close-quote.svg %} | {% include icons/close-quote-round.svg %} | close-quote | double-quote |
+          | {% include icons/close-quote.svg %} | {% include icons/close-quote-round.svg %} | close-quote | double-quote | |
 
-          | {% include icons/parent.svg %} | {% include icons/parent-round.svg %} | parent | family |
+          | {% include icons/parent.svg %} | {% include icons/parent-round.svg %} | parent | family | |
 
-          | {% include icons/play.svg %} | {% include icons/play-round.svg %} | play |  |
+          | {% include icons/play.svg %} | {% include icons/play-round.svg %} | play | | |
 
-          | {% include icons/policy.svg %} | {% include icons/policy-round.svg %} | policy | law |
+          | {% include icons/policy.svg %} | {% include icons/policy-round.svg %} | policy | law | |
 
-          | {% include icons/pop-up.svg %} | {% include icons/pop-up-round.svg %} | pop-up | new-window |
+          | {% include icons/pop-up.svg %} | {% include icons/pop-up-round.svg %} | pop-up | new-window | |
 
-          | {% include icons/regulation.svg %} | {% include icons/regulation-round.svg %} | regulation | rule, justice |
+          | {% include icons/regulation.svg %} | {% include icons/regulation-round.svg %} | regulation | rule, justice | |
 
-          | {% include icons/search.svg %} | {% include icons/search-round.svg %} | search | zoom, magnifying-glass |
+          | {% include icons/search.svg %} | {% include icons/search-round.svg %} | search | zoom, magnifying-glass | |
 
-          | {% include icons/serve.svg %} | {% include icons/serve-round.svg %} | serve | hand, raise-hand |
+          | {% include icons/serve.svg %} | {% include icons/serve-round.svg %} | serve | hand, raise-hand | |
 
-          | {% include icons/settings.svg %} | {% include icons/settings-round.svg %} | settings | preferences, gear, cog |
+          | {% include icons/settings.svg %} | {% include icons/settings-round.svg %} | settings | preferences, gear, cog | |
 
-          | {% include icons/share.svg %} | {% include icons/share-round.svg %} | share |  |
+          | {% include icons/share.svg %} | {% include icons/share-round.svg %} | share | | |
 
-          | {% include icons/share-alt.svg %} | {% include icons/share-alt-round.svg %} | share-alt |  |
+          | {% include icons/share-alt.svg %} | {% include icons/share-alt-round.svg %} | share-alt | | |
 
-          | {% include icons/speech-bubble.svg %} | {% include icons/speech-bubble-round.svg %} | speech-bubble | chat-bubble |
+          | {% include icons/speech-bubble.svg %} | {% include icons/speech-bubble-round.svg %} | speech-bubble | chat-bubble | |
 
-          | {% include icons/thought-bubble.svg %} | {% include icons/thought-bubble-round.svg %} | thought-bubble | thinking, thoughts |
+          | {% include icons/thought-bubble.svg %} | {% include icons/thought-bubble-round.svg %} | thought-bubble | thinking, thoughts | |
 
-          | {% include icons/user.svg %} | {% include icons/user-round.svg %} | user | person |
+          | {% include icons/user.svg %} | {% include icons/user-round.svg %} | user | person | |
 
-          | {% include icons/wifi.svg %} | {% include icons/wifi-round.svg %} | wifi | wi-fi, wireless, signal |
+          | {% include icons/wifi.svg %} | {% include icons/wifi-round.svg %} | wifi | wi-fi, wireless, signal | |
 
           {: class="icon-table"}
         variation_name: ''

--- a/packages/cfpb-icons/src/cfpb-icons.less
+++ b/packages/cfpb-icons/src/cfpb-icons.less
@@ -61,3 +61,43 @@
     transform: rotate(359deg);
   }
 }
+
+// Right-to-left (RTL) certain icons on arabic pages.
+html[lang='ar'] {
+  .cf-icon-svg {
+    &__right,
+    &__right-round,
+    &__left,
+    &__left-round,
+    &__arrow-right,
+    &__arrow-right-round,
+    &__arrow-left,
+    &__arrow-left-round,
+    &__help,
+    &__help-round,
+    &__book,
+    &__book-round,
+    &__document,
+    &__document-round,
+    &__edit,
+    &__edit-round,
+    &__paper-clip,
+    &__paper-clip-round,
+    &__cart,
+    &__cart-round,
+    &__disability,
+    &__disability-round,
+    &__travel,
+    &__travel-round,
+    &__bullhorn,
+    &__bullhorn-round,
+    &__chart,
+    &__chart-round,
+    &__list,
+    &__list-round,
+    &__external-link,
+    &__external-link-round {
+      transform: scaleX(-1);
+    }
+  }
+}


### PR DESCRIPTION
Flip certain icons that appear on RTL language pages, which is specifically arabic at this stage.

## Changes

- Flip specific icons on arabic pages.

## Testing

1. [In the PR preview](https://deploy-preview-1655--cfpb-design-system.netlify.app/design-system/foundation/iconography), visit the iconography page and see that there is a new RTL column and a check box next to each icon that corresponds to [GHE]/Design-Development/Design-and-Content-Team/issues/176#issuecomment-334258 and that the list of CSS changes in cfpb-icons.less corresponds to the same set.

2. You can simulate the flip by inspecting the page and changing the `<html lang='en'>` tag to `<html lang='ar'>`.

## Screenshots
<img width="862" alt="Screen Shot 2023-05-30 at 10 47 39 AM" src="https://github.com/cfpb/design-system/assets/704760/9169672c-2e3d-4546-b0e6-a42bf6b8ffbd">

