### PR TITLE
Make licensed font loading optional, clean up obsolete `@webfont-` variables

### DIFF
--- a/packages/cfpb-core/src/base.less
+++ b/packages/cfpb-core/src/base.less
@@ -9,7 +9,7 @@
 
 body {
   color: @text;
-  font-family: 'Avenir Next', Arial, sans-serif;
+  font-family: @font-stack;
   font-size: unit((@base-font-size-px / 16 * 100), %);
   line-height: @base-line-height;
   -webkit-font-smoothing: antialiased;
@@ -21,7 +21,7 @@ select,
 textarea {
   // Must set these explicitly to override Normalize.css's provided default
   // of `font-family: sans-serif;`
-  font-family: 'Avenir Next', Arial, sans-serif;
+  font-family: @font-stack;
 }
 
 strong,

--- a/packages/cfpb-core/src/vars.less
+++ b/packages/cfpb-core/src/vars.less
@@ -53,9 +53,6 @@
 @size-vi: 12px; // h6-size
 @size-code: 13px; // Custom size only for Mono code blocks
 
-// Web fonts
+// Font variables
 
-@webfont-regular: Arial;
-@webfont-italic: Arial;
-@webfont-medium: Arial;
-@webfont-demi: Arial;
+@font-stack: system-ui, sans-serif;

--- a/packages/cfpb-typography/src/cfpb-typography.less
+++ b/packages/cfpb-typography/src/cfpb-typography.less
@@ -12,12 +12,11 @@
 //
 
 // Font variables
-@webfont-regular: 'AvenirNextLTW01-Regular';
-@webfont-italic: @webfont-regular;
-@webfont-medium: 'AvenirNextLTW01-Medium';
-@webfont-demi: @webfont-medium;
+@font-stack: "Avenir Next", Arial, sans-serif;
 
 // Webfont variables
+// This is the path to your stylesheet containing @font-face rules.
+@font-face-path: 'licensed-fonts.less';
 // This is the path for self-hosted fonts.
 @cf-fonts-path: '/static/fonts';
 
@@ -78,4 +77,5 @@
 //
 // Import web fonts
 //
-@import (less) 'licensed-fonts.less';
+// To not load any fonts, set @font-face-path to an empty string in your project.
+@import (less, optional) '@{font-face-path}';

--- a/packages/cfpb-typography/src/licensed-fonts.less
+++ b/packages/cfpb-typography/src/licensed-fonts.less
@@ -4,28 +4,6 @@
    ========================================================================== */
 
 @font-face {
-  font-family: 'AvenirNextLTW01-Regular';
-  src: url('@{cf-fonts-path}/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2')
-      format('woff2'),
-    url('@{cf-fonts-path}/1e9892c0-6927-4412-9874-1b82801ba47a.woff')
-      format('woff');
-  font-style: normal;
-  font-weight: normal;
-  font-display: fallback;
-}
-
-@font-face {
-  font-family: 'AvenirNextLTW01-Medium';
-  src: url('@{cf-fonts-path}/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2')
-      format('woff2'),
-    url('@{cf-fonts-path}/f26faddb-86cc-4477-a253-1e1287684336.woff')
-      format('woff');
-  font-style: normal;
-  font-weight: 500;
-  font-display: fallback;
-}
-
-@font-face {
   font-family: 'Avenir Next';
   src: url('@{cf-fonts-path}/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2')
       format('woff2'),


### PR DESCRIPTION
When loading the cfpb-typography component's `cfpb-typography.less` file, there is currently no means to prevent it from importing `licensed-fonts.less` and trying to find the various Avenir Next font files. This PR adds the ability to do so by introducing a new variable, `@font-face-path`, which can be set to an empty string in a consuming project's Less in order to avoid loading `licensed-fonts.less` (or can be set to some other path to a file with the project's own `@font-face` rules).

Additionally, it seemed like the `@webfont-` variables were no longer used anywhere, nor were the fonts loaded under the name `AvenirNextLTW01-`. The font stack seems completely controlled now by the explicit declaration of `'Avenir Next', Arial, sans-serif` on `body` in cfpb-core's `base.less`, so I have added another new variable, @font-stack, so that can be overridden, and I have cleaned up the stuff that's no longer used.

Opening this as a draft because I haven't updated any of the docs yet. Assuming this all checks out with CFPB front-end devs, I will update the docs before merging.


## Additions

- `@font-face-path` variable for telling cfpb-typography where to find `@font-face` rules
- `@font-stack` variable for easier customization of the entire stack

## Removals

- `@webfont-` variables
- `AvenirNextLTW01-` `@font-face` declarations


## Testing

1. Pull branch
2. Link to cf.gov
3. Rebuild cf.gov frontend
4. Verify that there are no visible changes
5. Add a `@font-stack` variable to `cf-theme-overrides.less` with a noticeably different font, rebuild, and verify that you see the new font


## Todos

- [ ] update docs

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
