### PR TITLE
Increase Contrast of Helper Text

### DIFF
--- a/docs/pages/buttons.md
+++ b/docs/pages/buttons.md
@@ -102,7 +102,7 @@ variation_groups:
         variation_specs: |-
           #### Default/Hover/Active
 
-          * Avenir Next Medium, 16px, Gray (#5a5d61)
+          * Avenir Next Medium, 16px, Dark Gray (#43484e)
           * Background: Gray 20 (#d2d3d5)
           * Cursor set to `not-allowed`
 

--- a/docs/pages/checkboxes.md
+++ b/docs/pages/checkboxes.md
@@ -54,7 +54,7 @@ variation_groups:
               <input class="a-checkbox" type="checkbox" id="test_checkbox_basic_disabled_selected" disabled checked>
               <label class="a-label" for="test_checkbox_basic_disabled_selected">Disabled/selected</label>
           </div>
-        variation_description: ""
+        variation_description: ''
         variation_name: Standard checkboxes
         variation_specs: >-
           #### Default checkbox
@@ -104,7 +104,7 @@ variation_groups:
 
           * Background: Gray 10 (#e7e8e9)
 
-          * Avenir Next Regular, 16 px, Gray (#5a5d61)
+          * Avenir Next Regular, 16 px, Dark Gray (#43484e)
 
 
           #### Spacing
@@ -112,7 +112,7 @@ variation_groups:
 
           Text spacing should inform spacing of checkboxes, and a checkbox should be vertically centered with the first line of text in an option.
     variation_group_name: Types
-  - variation_group_description: ""
+  - variation_group_description: ''
     variations:
       - variation_code_snippet: >-
           <div class="m-form-field m-form-field__checkbox
@@ -236,8 +236,9 @@ variation_groups:
 
           * Border: 1 px, Gray 60 (#919395)
           * Background: Gray 20 (#d2d3d5)
-          * Avenir Next Regular, 16 px, Gray (#5a5d61)
-        variation_description: For better usability, consider using checkboxes with
+          * Avenir Next Regular, 16 px, Dark Gray (#43484e)
+        variation_description:
+          For better usability, consider using checkboxes with
           large target areas. These are easier to interact with (especially on
           smaller screens) and harder to miss. They are especially desirable
           when the form will have heavy mobile usage. Given the amount of real
@@ -263,7 +264,7 @@ description: Use checkboxes when the user can select more than one option from a
   list. Make clear with helper text that this is the case. Use [radio
   buttons](/design-system/components/radio-buttons) when the user can choose
   only one option from a list.
-use_cases: ""
+use_cases: ''
 behavior: >-
   Selecting the checkbox or touching the label text next to it should toggle the
   state of the checkbox on and off.
@@ -273,5 +274,5 @@ behavior: >-
 accessibility: To optimize screen reader accessibility, lay out checkboxes
   vertically rather than horizontally.
 last_updated: 2019-09-17T14:30:15.293Z
-research: ""
+research: ''
 ---

--- a/docs/pages/dropdowns.md
+++ b/docs/pages/dropdowns.md
@@ -115,7 +115,7 @@ variation_groups:
           <h3 class="h4">Disabled</h3>
 
           * Background: Gray 10 (#e7e8e9)
-          * Avenir Next Regular, 16 px, Gray (#5a5d61)
+          * Avenir Next Regular, 16 px, Dark Gray (#43484e)
     variation_group_name: Dropdowns
   - variation_group_name: Multiselects
     variations:

--- a/docs/pages/helper-text.md
+++ b/docs/pages/helper-text.md
@@ -26,7 +26,7 @@ variation_groups:
 
           #### Block helper text
 
-          - Avenir Next Regular, 16 px, Gray (#5a5d61)
+          - Avenir Next Regular, 16 px, Dark Gray (#43484e)
 
           - Margin top: 10 px
 
@@ -45,7 +45,7 @@ variation_groups:
         variation_specs: >-
           #### Inline helper text
 
-          * Avenir Next Regular, 16 px, Gray (#5a5d61)
+          * Avenir Next Regular, 16 px, Dark Gray (#43484e)
 
           * Margin bottom: 10 px
 
@@ -68,7 +68,7 @@ variation_groups:
         variation_name: Placeholder text
         variation_specs: |-
           #### Placeholder text
-          Avenir Next Regular, 16 px, Gray (#5a5d61)
+          Avenir Next Regular, 16 px, Dark Gray (#43484e)
     variation_group_name: Types
     variation_group_description:
       'Types of helper text include block helper text,

--- a/docs/pages/radio-buttons.md
+++ b/docs/pages/radio-buttons.md
@@ -172,7 +172,7 @@ variation_groups:
 
           * Border: 1 px, Gray 60 (#919395)
           * Background: Gray 20 (#d2d3d5)
-          * Avenir Next Regular, 16 px, Gray (#5a5d61)
+          * Avenir Next Regular, 16 px, Dark Gray (#43484e)
   - variations:
       - variation_code_snippet: >-
           <div class="m-form-field m-form-field__radio m-form-field__lg-target">

--- a/docs/pages/sample-component-page.md
+++ b/docs/pages/sample-component-page.md
@@ -124,7 +124,7 @@ variation_groups:
           #### Disabled
           - Border: 1 px, Gray 60 (#919395)
           - Background: Gray 10 (#e7e8e9)
-          - Avenir Next Regular, 16 px, Gray (#5a5d61)
+          - Avenir Next Regular, 16 px, Dark Gray (#43484e)
   - variation_group_name: Variations
     variation_group_description: >
       Optional descriptive text. 1-3 sentences, 200-350 characters.

--- a/docs/pages/text-inputs.md
+++ b/docs/pages/text-inputs.md
@@ -64,7 +64,7 @@ variation_groups:
           - Border: 1 px, Gray 60 (#919395)
           - Height: 35 px
           - Padding: 7px
-          - Placeholder text: Avenir Next Regular, 16px, Gray (#5a5d61) 
+          - Placeholder text: Avenir Next Regular, 16px, Dark Gray (#43484e) 
           - Input text: Avenir Next Regular, 16px, Black (#101820)
           - Text should be in sentence case
 
@@ -103,7 +103,7 @@ variation_groups:
                     placeholder="Placeholder text">Input text</textarea>
         variation_specs: |-
           * Border: 1 px, Gray 60 (#919395)
-          * Avenir Next Regular, 16 px, Gray (#5a5d61)
+          * Avenir Next Regular, 16 px, Dark Gray (#434484e)
     variation_group_description: ''
   - variation_group_name: Variations
     variations:

--- a/packages/cfpb-buttons/src/cfpb-buttons.less
+++ b/packages/cfpb-buttons/src/cfpb-buttons.less
@@ -32,7 +32,7 @@
 @btn__warning-bg-active: @gray-dark;
 
 // .btn__disabled
-@btn__disabled-text: @gray;
+@btn__disabled-text: @gray-dark;
 @btn__disabled-bg: @gray-20;
 @btn__disabled-outline: @gray-20;
 

--- a/packages/cfpb-forms/src/cfpb-forms.less
+++ b/packages/cfpb-forms/src/cfpb-forms.less
@@ -30,7 +30,7 @@
 
 // .a-text-input text
 @input-text: @black;
-@input-text__disabled: @gray;
+@input-text__disabled: @gray-dark;
 @input-text__placeholder: @gray-dark;
 
 // .a-text-input icons
@@ -56,7 +56,7 @@
 @form-field-input-lg-target-border: @pacific;
 
 // .a-label_helper
-@label-helper: @gray;
+@label-helper: @gray-dark;
 
 // Sizing variables
 

--- a/packages/cfpb-forms/src/cfpb-forms.less
+++ b/packages/cfpb-forms/src/cfpb-forms.less
@@ -31,7 +31,7 @@
 // .a-text-input text
 @input-text: @black;
 @input-text__disabled: @gray;
-@input-text__placeholder: @gray;
+@input-text__placeholder: @gray-dark;
 
 // .a-text-input icons
 @input-icon: @gray;


### PR DESCRIPTION
**Taken from issue #1702** 

### Current behavior

- Text is Avenir Next Regular, 16 px, Gray (#5a5d61)

### Proposed behavior

- Change text to Avenir Next Regular, 16 px, Dark Gray (#43484e)
- Includes: Inline helper, block helper, placeholder text, disabled field text (includes standard and large target checkbox, standard and large target radio button, and dropdown), and pagination

### Test placeholder and helper text changes on local:
**Navigate to pages:**

1. http://localhost:4000/design-system/components/helper-text
2. http://localhost:4000/design-system/components/checkboxes
3. Verify helper and disabled text color (#5a5d61)

**_switch to branch, yarn build_**
**Navigate to pages:**

1. http://localhost:4000/design-system/components/helper-text
2. http://localhost:4000/design-system/components/checkboxes
3. Verify helper and disabled text color (#43484e)

| Current | Updated |
| -------- | -------- |
|![Screenshot 2023-09-12 at 4 46 22 PM](https://github.com/cfpb/design-system/assets/130792942/94411373-8581-46f8-9235-9ab6ba57689f)|![Screenshot 2023-09-12 at 4 47 05 PM](https://github.com/cfpb/design-system/assets/130792942/5eca23b3-7b04-4441-a74a-d394f4a78a51)|
|![Screenshot 2023-09-12 at 4 46 32 PM](https://github.com/cfpb/design-system/assets/130792942/ebab1ba7-599b-404c-9a9a-34a3f8e3822d)|![Screenshot 2023-09-12 at 4 47 13 PM](https://github.com/cfpb/design-system/assets/130792942/dc42b677-859c-4a59-b127-c2bc04e4b2bf)|

