### PR TITLE
cfpb-grid: Fix grid demo

### DIFF
--- a/docs/assets/css/grid-demo.less
+++ b/docs/assets/css/grid-demo.less
@@ -6,10 +6,11 @@
 .col {
   background-color: @gray-5;
 
-  p {
+  > div {
     background-color: @gray-10;
     font-weight: bold;
     text-align: center;
+    margin-bottom: unit((15px / @base-font-size-px), em);
   }
 }
 

--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -25,57 +25,57 @@ variation_groups:
         variation_code_snippet: |-
           <div class="cols-12">
               <section>
-                  <div class="col col-1"><p>one</p></div>
-                  <div class="col col-1"><p>one</p></div>
-                  <div class="col col-1"><p>one</p></div>
-                  <div class="col col-1"><p>one</p></div>
-                  <div class="col col-1"><p>one</p></div>
-                  <div class="col col-1"><p>one</p></div>
-                  <div class="col col-1"><p>one</p></div>
-                  <div class="col col-1"><p>one</p></div>
-                  <div class="col col-1"><p>one</p></div>
-                  <div class="col col-1"><p>one</p></div>
-                  <div class="col col-1"><p>one</p></div>
-                  <div class="col col-1"><p>one</p></div>
+                  <div class="col col-1"><div>one</div></div>
+                  <div class="col col-1"><div>one</div></div>
+                  <div class="col col-1"><div>one</div></div>
+                  <div class="col col-1"><div>one</div></div>
+                  <div class="col col-1"><div>one</div></div>
+                  <div class="col col-1"><div>one</div></div>
+                  <div class="col col-1"><div>one</div></div>
+                  <div class="col col-1"><div>one</div></div>
+                  <div class="col col-1"><div>one</div></div>
+                  <div class="col col-1"><div>one</div></div>
+                  <div class="col col-1"><div>one</div></div>
+                  <div class="col col-1"><div>one</div></div>
               </section>
 
               <section>
-                  <div class="col col-2"><p>two</p></div>
-                  <div class="col col-2"><p>two</p></div>
-                  <div class="col col-2"><p>two</p></div>
-                  <div class="col col-2"><p>two</p></div>
-                  <div class="col col-2"><p>two</p></div>
-                  <div class="col col-2"><p>two</p></div>
+                  <div class="col col-2"><div>two</div></div>
+                  <div class="col col-2"><div>two</div></div>
+                  <div class="col col-2"><div>two</div></div>
+                  <div class="col col-2"><div>two</div></div>
+                  <div class="col col-2"><div>two</div></div>
+                  <div class="col col-2"><div>two</div></div>
               </section>
 
               <section>
-                  <div class="col col-2"><p>two</p></div>
-                  <div class="col col-3"><p>three</p></div>
-                  <div class="col col-2"><p>two</p></div>
-                  <div class="col col-3"><p>three</p></div>
-                  <div class="col col-2"><p>two</p></div>
+                  <div class="col col-2"><div>two</div></div>
+                  <div class="col col-3"><div>three</div></div>
+                  <div class="col col-2"><div>two</div></div>
+                  <div class="col col-3"><div>three</div></div>
+                  <div class="col col-2"><div>two</div></div>
               </section>
 
               <section>
-                  <div class="col col-3"><p>three</p></div>
-                  <div class="col col-3"><p>three</p></div>
-                  <div class="col col-3"><p>three</p></div>
-                  <div class="col col-3"><p>three</p></div>
+                  <div class="col col-3"><div>three</div></div>
+                  <div class="col col-3"><div>three</div></div>
+                  <div class="col col-3"><div>three</div></div>
+                  <div class="col col-3"><div>three</div></div>
               </section>
 
               <section>
-                  <div class="col col-4"><p>four</p></div>
-                  <div class="col col-4"><p>four</p></div>
-                  <div class="col col-4"><p>four</p></div>
+                  <div class="col col-4"><div>four</div></div>
+                  <div class="col col-4"><div>four</div></div>
+                  <div class="col col-4"><div>four</div></div>
               </section>
 
               <section>
-                  <div class="col col-6"><p>six</p></div>
-                  <div class="col col-6"><p>six</p></div>
+                  <div class="col col-6"><div>six</div></div>
+                  <div class="col col-6"><div>six</div></div>
               </section>
 
               <section>
-                  <div class="col col-12"><p>twelve</p></div>
+                  <div class="col col-12"><div>twelve</div></div>
               </section>
           </div>
   - variation_group_name: Breakpoints
@@ -260,49 +260,49 @@ variation_groups:
           <div class="cols-12">
               <section>
                   <div class="col col-6">
-                      <p>six</p>
+                      <div>six</div>
                       <section class="nested">
-                          <div class="col col-4"><p>four</p></div>
-                          <div class="col col-4"><p>four</p></div>
-                          <div class="col col-4"><p>four</p></div>
+                          <div class="col col-4"><div>four</div></div>
+                          <div class="col col-4"><div>four</div></div>
+                          <div class="col col-4"><div>four</div></div>
                       </section>
                   </div>
 
                   <div class="col col-6">
-                      <p>six</p>
+                      <div>six</div>
                       <section class="nested">
-                          <div class="col col-4"><p>four</p></div>
-                          <div class="col col-4"><p>four</p></div>
-                          <div class="col col-4"><p>four</p></div>
+                          <div class="col col-4"><div>four</div></div>
+                          <div class="col col-4"><div>four</div></div>
+                          <div class="col col-4"><div>four</div></div>
                       </section>
                   </div>
               </section>
 
               <section>
                   <div class="col col-3">
-                      <p>three</p>
+                      <div>three</div>
                       <section class="nested">
-                          <div class="col col-6"><p>six</p></div>
-                          <div class="col col-6"><p>six</p></div>
+                          <div class="col col-6"><div>six</div></div>
+                          <div class="col col-6"><div>six</div></div>
                       </section>
                   </div>
 
                   <div class="col col-6">
-                      <p>six</p>
+                      <div>six</div>
                       <section class="nested">
-                          <div class="col col-4"><p>four</p></div>
-                          <div class="col col-4"><p>four</p></div>
-                          <div class="col col-4"><p>four</p></div>
+                          <div class="col col-4"><div>four</div></div>
+                          <div class="col col-4"><div>four</div></div>
+                          <div class="col col-4"><div>four</div></div>
                       </section>
                   </div>
 
                   <div class="col col-3">
-                      <p>three</p>
+                      <div>three</div>
                       <section class="nested">
-                          <div class="col col-3"><p>three</p></div>
-                          <div class="col col-3"><p>three</p></div>
-                          <div class="col col-3"><p>three</p></div>
-                          <div class="col col-3"><p>three</p></div>
+                          <div class="col col-3"><div>three</div></div>
+                          <div class="col col-3"><div>three</div></div>
+                          <div class="col col-3"><div>three</div></div>
+                          <div class="col col-3"><div>three</div></div>
                       </section>
                   </div>
               </section>
@@ -360,18 +360,18 @@ variation_groups:
       - variation_code_snippet: >-
           <div class="cols-12">
               <section>
-                  <div class="col col-1 suffix-11"><p>prefix 0, suffix 11</p></div>
-                  <div class="col col-1 prefix-1 suffix-10"><p>prefix 1, suffix 10</p></div>
-                  <div class="col col-1 prefix-2 suffix-9"><p>prefix 2, suffix 9</p></div>
-                  <div class="col col-1 prefix-3 suffix-8"><p>prefix 3, suffix 8</p></div>
-                  <div class="col col-1 prefix-4 suffix-7"><p>prefix 4, suffix 7</p></div>
-                  <div class="col col-1 prefix-5 suffix-6"><p>prefix 5, suffix 6</p></div>
-                  <div class="col col-1 prefix-6 suffix-5"><p>prefix 6, suffix 5</p></div>
-                  <div class="col col-1 prefix-7 suffix-4"><p>prefix 7, suffix 4</p></div>
-                  <div class="col col-1 prefix-8 suffix-3"><p>prefix 8, suffix 3</p></div>
-                  <div class="col col-1 prefix-9 suffix-2"><p>prefix 9, suffix 2</p></div>
-                  <div class="col col-1 prefix-10 suffix-1"><p>prefix 10, suffix 1</p></div>
-                  <div class="col col-1 prefix-11"><p>prefix 11, suffix 0</p></div>
+                  <div class="col col-1 suffix-11"><div>prefix 0, suffix 11</div></div>
+                  <div class="col col-1 prefix-1 suffix-10"><div>prefix 1, suffix 10</div></div>
+                  <div class="col col-1 prefix-2 suffix-9"><div>prefix 2, suffix 9</div></div>
+                  <div class="col col-1 prefix-3 suffix-8"><div>prefix 3, suffix 8</div></div>
+                  <div class="col col-1 prefix-4 suffix-7"><div>prefix 4, suffix 7</div></div>
+                  <div class="col col-1 prefix-5 suffix-6"><div>prefix 5, suffix 6</div></div>
+                  <div class="col col-1 prefix-6 suffix-5"><div>prefix 6, suffix 5</div></div>
+                  <div class="col col-1 prefix-7 suffix-4"><div>prefix 7, suffix 4</div></div>
+                  <div class="col col-1 prefix-8 suffix-3"><div>prefix 8, suffix 3</div></div>
+                  <div class="col col-1 prefix-9 suffix-2"><div>prefix 9, suffix 2</div></div>
+                  <div class="col col-1 prefix-10 suffix-1"><div>prefix 10, suffix 1</div></div>
+                  <div class="col col-1 prefix-11"><div>prefix 11, suffix 0</div></div>
               </section>
           </div>
         variation_description: ''

--- a/docs/pages/variables.md
+++ b/docs/pages/variables.md
@@ -113,7 +113,7 @@ variation_groups:
     variation_group_description: >-
       ```
 
-      @grid_wrapper-width: 1200px;
+      @grid_wrapper-width: 1230px;
 
       ```
 

--- a/packages/cfpb-grid/usage.md
+++ b/packages/cfpb-grid/usage.md
@@ -48,7 +48,7 @@ This customized variable would be placed in the same file
 where this component's less file is imported.
 
 ```
-@grid_wrapper-width: 1200px;
+@grid_wrapper-width: 1230px;
 ```
 
 The grid's maximum width in px.
@@ -245,61 +245,61 @@ content first in the source order, but it's here if you absolutely need it.
 
 ## Example grid layouts
 
-### 12 columns w/ 1200px max width
+### 12 columns w/ 1230px max width
 
 <div class="cols-12">
     <section>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
     </section>
 
     <section>
-        <div class="col col-2"><p>two</p></div>
-        <div class="col col-2"><p>two</p></div>
-        <div class="col col-2"><p>two</p></div>
-        <div class="col col-2"><p>two</p></div>
-        <div class="col col-2"><p>two</p></div>
-        <div class="col col-2"><p>two</p></div>
+        <div class="col col-2"><div>two</div></div>
+        <div class="col col-2"><div>two</div></div>
+        <div class="col col-2"><div>two</div></div>
+        <div class="col col-2"><div>two</div></div>
+        <div class="col col-2"><div>two</div></div>
+        <div class="col col-2"><div>two</div></div>
     </section>
 
     <section>
-        <div class="col col-2"><p>two</p></div>
-        <div class="col col-3"><p>three</p></div>
-        <div class="col col-2"><p>two</p></div>
-        <div class="col col-3"><p>three</p></div>
-        <div class="col col-2"><p>two</p></div>
+        <div class="col col-2"><div>two</div></div>
+        <div class="col col-3"><div>three</div></div>
+        <div class="col col-2"><div>two</div></div>
+        <div class="col col-3"><div>three</div></div>
+        <div class="col col-2"><div>two</div></div>
     </section>
 
     <section>
-        <div class="col col-3"><p>three</p></div>
-        <div class="col col-3"><p>three</p></div>
-        <div class="col col-3"><p>three</p></div>
-        <div class="col col-3"><p>three</p></div>
+        <div class="col col-3"><div>three</div></div>
+        <div class="col col-3"><div>three</div></div>
+        <div class="col col-3"><div>three</div></div>
+        <div class="col col-3"><div>three</div></div>
     </section>
 
     <section>
-        <div class="col col-4"><p>four</p></div>
-        <div class="col col-4"><p>four</p></div>
-        <div class="col col-4"><p>four</p></div>
+        <div class="col col-4"><div>four</div></div>
+        <div class="col col-4"><div>four</div></div>
+        <div class="col col-4"><div>four</div></div>
     </section>
 
     <section>
-        <div class="col col-6"><p>six</p></div>
-        <div class="col col-6"><p>six</p></div>
+        <div class="col col-6"><div>six</div></div>
+        <div class="col col-6"><div>six</div></div>
     </section>
 
     <section>
-        <div class="col col-12"><p>twelve</p></div>
+        <div class="col col-12"><div>twelve</div></div>
     </section>
 
 </div>
@@ -307,57 +307,57 @@ content first in the source order, but it's here if you absolutely need it.
 ```
 <div class="cols-12">
     <section>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
-        <div class="col col-1"><p>one</p></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
+        <div class="col col-1"><div>one</div></div>
     </section>
 
     <section>
-        <div class="col col-2"><p>two</p></div>
-        <div class="col col-2"><p>two</p></div>
-        <div class="col col-2"><p>two</p></div>
-        <div class="col col-2"><p>two</p></div>
-        <div class="col col-2"><p>two</p></div>
-        <div class="col col-2"><p>two</p></div>
+        <div class="col col-2"><div>two</div></div>
+        <div class="col col-2"><div>two</div></div>
+        <div class="col col-2"><div>two</div></div>
+        <div class="col col-2"><div>two</div></div>
+        <div class="col col-2"><div>two</div></div>
+        <div class="col col-2"><div>two</div></div>
     </section>
 
     <section>
-        <div class="col col-2"><p>two</p></div>
-        <div class="col col-3"><p>three</p></div>
-        <div class="col col-2"><p>two</p></div>
-        <div class="col col-3"><p>three</p></div>
-        <div class="col col-2"><p>two</p></div>
+        <div class="col col-2"><div>two</div></div>
+        <div class="col col-3"><div>three</div></div>
+        <div class="col col-2"><div>two</div></div>
+        <div class="col col-3"><div>three</div></div>
+        <div class="col col-2"><div>two</div></div>
     </section>
 
     <section>
-        <div class="col col-3"><p>three</p></div>
-        <div class="col col-3"><p>three</p></div>
-        <div class="col col-3"><p>three</p></div>
-        <div class="col col-3"><p>three</p></div>
+        <div class="col col-3"><div>three</div></div>
+        <div class="col col-3"><div>three</div></div>
+        <div class="col col-3"><div>three</div></div>
+        <div class="col col-3"><div>three</div></div>
     </section>
 
     <section>
-        <div class="col col-4"><p>four</p></div>
-        <div class="col col-4"><p>four</p></div>
-        <div class="col col-4"><p>four</p></div>
+        <div class="col col-4"><div>four</div></div>
+        <div class="col col-4"><div>four</div></div>
+        <div class="col col-4"><div>four</div></div>
     </section>
 
     <section>
-        <div class="col col-6"><p>six</p></div>
-        <div class="col col-6"><p>six</p></div>
+        <div class="col col-6"><div>six</div></div>
+        <div class="col col-6"><div>six</div></div>
     </section>
 
     <section>
-        <div class="col col-12"><p>twelve</p></div>
+        <div class="col col-12"><div>twelve</div></div>
     </section>
 </div>
 ```
@@ -366,36 +366,36 @@ content first in the source order, but it's here if you absolutely need it.
 
 <div class="cols-12">
     <section>
-        <div class="col col-1 suffix-11"><p>prefix 0, suffix 11</p></div>
-        <div class="col col-1 prefix-1 suffix-10"><p>prefix 1, suffix 10</p></div>
-        <div class="col col-1 prefix-2 suffix-9"><p>prefix 2, suffix 9</p></div>
-        <div class="col col-1 prefix-3 suffix-8"><p>prefix 3, suffix 8</p></div>
-        <div class="col col-1 prefix-4 suffix-7"><p>prefix 4, suffix 7</p></div>
-        <div class="col col-1 prefix-5 suffix-6"><p>prefix 5, suffix 6</p></div>
-        <div class="col col-1 prefix-6 suffix-5"><p>prefix 6, suffix 5</p></div>
-        <div class="col col-1 prefix-7 suffix-4"><p>prefix 7, suffix 4</p></div>
-        <div class="col col-1 prefix-8 suffix-3"><p>prefix 8, suffix 3</p></div>
-        <div class="col col-1 prefix-9 suffix-2"><p>prefix 9, suffix 2</p></div>
-        <div class="col col-1 prefix-10 suffix-1"><p>prefix 10, suffix 1</p></div>
-        <div class="col col-1 prefix-11"><p>prefix 11, suffix 0</p></div>
+        <div class="col col-1 suffix-11"><div>prefix 0, suffix 11</div></div>
+        <div class="col col-1 prefix-1 suffix-10"><div>prefix 1, suffix 10</div></div>
+        <div class="col col-1 prefix-2 suffix-9"><div>prefix 2, suffix 9</div></div>
+        <div class="col col-1 prefix-3 suffix-8"><div>prefix 3, suffix 8</div></div>
+        <div class="col col-1 prefix-4 suffix-7"><div>prefix 4, suffix 7</div></div>
+        <div class="col col-1 prefix-5 suffix-6"><div>prefix 5, suffix 6</div></div>
+        <div class="col col-1 prefix-6 suffix-5"><div>prefix 6, suffix 5</div></div>
+        <div class="col col-1 prefix-7 suffix-4"><div>prefix 7, suffix 4</div></div>
+        <div class="col col-1 prefix-8 suffix-3"><div>prefix 8, suffix 3</div></div>
+        <div class="col col-1 prefix-9 suffix-2"><div>prefix 9, suffix 2</div></div>
+        <div class="col col-1 prefix-10 suffix-1"><div>prefix 10, suffix 1</div></div>
+        <div class="col col-1 prefix-11"><div>prefix 11, suffix 0</div></div>
     </section>
 </div>
 
 ```
 <div class="cols-12">
     <section>
-        <div class="col col-1 suffix-11"><p>prefix 0, suffix 11</p></div>
-        <div class="col col-1 prefix-1 suffix-10"><p>prefix 1, suffix 10</p></div>
-        <div class="col col-1 prefix-2 suffix-9"><p>prefix 2, suffix 9</p></div>
-        <div class="col col-1 prefix-3 suffix-8"><p>prefix 3, suffix 8</p></div>
-        <div class="col col-1 prefix-4 suffix-7"><p>prefix 4, suffix 7</p></div>
-        <div class="col col-1 prefix-5 suffix-6"><p>prefix 5, suffix 6</p></div>
-        <div class="col col-1 prefix-6 suffix-5"><p>prefix 6, suffix 5</p></div>
-        <div class="col col-1 prefix-7 suffix-4"><p>prefix 7, suffix 4</p></div>
-        <div class="col col-1 prefix-8 suffix-3"><p>prefix 8, suffix 3</p></div>
-        <div class="col col-1 prefix-9 suffix-2"><p>prefix 9, suffix 2</p></div>
-        <div class="col col-1 prefix-10 suffix-1"><p>prefix 10, suffix 1</p></div>
-        <div class="col col-1 prefix-11"><p>prefix 11, suffix 0</p></div>
+        <div class="col col-1 suffix-11"><div>prefix 0, suffix 11</div></div>
+        <div class="col col-1 prefix-1 suffix-10"><div>prefix 1, suffix 10</div></div>
+        <div class="col col-1 prefix-2 suffix-9"><div>prefix 2, suffix 9</div></div>
+        <div class="col col-1 prefix-3 suffix-8"><div>prefix 3, suffix 8</div></div>
+        <div class="col col-1 prefix-4 suffix-7"><div>prefix 4, suffix 7</div></div>
+        <div class="col col-1 prefix-5 suffix-6"><div>prefix 5, suffix 6</div></div>
+        <div class="col col-1 prefix-6 suffix-5"><div>prefix 6, suffix 5</div></div>
+        <div class="col col-1 prefix-7 suffix-4"><div>prefix 7, suffix 4</div></div>
+        <div class="col col-1 prefix-8 suffix-3"><div>prefix 8, suffix 3</div></div>
+        <div class="col col-1 prefix-9 suffix-2"><div>prefix 9, suffix 2</div></div>
+        <div class="col col-1 prefix-10 suffix-1"><div>prefix 10, suffix 1</div></div>
+        <div class="col col-1 prefix-11"><div>prefix 11, suffix 0</div></div>
     </section>
 </div>
 ```
@@ -405,49 +405,49 @@ content first in the source order, but it's here if you absolutely need it.
 <div class="cols-12">
     <section>
         <div class="col col-6">
-            <p>six</p>
+            <div>six</div>
             <section class="nested">
-                <div class="col col-4"><p>four</p></div>
-                <div class="col col-4"><p>four</p></div>
-                <div class="col col-4"><p>four</p></div>
+                <div class="col col-4"><div>four</div></div>
+                <div class="col col-4"><div>four</div></div>
+                <div class="col col-4"><div>four</div></div>
             </section>
         </div>
 
         <div class="col col-6">
-            <p>six</p>
+            <div>six</div>
             <section class="nested">
-                <div class="col col-4"><p>four</p></div>
-                <div class="col col-4"><p>four</p></div>
-                <div class="col col-4"><p>four</p></div>
+                <div class="col col-4"><div>four</div></div>
+                <div class="col col-4"><div>four</div></div>
+                <div class="col col-4"><div>four</div></div>
             </section>
         </div>
     </section>
 
     <section>
         <div class="col col-3">
-            <p>three</p>
+            <div>three</div>
             <section class="nested">
-                <div class="col col-6"><p>six</p></div>
-                <div class="col col-6"><p>six</p></div>
+                <div class="col col-6"><div>six</div></div>
+                <div class="col col-6"><div>six</div></div>
             </section>
         </div>
 
         <div class="col col-6">
-            <p>six</p>
+            <div>six</div>
             <section class="nested">
-                <div class="col col-4"><p>four</p></div>
-                <div class="col col-4"><p>four</p></div>
-                <div class="col col-4"><p>four</p></div>
+                <div class="col col-4"><div>four</div></div>
+                <div class="col col-4"><div>four</div></div>
+                <div class="col col-4"><div>four</div></div>
             </section>
         </div>
 
         <div class="col col-3">
-            <p>three</p>
+            <div>three</div>
             <section class="nested">
-                <div class="col col-3"><p>three</p></div>
-                <div class="col col-3"><p>three</p></div>
-                <div class="col col-3"><p>three</p></div>
-                <div class="col col-3"><p>three</p></div>
+                <div class="col col-3"><div>three</div></div>
+                <div class="col col-3"><div>three</div></div>
+                <div class="col col-3"><div>three</div></div>
+                <div class="col col-3"><div>three</div></div>
             </section>
         </div>
     </section>
@@ -458,49 +458,49 @@ content first in the source order, but it's here if you absolutely need it.
 <div class="cols-12">
     <section>
         <div class="col col-6">
-            <p>six</p>
+            <div>six</div>
             <section class="nested">
-                <div class="col col-4"><p>four</p></div>
-                <div class="col col-4"><p>four</p></div>
-                <div class="col col-4"><p>four</p></div>
+                <div class="col col-4"><div>four</div></div>
+                <div class="col col-4"><div>four</div></div>
+                <div class="col col-4"><div>four</div></div>
             </section>
         </div>
 
         <div class="col col-6">
-            <p>six</p>
+            <div>six</div>
             <section class="nested">
-                <div class="col col-4"><p>four</p></div>
-                <div class="col col-4"><p>four</p></div>
-                <div class="col col-4"><p>four</p></div>
+                <div class="col col-4"><div>four</div></div>
+                <div class="col col-4"><div>four</div></div>
+                <div class="col col-4"><div>four</div></div>
             </section>
         </div>
     </section>
 
     <section>
         <div class="col col-3">
-            <p>three</p>
+            <div>three</div>
             <section class="nested">
-                <div class="col col-6"><p>six</p></div>
-                <div class="col col-6"><p>six</p></div>
+                <div class="col col-6"><div>six</div></div>
+                <div class="col col-6"><div>six</div></div>
             </section>
         </div>
 
         <div class="col col-6">
-            <p>six</p>
+            <div>six</div>
             <section class="nested">
-                <div class="col col-4"><p>four</p></div>
-                <div class="col col-4"><p>four</p></div>
-                <div class="col col-4"><p>four</p></div>
+                <div class="col col-4"><div>four</div></div>
+                <div class="col col-4"><div>four</div></div>
+                <div class="col col-4"><div>four</div></div>
             </section>
         </div>
 
         <div class="col col-3">
-            <p>three</p>
+            <div>three</div>
             <section class="nested">
-                <div class="col col-3"><p>three</p></div>
-                <div class="col col-3"><p>three</p></div>
-                <div class="col col-3"><p>three</p></div>
-                <div class="col col-3"><p>three</p></div>
+                <div class="col col-3"><div>three</div></div>
+                <div class="col col-3"><div>three</div></div>
+                <div class="col col-3"><div>three</div></div>
+                <div class="col col-3"><div>three</div></div>
             </section>
         </div>
     </section>


### PR DESCRIPTION
The grid demo was using paragraph tags for its demo labels, which were picking up the max-width we set on paragraphs, so that they weren't extending 100%. This PR changes those tags to be paragraph tags.

Also, we set the `@grid_wrapper-width` variable in code to be 1230px, but referenced it in the docs as 1200px. This PR makes all occurrences show 1230px. 

## Changes

- Change grid demo label elements to be `<div>`s instead of `<p>`s.
- Update `@grid_wrapper-width` values to be `1230px`.

## Testing

1. PR preview grid demo page should show grid cells that extend their full area.

## Screenshots

Before:
<img width="807" alt="Screen Shot 2023-07-12 at 6 15 41 PM" src="https://github.com/cfpb/design-system/assets/704760/8835a7da-1e1c-4dd8-a30a-d0ae546548e2">

After:
<img width="821" alt="Screen Shot 2023-07-12 at 6 15 34 PM" src="https://github.com/cfpb/design-system/assets/704760/ae8c3818-2f25-440a-9348-8735b72c211a">


