### PR TITLE
Update `o-expandable_link` to `o-expandable_cues` | RTL fixes

### DIFF
--- a/docs/pages/expandables.md
+++ b/docs/pages/expandables.md
@@ -17,7 +17,7 @@ variation_groups:
                   <h3 class="h4 o-expandable_label">
                       Expandable Header
                   </h3>
-                  <span class="o-expandable_link">
+                  <span class="o-expandable_cues">
                       <span class="o-expandable_cue-open" role="img" aria-label="Show">
                           {% include icons/plus-round.svg %}
                       </span>
@@ -122,7 +122,7 @@ variation_groups:
                   <h3 class="h4 o-expandable_label">
                       Expandable Header
                   </h3>
-                  <span class="o-expandable_link">
+                  <span class="o-expandable_cues">
                       <span class="o-expandable_cue-open" role="img" aria-label="Show">
                           {% include icons/plus-round.svg %}
                       </span>
@@ -161,7 +161,7 @@ variation_groups:
                       <h3 class="h4 o-expandable_label">
                           Expandable Header 1
                       </h3>
-                      <span class="o-expandable_link">
+                      <span class="o-expandable_cues">
                           <span class="o-expandable_cue-open" role="img" aria-label="Show">
                               {% include icons/plus-round.svg %}
                           </span>
@@ -187,7 +187,7 @@ variation_groups:
                       <h3 class="h4 o-expandable_label">
                           Expandable Header 2
                       </h3>
-                      <span class="o-expandable_link">
+                      <span class="o-expandable_cues">
                           <span class="o-expandable_cue-open" role="img" aria-label="Show">
                               {% include icons/plus-round.svg %}
                           </span>
@@ -213,7 +213,7 @@ variation_groups:
                       <h3 class="h4 o-expandable_label">
                           Expandable Header 3
                       </h3>
-                      <span class="o-expandable_link">
+                      <span class="o-expandable_cues">
                           <span class="o-expandable_cue-open" role="img" aria-label="Show">
                               {% include icons/plus-round.svg %}
                           </span>
@@ -280,7 +280,7 @@ variation_groups:
                       <h3 class="h4 o-expandable_label">
                           Expandable Header 1
                       </h3>
-                      <span class="o-expandable_link">
+                      <span class="o-expandable_cues">
                           <span class="o-expandable_cue-open" role="img" aria-label="Show">
                               {% include icons/plus-round.svg %}
                           </span>
@@ -306,7 +306,7 @@ variation_groups:
                       <h3 class="h4 o-expandable_label">
                           Expandable Header 2
                       </h3>
-                      <span class="o-expandable_link">
+                      <span class="o-expandable_cues">
                           <span class="o-expandable_cue-open" role="img" aria-label="Show">
                               {% include icons/plus-round.svg %}
                           </span>
@@ -368,7 +368,7 @@ variation_groups:
                       <h3 class="h4 o-expandable_label">
                           Expandable Header 3
                       </h3>
-                      <span class="o-expandable_link">
+                      <span class="o-expandable_cues">
                           <span class="o-expandable_cue-open" role="img" aria-label="Show">
                               {% include icons/plus-round.svg %}
                           </span>

--- a/docs/pages/filterable-list-control-panels.md
+++ b/docs/pages/filterable-list-control-panels.md
@@ -21,7 +21,7 @@ variation_groups:
                       <span class="h4 o-expandable_label">
                       Filter posts
                       </span>
-                      <span class="o-expandable_link">
+                      <span class="o-expandable_cues">
                           <span class="o-expandable_cue-open" role="img" aria-label="Show filters">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="cf-icon-svg cf-icon-svg__plus-round" viewBox="0 0 17 20.4"><path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H9.284V6.12a.792.792 0 1 0-1.583 0V9.5H4.32a.792.792 0 0 0 0 1.584H7.7v3.382a.792.792 0 0 0 1.583 0v-3.382h3.382a.792.792 0 0 0 .792-.791z"/></svg>
                           </span>

--- a/docs/special-pages/updating-this-website.md
+++ b/docs/special-pages/updating-this-website.md
@@ -37,7 +37,7 @@ description: >-
               <h3 class="h4 o-expandable_label">
                   Step 1. Click a page's "Edit this page" pencil icon.
               </h3>
-              <span class="o-expandable_link">
+              <span class="o-expandable_cues">
                   <span class="o-expandable_cue-open" role="img" aria-label="Show">
                       {% include icons/plus-round.svg %}
                   </span>
@@ -61,7 +61,7 @@ description: >-
               <h3 class="h4 o-expandable_label">
                   Step 2. Log into the CMS
               </h3>
-              <span class="o-expandable_link">
+              <span class="o-expandable_cues">
                   <span class="o-expandable_cue-open" role="img" aria-label="Show">
                       {% include icons/plus-round.svg %}
                   </span>
@@ -88,7 +88,7 @@ description: >-
               <h3 class="h4 o-expandable_label">
                   Step 3. Edit a page's content
               </h3>
-              <span class="o-expandable_link">
+              <span class="o-expandable_cues">
                   <span class="o-expandable_cue-open" role="img" aria-label="Show">
                       {% include icons/plus-round.svg %}
                   </span>
@@ -112,7 +112,7 @@ description: >-
               <h3 class="h4 o-expandable_label">
                   Step 4. Save your changes
               </h3>
-              <span class="o-expandable_link">
+              <span class="o-expandable_cues">
                   <span class="o-expandable_cue-open" role="img" aria-label="Show">
                       {% include icons/plus-round.svg %}
                   </span>
@@ -139,7 +139,7 @@ description: >-
               <h3 class="h4 o-expandable_label">
                   Step 5. Preview your changes
               </h3>
-              <span class="o-expandable_link">
+              <span class="o-expandable_cues">
                   <span class="o-expandable_cue-open" role="img" aria-label="Show">
                       {% include icons/plus-round.svg %}
                   </span>
@@ -166,7 +166,7 @@ description: >-
               <h3 class="h4 o-expandable_label">
                   Step 6. Publish your changes
               </h3>
-              <span class="o-expandable_link">
+              <span class="o-expandable_cues">
                   <span class="o-expandable_cue-open" role="img" aria-label="Show">
                       {% include icons/plus-round.svg %}
                   </span>

--- a/packages/cfpb-expandables/src/expandable.less
+++ b/packages/cfpb-expandables/src/expandable.less
@@ -72,7 +72,7 @@
     font-weight: 500;
   }
 
