### PR TITLE
fix: Update explanation of icon height scaling to include the updated SVG height x width

### DIFF
--- a/packages/cfpb-icons/src/cfpb-icons.less
+++ b/packages/cfpb-icons/src/cfpb-icons.less
@@ -11,7 +11,7 @@
 // Size variables
 //
 
-// Icon SVGs viewbox is 1000 (w) x 1200 (h).
+// Icons' SVG viewbox are a consistent 19px (h) x variable (w).
 // The height matches the 19px rendered canvas of text set in Avenir Next
 // sized at 16px (19/16 = 1.1875).
 @cf-icon-height: 1.1875em;


### PR DESCRIPTION
Align code documentation with the current state of Icons

## Changes

- Update comment about icon size from 1000x1200 to variable (w) x 19px (h)

