### PR TITLE
Convert `a-heading` inside `m-slug-header` to `m-slug-header_heading`

### DIFF
--- a/docs/pages/e-mail-signup-forms.md
+++ b/docs/pages/e-mail-signup-forms.md
@@ -7,7 +7,7 @@ variation_groups:
       - variation_code_snippet: >-
           <div class="o-email-signup">
               <header class="m-slug-header">
-                  <h2 class="a-heading">
+                  <h2 class="m-slug-header_heading">
                       Buying a House?
                   </h2>
               </header>
@@ -48,7 +48,7 @@ variation_groups:
           <div class="o-well" style="max-width: 370px">
               <div class="o-email-signup">
                   <header class="m-slug-header">
-                      <h2 class="a-heading">
+                      <h2 class="m-slug-header_heading">
                           Buying a House?
                       </h2>
                   </header>

--- a/docs/pages/heading-hierarchy.md
+++ b/docs/pages/heading-hierarchy.md
@@ -87,7 +87,7 @@ variation_groups:
           | --------- | -------------------------------------------- |
           | Display   | Avenir Next Medium, 60pt / 66pt              |
           | Heading 1 | Avenir Next Regular, 38pt / 40pt             |
-          | Heading 2 | Avenir Next Regular, 26pt / 28pt            
+          | Heading 2 | Avenir Next Regular, 26pt / 28pt
           |
           | Heading 3 | Avenir Next Demi Bold, 16pt / 18pt           |
           | Heading 4 | Avenir Next Medium, 14pt / 16pt              |
@@ -176,7 +176,7 @@ variation_groups:
           modules.
         variation_code_snippet: |-
           <header class="m-slug-header">
-              <h2 class="a-heading">
+              <h2 class="m-slug-header_heading">
                   Slug heading
               </h2>
           </header>

--- a/packages/cfpb-typography/src/molecules/slug-header.less
+++ b/packages/cfpb-typography/src/molecules/slug-header.less
@@ -1,7 +1,7 @@
 .m-slug-header {
   border-top: 1px solid @slug-header_border__thin;
 
-  .a-heading {
+  &_heading {
     .heading-5();
 
     display: inline-block;

--- a/packages/cfpb-typography/usage.md
+++ b/packages/cfpb-typography/usage.md
@@ -134,14 +134,14 @@ readers (see Meta Header below).
 ### Slug header
 
 <header class="m-slug-header">
-    <h2 class="a-heading">
+    <h2 class="m-slug-header_heading">
         Blog summary
     </h2>
 </header>
 
 ```
 <header class="m-slug-header">
-    <h2 class="a-heading">
+    <h2 class="m-slug-header_heading">
         Blog summary
     </h2>
 </header>


### PR DESCRIPTION
`m-slug-header` contained a heavily-customized `a-heading`. It seems like this should be an element of the slug header instead.

## Changes

- Convert `a-heading` inside `m-slug-header` to `m-slug-header_heading`

## Testing

1. The "slug heading" on https://deploy-preview-1732--cfpb-design-system.netlify.app/design-system/foundation/headings#slug-heading and https://deploy-preview-1732--cfpb-design-system.netlify.app/design-system/patterns/e-mail-signup-forms should be unchanged.
