### PR TITLE
Add `justify-content: center` to cards

### DIFF
--- a/packages/cfpb-layout/src/organisms/card-group.less
+++ b/packages/cfpb-layout/src/organisms/card-group.less
@@ -141,6 +141,7 @@ _:-ms-lang(x),
     .o-card-group_cards {
       display: flex;
       flex-wrap: wrap;
+      justify-content: center;
     }
   }
 }


### PR DESCRIPTION
Move CSS from here https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/css/main.less#L124

## Changes

- Add `justify-content: center` to cards

## Testing

1. PR preview cards page should be center aligned.

https://deploy-preview-1660--cfpb-design-system.netlify.app/design-system/patterns/cards

vs

https://cfpb.github.io/design-system/patterns/cards


Before:
<img width="822" alt="Screen Shot 2023-06-22 at 8 50 15 AM" src="https://github.com/cfpb/design-system/assets/704760/6b4b1c02-0726-4f26-b83c-2369236592b9">


After:
<img width="815" alt="Screen Shot 2023-06-22 at 8 50 11 AM" src="https://github.com/cfpb/design-system/assets/704760/3d2c9473-2a64-44c0-abf9-981d849816bb">
