### PR TITLE
cfpb-layout: Fix breakout card margin

### DIFF
--- a/packages/cfpb-layout/src/molecules/card.less
+++ b/packages/cfpb-layout/src/molecules/card.less
@@ -98,7 +98,7 @@
     outline-offset: 2px;
   }
 
-  &:not(.m-card__highlight) {
+  &:not(.m-card__highlight):not(.m-card__breakout) {
     .m-card_footer {
       margin-top: auto;
     }
@@ -235,13 +235,13 @@
 
     // Provide padding offset set to half the image height.
     > a {
-      padding-top: @card_img_height / 2;
+      padding-top: (@card_img_height / 2);
     }
 
     .m-card_inner-wrapper {
       position: relative;
       z-index: 0;
-      min-height: @card_img_height + (@grid_gutter-width / 2);
+      min-height: (@card_img_height + (@grid_gutter-width / 2));
 
       background: @gray-5;
       border: 1px solid @gray-20;


### PR DESCRIPTION
https://github.com/cfpb/design-system/pull/1663 fixed a typo in the less syntax, however, this needs to also exclude the breakout cards so that they don't have their top margin overridden with `auto`.

Also, I noticed that calculations need to be wrapped in parentheses to be applied, otherwise the value ends up as `120px / 2` or whatever, instead of `60px`. 

## Changes

- cfpb-layout: Fix breakout card margin

## Testing

1. Check the cards page of the PR preview and compare to the live DS site.

PR preview: https://deploy-preview-1668--cfpb-design-system.netlify.app/design-system/patterns/cards

Live site: https://cfpb.github.io/design-system/patterns/cards

## Screenshots

Before:
<img width="766" alt="Screen Shot 2023-07-11 at 10 18 47 AM" src="https://github.com/cfpb/design-system/assets/704760/ef31ef71-d083-48bf-b48b-f287a48bf37b">

<img width="753" alt="Screen Shot 2023-07-11 at 10 23 59 AM" src="https://github.com/cfpb/design-system/assets/704760/7000e8bb-9e0b-4183-a7b0-00583a329e9a">


After:
<img width="762" alt="Screen Shot 2023-07-11 at 10 18 51 AM" src="https://github.com/cfpb/design-system/assets/704760/c4227a2d-79d1-42a0-9c32-2dfa52b53018">

<img width="751" alt="Screen Shot 2023-07-11 at 10 24 06 AM" src="https://github.com/cfpb/design-system/assets/704760/71e1477a-8122-497a-a556-e303da7a5a06">