-  &_link {
+  &_cues {
     min-width: 60px;
     text-align: right;
     color: @pacific;
@@ -158,7 +158,12 @@
 }
 
 // Used when the set language reads right-to-left
-div[dir='rtl'] .o-expandable_header {
-  width: 100%;
-  text-align: right;
+html[lang='ar'] {
+  .o-expandable_header {
+    text-align: right;
+
+    &_cues {
+      text-align: left;
+    }
+  }
 }

--- a/packages/cfpb-expandables/usage.md
+++ b/packages/cfpb-expandables/usage.md
@@ -70,12 +70,12 @@ Allows you to add some styled text to look like a link.
 
 _Note: only use this in the expandable header_
 
-<span class="o-expandable_link">
+<span class="o-expandable_cues">
     Lorem ipsum
 </span>
 
 ```
-<span class="o-expandable_link">
+<span class="o-expandable_cues">
     Lorem ipsum
 </span>
 ```
@@ -99,7 +99,7 @@ The following combination is our recommended go-to expandable pattern.
         <h3 class="h4 o-expandable_label">
             Expandable Header
         </h3>
-        <span class="o-expandable_link">
+        <span class="o-expandable_cues">
             <span class="o-expandable_cue-open" role="img" aria-label="Show">
                 {% include icons/plus-round.svg %}
             </span>
@@ -129,7 +129,7 @@ The following combination is our recommended go-to expandable pattern.
         <h3 class="h4 o-expandable_label">
             Expandable Header
         </h3>
-        <span class="o-expandable_link">
+        <span class="o-expandable_cues">
             <span class="o-expandable_cue-open" role="img" aria-label="Show">
                 {% raw %}{% include icons/plus-round.svg %}{% endraw %}
             </span>
@@ -162,7 +162,7 @@ The following combination is our recommended go-to expandable pattern.
         <h3 class="h4 o-expandable_label">
             Expandable Header
         </h3>
-        <span class="o-expandable_link">
+        <span class="o-expandable_cues">
             <span class="o-expandable_cue-open" role="img" aria-label="Show">
                 {% include icons/plus-round.svg %}
             </span>
@@ -193,7 +193,7 @@ The following combination is our recommended go-to expandable pattern.
         <h3 class="h4 o-expandable_label">
             Expandable Header
         </h3>
-        <span class="o-expandable_link">
+        <span class="o-expandable_cues">
             <span class="o-expandable_cue-open" role="img" aria-label="Show">
                 {% raw %}{% include icons/plus-round.svg %}{% endraw %}
             </span>
@@ -227,7 +227,7 @@ Should you need an expandable thing that is not covered by the expandables above
             <h3 class="h4 o-expandable_label">
                 Expandable Header 1
             </h3>
-            <span class="o-expandable_link">
+            <span class="o-expandable_cues">
                 <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     {% include icons/plus-round.svg %}
                 </span>
@@ -252,7 +252,7 @@ Should you need an expandable thing that is not covered by the expandables above
             <h3 class="h4 o-expandable_label">
                 Expandable Header 2
             </h3>
-            <span class="o-expandable_link">
+            <span class="o-expandable_cues">
                 <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     {% include icons/plus-round.svg %}
                 </span>
@@ -277,7 +277,7 @@ Should you need an expandable thing that is not covered by the expandables above
             <h3 class="h4 o-expandable_label">
                 Expandable Header 3
             </h3>
-            <span class="o-expandable_link">
+            <span class="o-expandable_cues">
                 <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     {% include icons/plus-round.svg %}
                 </span>
@@ -306,7 +306,7 @@ Should you need an expandable thing that is not covered by the expandables above
             <h3 class="h4 o-expandable_label">
                 Expandable Header 1
             </h3>
-            <span class="o-expandable_link">
+            <span class="o-expandable_cues">
                 <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
@@ -331,7 +331,7 @@ Should you need an expandable thing that is not covered by the expandables above
             <h3 class="h4 o-expandable_label">
                 Expandable Header 2
             </h3>
-            <span class="o-expandable_link">
+            <span class="o-expandable_cues">
                 <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
@@ -356,7 +356,7 @@ Should you need an expandable thing that is not covered by the expandables above
             <h3 class="h4 o-expandable_label">
                 Expandable Header 3
             </h3>
-            <span class="o-expandable_link">
+            <span class="o-expandable_cues">
                 <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
@@ -391,7 +391,7 @@ to activate the accordion mode.
             <h3 class="h4 o-expandable_label">
                 Expandable Header 1
             </h3>
-            <span class="o-expandable_link">
+            <span class="o-expandable_cues">
                 <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     {% include icons/plus-round.svg %}
                 </span>
@@ -416,7 +416,7 @@ to activate the accordion mode.
             <h3 class="h4 o-expandable_label">
                 Expandable Header 2
             </h3>
-            <span class="o-expandable_link">
+            <span class="o-expandable_cues">
                 <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     {% include icons/plus-round.svg %}
                 </span>
@@ -441,7 +441,7 @@ to activate the accordion mode.
             <h3 class="h4 o-expandable_label">
                 Expandable Header 3
             </h3>
-            <span class="o-expandable_link">
+            <span class="o-expandable_cues">
                 <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     {% include icons/plus-round.svg %}
                 </span>
@@ -470,7 +470,7 @@ to activate the accordion mode.
             <h3 class="h4 o-expandable_label">
                 Expandable Header 1
             </h3>
-            <span class="o-expandable_link">
+            <span class="o-expandable_cues">
                 <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
@@ -495,7 +495,7 @@ to activate the accordion mode.
             <h3 class="h4 o-expandable_label">
                 Expandable Header 2
             </h3>
-            <span class="o-expandable_link">
+            <span class="o-expandable_cues">
                 <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>
@@ -520,7 +520,7 @@ to activate the accordion mode.
             <h3 class="h4 o-expandable_label">
                 Expandable Header 3
             </h3>
-            <span class="o-expandable_link">
+            <span class="o-expandable_cues">
                 <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     {% raw %}{% include icons/plus-round.svg %}{% endraw %}
                 </span>

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/atomic-helpers.spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/atomic-helpers.spec.js
@@ -15,7 +15,7 @@ const HTML_SNIPPET = `
           <span class="o-expandable_label">
               Expandable Header 3
           </span>
-          <span class="o-expandable_link">
+          <span class="o-expandable_cues">
               <span class="o-expandable_cue-open">
                   Show
               </span>

--- a/test/unit-test/src/cfpb-expandables/src/Expandable.spec.js
+++ b/test/unit-test/src/cfpb-expandables/src/Expandable.spec.js
@@ -14,7 +14,7 @@ const HTML_SNIPPET = `
             <span class="o-expandable_label">
                 Expandable Header 1
             </span>
-            <span class="o-expandable_link">
+            <span class="o-expandable_cues">
                 <span class="o-expandable_cue-open">
                     Show
                 </span>
@@ -40,7 +40,7 @@ const HTML_SNIPPET = `
             <span class="o-expandable_label">
                 Expandable Header 2
             </span>
-            <span class="o-expandable_link">
+            <span class="o-expandable_cues">
                 <span class="o-expandable_cue-open">
                     Show
                 </span>
@@ -67,7 +67,7 @@ const HTML_SNIPPET = `
         <span class="o-expandable_label">
             Expandable Header 3
         </span>
-        <span class="o-expandable_link">
+        <span class="o-expandable_cues">
             <span class="o-expandable_cue-open">
                 Show
             </span>


### PR DESCRIPTION
## Changes

- Update `o-expandable_link` to more descriptive `o-expandable_cues`
- Add fix to RTL code to target the html lang attribute, like elsewhere where we have RTL targeting CSS. Also, correctly align the cue on RTL pages.

## Testing

1. PR preview should show an unchanged expandables page.

https://deploy-preview-1659--cfpb-design-system.netlify.app/design-system/components/expandables

vs

https://cfpb.github.io/design-system/components/expandables