### PR TITLE
second level nav missing

### DIFF
--- a/docs/_data/side-navigation.yml
+++ b/docs/_data/side-navigation.yml
@@ -83,7 +83,8 @@ first-level:
               - page: Info unit groups
               - page: Interactive charts
   - heading: Pages
-    nav-items:
+    second-level:
+      nav-items:
       - page: Landing pages
       - page: Sublanding pages
       - page: Browse pages

--- a/docs/_data/side-navigation.yml
+++ b/docs/_data/side-navigation.yml
@@ -84,14 +84,15 @@ first-level:
               - page: Interactive charts
   - heading: Pages
     second-level:
-      nav-items:
-      - page: Landing pages
-      - page: Sublanding pages
-      - page: Browse pages
-      - page: Learn pages
-      - page: Filterable list pages
-      - page: Document detail pages
-      - page: Story pages
+      - heading:
+        nav-items:
+        - page: Landing pages
+        - page: Sublanding pages
+        - page: Browse pages
+        - page: Learn pages
+        - page: Filterable list pages
+        - page: Document detail pages
+        - page: Story pages
   - heading: Development
     second-level:
       - heading: Atomic

--- a/docs/pages/browse-pages.md
+++ b/docs/pages/browse-pages.md
@@ -2,6 +2,7 @@
 title: Browse pages
 layout: variation
 section: pages
+eyebrow: 
 status: Released
 description: >-
   "Browse" page types provide detailed information related to a larger topic

--- a/docs/pages/browse-pages.md
+++ b/docs/pages/browse-pages.md
@@ -2,7 +2,6 @@
 title: Browse pages
 layout: variation
 section: pages
-eyebrow: 
 status: Released
 description: >-
   "Browse" page types provide detailed information related to a larger topic


### PR DESCRIPTION
Fix for missing indentation of "Pages" links in Design System sidenav. Taken from Issue 1294:

It's weird that https://cfpb.github.io/design-system/pages/ doesn't have indented links, unlike every other section:

