### PR TITLE
Swap Default "Value" text with Placeholder Text in Disabled Field

### DIFF
--- a/docs/pages/text-inputs.md
+++ b/docs/pages/text-inputs.md
@@ -57,7 +57,6 @@ variation_groups:
                  type="text"
                  id="textinput-example-disabled"
                  placeholder="Placeholder text"
-                 value="Input text"
                  disabled>
         variation_specs: |-
           #### Default

--- a/docs/pages/text-inputs.md
+++ b/docs/pages/text-inputs.md
@@ -17,8 +17,7 @@ variation_groups:
           <input class="a-text-input"
                 type="text"
                 id="textinput-example-default"
-                placeholder="Placeholder text"
-                value="Input text">
+                placeholder="Placeholder text" >
           <br><br>
 
           <label class="a-label a-label__heading" for="textinput-example-hover">


### PR DESCRIPTION
On the current [text inputs page](https://cfpb.github.io/design-system/components/text-inputs), the disabled input field shows the same value as the other input fields. As a user would not be able to interact with a disabled field, we should display the default placeholder text. 

| Current | After Update |
| -------- | ------------- |
|![Screenshot 2023-09-12 at 6 31 06 PM](https://github.com/cfpb/design-system/assets/130792942/973c276b-9f19-4859-a9ac-082f32e540ac)|![Screenshot 2023-09-12 at 6 29 47 PM](https://github.com/cfpb/design-system/assets/130792942/a42d29fb-810c-44b7-8b75-fefc8b086a75)|