### PR TITLE
Update a-label_helper CSS

### DIFF
--- a/packages/cfpb-forms/src/atoms/label.less
+++ b/packages/cfpb-forms/src/atoms/label.less
@@ -21,5 +21,10 @@
 
     // Overwrites heading-4 margin.
     margin-bottom: unit((10px / @font-size), em);
+
+    // Add a gap between the label helper and label heading
+    .a-label_helper__block {
+      margin-top: unit((10px / @base-font-size-px), rem);
+    }
   }
 }

--- a/packages/cfpb-forms/src/atoms/label.less
+++ b/packages/cfpb-forms/src/atoms/label.less
@@ -3,7 +3,12 @@
 
   &_helper {
     color: @label-helper;
-    font-size: unit((@size-v / @base-font-size-px), em);
+    font-size: unit((16px / @base-font-size-px), rem);
+    font-weight: normal;
+
+    .respond-to-max( @bp-xs-max, {
+      font-size: unit((14px / @base-font-size-px), rem);
+    });
 
     &__block {
       display: block;
@@ -20,15 +25,5 @@
 
     // Overwrites heading-4 margin.
     margin-bottom: unit((10px / @font-size), em);
-
-    .a-label_helper {
-      font-size: unit((@base-font-size-px / @font-size), em);
-      font-weight: normal;
-
-      &__block {
-        // Add a gap between the label helper and label.
-        margin-top: unit((10px / @base-font-size-px), em);
-      }
-    }
   }
 }

--- a/packages/cfpb-forms/src/atoms/label.less
+++ b/packages/cfpb-forms/src/atoms/label.less
@@ -6,10 +6,6 @@
     font-size: unit((16px / @base-font-size-px), rem);
     font-weight: normal;
 
-    .respond-to-max( @bp-xs-max, {
-      font-size: unit((14px / @base-font-size-px), rem);
-    });
-
     &__block {
       display: block;
 


### PR DESCRIPTION
**Taken from Bug #1709** 

The live code for the helper text on "[Fieldsets](https://cfpb.github.io/design-system/components/fieldsets)" and "[Helper text](https://cfpb.github.io/design-system/components/helper-text)" pages does not match specs.

NOTE: the [Helper text](http://localhost:4000/design-system/components/helper-text) page is also affected 

**To Reproduce Original Problem:**

1. Navigate to http://localhost:4000/design-system/components/fieldsets
2. Inspect any live code helper text example on the page _(Text is 500 instead of 400 and scales to 14px at mobile)_

**To see CSS fix:**
yarn build
Navigate to and inspect http://localhost:4000/design-system/components/fieldsets
Navigate to and inspect http://localhost:4000/design-system/components/helper-text
Verify font-weight and font-size have both been updated to 400 and 16px on desktop and 14px on mobile. 

**Expected behavior** - Live code example should match Design System specs
