### PR TITLE
Remove problematic icon max-width property

### DIFF
--- a/packages/cfpb-icons/src/cfpb-icons.less
+++ b/packages/cfpb-icons/src/cfpb-icons.less
@@ -43,9 +43,6 @@
   vertical-align: text-top;
   fill: currentcolor;
 
-  // IE 10 & 11 require a max-width otherwise the SVG takes up 100%.
-  max-width: 1em;
-
   &__updating,
   &__updating-round {
     animation: updating-animation 1.25s infinite linear;


### PR DESCRIPTION
We have dropped support for legacy IE and no longer need to set a max width for our icons. The property causes icons wider than 16px to display smaller than intended.

Fixes https://github.com/cfpb/design-system/issues/1698

## Removals

- Hard-coded SVG icon maximum width

## Testing

1. Follow the [reproduction steps](https://github.com/cfpb/design-system/issues/1698) with the [PR preview icon page](https://deploy-preview-1699--cfpb-design-system.netlify.app/design-system/foundation/iconography#icons-with-text). The icons should be 17px wide instead of 16px.

