### PR TITLE
update date field placeholder text

### DIFF
--- a/packages/cfpb-forms/src/atoms/text-input.less
+++ b/packages/cfpb-forms/src/atoms/text-input.less
@@ -80,6 +80,14 @@
   appearance: none;
 }
 
+//Change place holder text to gray (#5a5d61)
 ::placeholder {
+  color: @input-text__placeholder;
+}
+::-webkit-input-placeholder {
+  color: @input-text__placeholder;
+}
+//Force placeholder text color change for "date" fieldtype
+input[type='date']::-webkit-datetime-edit {
   color: @input-text__placeholder;
 }


### PR DESCRIPTION
**Taken from #1713** 

**The date-picker is not pulling in the placeholder text styling. The placeholder CSS here** https://github.com/cfpb/design-system/blob/main/packages/cfpb-forms/src/atoms/text-input.less#L83 **needs to be updated to apply to the date picker inputs.**

**To Reproduce**
Steps to reproduce the behavior:

1. Go to '[/design-system/components/text-inputs#date-picker-inputs](https://cfpb.github.io/design-system/components/text-inputs#date-picker-inputs)'
2. Look at placeholder text color
3. Compare to [/design-system/components/helper-text#placeholder-text-1](https://cfpb.github.io/design-system/components/helper-text#placeholder-text-1)

**Current Behavior**
Placeholder text in date field is same color as label text (#101820), which is darker than placeholder text (#5a5d61).
![Screenshot 2023-09-07 at 5 54 16 PM](https://github.com/cfpb/design-system/assets/130792942/e9732e04-f4bb-4714-ba01-b268e047175e)

**See Fix**

1. Pull branch
2. yarn build
3. Go to '[/design-system/components/text-inputs#date-picker-inputs](https://cfpb.github.io/design-system/components/text-inputs#date-picker-inputs)'
4. Verify text color has changed to standard placeholder gray (#5a5d61)
![Screenshot 2023-09-07 at 5 52 22 PM](https://github.com/cfpb/design-system/assets/130792942/b0c855a4-1f5a-4c81-8c4e-b51a42c1d4f2)

**Expected behavior**
Date-picker placeholder text should match the styling of other placeholder text: /design-system/components/helper-text#placeholder-text-1