### PR TITLE
cfpb-icons: Add numerical icons

### DIFF
--- a/docs/pages/iconography.md
+++ b/docs/pages/iconography.md
@@ -26,6 +26,8 @@ variation_groups:
 
           - [Web application icons](#web-application-icons)
 
+          - [Numerical icons](#numerical-icons)
+
 
           The RTL (right-to-left) column designates whether an icon will flip
           on pages where the HTML element has its language set to an RTL-reading
@@ -427,6 +429,55 @@ variation_groups:
           | {% include icons/user.svg %} | {% include icons/user-round.svg %} | user | person | |
 
           | {% include icons/wifi.svg %} | {% include icons/wifi-round.svg %} | wifi | wi-fi, wireless, signal | |
+
+          {: class="icon-table"}
+
+          ### Numerical icons
+
+
+          | icon | icon-round | canonical name | aliases (for searchability only) | RTL? |
+
+          | ---- | ---------- | -------------- | ------- | ------ |
+
+          | {% include icons/zero-closed.svg %} | | zero-closed | | |
+
+          | {% include icons/one-closed.svg %} | | one-closed | | |
+
+          | {% include icons/two-closed.svg %} | | two-closed | | |
+
+          | {% include icons/three-closed.svg %} | | three-closed | | |
+
+          | {% include icons/four-closed.svg %} | | four-closed | | |
+
+          | {% include icons/five-closed.svg %} | | five-closed | | |
+
+          | {% include icons/six-closed.svg %} | | six-closed | | |
+
+          | {% include icons/seven-closed.svg %} | | seven-closed | | |
+
+          | {% include icons/eight-closed.svg %} | | eight-closed | | |
+
+          | {% include icons/nine-closed.svg %} | | nine-closed | | |
+
+          | {% include icons/zero-open.svg %} | | zero-open | | |
+
+          | {% include icons/one-open.svg %} | | one-open | | |
+
+          | {% include icons/two-open.svg %} | | two-open | | |
+
+          | {% include icons/three-open.svg %} | | three-open | | |
+
+          | {% include icons/four-open.svg %} | | four-open | | |
+
+          | {% include icons/five-open.svg %} | | five-open | | |
+
+          | {% include icons/six-open.svg %} | | six-open | | |
+
+          | {% include icons/seven-open.svg %} | | seven-open | | |
+
+          | {% include icons/eight-open.svg %} | | eight-open | | |
+
+          | {% include icons/nine-open.svg %} | | nine-open | | |
 
           {: class="icon-table"}
         variation_name: ''

--- a/packages/cfpb-icons/usage.md
+++ b/packages/cfpb-icons/usage.md
@@ -378,3 +378,51 @@ search this page for a particular icon.
 | {% include icons/wifi.svg %}           | {% include icons/wifi-round.svg %}           | wifi           | wi-fi, wireless, signal          |
 
 {: class="icon-table"}
+
+### Numerical icons
+
+| icon | icon-round | canonical name | aliases (for searchability only) | RTL? |
+
+| ---- | ---------- | -------------- | ------- | ------ |
+
+| {% include icons/zero-closed.svg %} | | zero-closed | | |
+
+| {% include icons/one-closed.svg %} | | one-closed | | |
+
+| {% include icons/two-closed.svg %} | | two-closed | | |
+
+| {% include icons/three-closed.svg %} | | three-closed | | |
+
+| {% include icons/four-closed.svg %} | | four-closed | | |
+
+| {% include icons/five-closed.svg %} | | five-closed | | |
+
+| {% include icons/six-closed.svg %} | | six-closed | | |
+
+| {% include icons/seven-closed.svg %} | | seven-closed | | |
+
+| {% include icons/eight-closed.svg %} | | eight-closed | | |
+
+| {% include icons/nine-closed.svg %} | | nine-closed | | |
+
+| {% include icons/zero-open.svg %} | | zero-open | | |
+
+| {% include icons/one-open.svg %} | | one-open | | |
+
+| {% include icons/two-open.svg %} | | two-open | | |
+
+| {% include icons/three-open.svg %} | | three-open | | |
+
+| {% include icons/four-open.svg %} | | four-open | | |
+
+| {% include icons/five-open.svg %} | | five-open | | |
+
+| {% include icons/six-open.svg %} | | six-open | | |
+
+| {% include icons/seven-open.svg %} | | seven-open | | |
+
+| {% include icons/eight-open.svg %} | | eight-open | | |
+
+| {% include icons/nine-open.svg %} | | nine-open | | |
+
+{: class="icon-table"}


### PR DESCRIPTION
We had numerical icons in the source svg folder, but hadn't included them in the DS docs for some reason. 

## Additions

- Add numerical icons to the docs.

## Testing

1. The PR preview iconography page should include icons.

## Screenshots

<img width="885" alt="Screenshot 2023-07-20 at 3 13 15 PM" src="https://github.com/cfpb/design-system/assets/704760/91107208-1406-46d1-a39d-a5bd4d4d11d5">
