### PR TITLE
Meta header: Adjust margin values

### DIFF
--- a/docs/pages/heading-hierarchy.md
+++ b/docs/pages/heading-hierarchy.md
@@ -103,8 +103,8 @@ variation_groups:
                     Office of Research Publication
                 </div>
                 <div class="m-meta-header_item">
-                    {% include icons/bullhorn.svg %}
-                    At the CFPB
+                    {% include icons/bank.svg %}
+                    Policy and compliance
                 </div>
               </div>
               <div class="m-meta-header_item">

--- a/packages/cfpb-typography/src/molecules/meta-header.less
+++ b/packages/cfpb-typography/src/molecules/meta-header.less
@@ -1,10 +1,11 @@
-@meta-header-gap: 5px;
+@meta-header-item-gap: 21px;
+@meta-header-icon-gap: 5px;
 
 .m-meta-header {
   display: flex;
   flex-direction: column-reverse;
   flex-wrap: wrap-reverse;
-  gap: @meta-header-gap;
+  gap: unit((@meta-header-item-gap / @base-font-size-px), rem);
   width: fit-content;
   padding-bottom: unit((10px / @base-font-size-px), rem);
   // Dividers are to the left of content, so this crops the unneeded 1st one.
@@ -13,13 +14,14 @@
   &_item-group {
     display: flex;
     flex-wrap: wrap;
+    gap: unit((@meta-header-item-gap / @base-font-size-px), rem);
   }
 
   &_item {
     // Use grid to indent the text from the icon when it wraps.
     display: grid;
     grid-template-columns: 0 auto 1fr;
-    gap: @meta-header-gap;
+    gap: unit((@meta-header-icon-gap / @base-font-size-px), rem);
 
     .h4();
     // Override h4 bottom margin at mobile size.
@@ -29,13 +31,9 @@
 
     text-wrap: balance;
     margin-bottom: 0;
-    margin-right: unit((18px / @base-font-size-px), rem);
+    //margin-right: unit((21px / @base-font-size-px), rem);
     // Negate first gap.
-    margin-left: -@meta-header-gap;
-
-    &:last-child {
-      margin-right: unit((15px / @base-font-size-px), rem);
-    }
+    margin-left: unit((-@meta-header-icon-gap / @base-font-size-px), rem);
 
     // Create the divider.
     &::before {

--- a/packages/cfpb-typography/src/molecules/meta-header.less
+++ b/packages/cfpb-typography/src/molecules/meta-header.less
@@ -29,19 +29,18 @@
 
     text-wrap: balance;
     margin-bottom: 0;
-    margin-right: 18px;
+    margin-right: unit((18px / @base-font-size-px), rem);
     // Negate first gap.
     margin-left: -@meta-header-gap;
 
     &:last-child {
-      margin-right: 15px;
+      margin-right: unit((15px / @base-font-size-px), rem);
     }
 
     // Create the divider.
     &::before {
       content: '|';
-      margin-right: 6px;
-      margin-left: -8px;
+      margin-left: unit((-7px / @base-font-size-px), rem);
     }
 
     // Adjustments to default date position.

--- a/packages/cfpb-typography/src/molecules/meta-header.less
+++ b/packages/cfpb-typography/src/molecules/meta-header.less
@@ -1,11 +1,11 @@
 @meta-header-item-gap: 21px;
-@meta-header-icon-gap: 5px;
 
 .m-meta-header {
   display: flex;
   flex-direction: column-reverse;
   flex-wrap: wrap-reverse;
-  gap: unit((@meta-header-item-gap / @base-font-size-px), rem);
+  row-gap: unit((10px / @base-font-size-px), rem);
+  column-gap: unit((@meta-header-item-gap / @base-font-size-px), rem);
   width: fit-content;
   padding-bottom: unit((10px / @base-font-size-px), rem);
   // Dividers are to the left of content, so this crops the unneeded 1st one.
@@ -14,14 +14,14 @@
   &_item-group {
     display: flex;
     flex-wrap: wrap;
-    gap: unit((@meta-header-item-gap / @base-font-size-px), rem);
+    column-gap: unit((@meta-header-item-gap / @base-font-size-px), rem);
   }
 
   &_item {
     // Use grid to indent the text from the icon when it wraps.
     display: grid;
     grid-template-columns: 0 auto 1fr;
-    gap: unit((@meta-header-icon-gap / @base-font-size-px), rem);
+    row-gap: unit((5px / @base-font-size-px), rem);
 
     .h4();
     // Override h4 bottom margin at mobile size.
@@ -31,14 +31,15 @@
 
     text-wrap: balance;
     margin-bottom: 0;
-    //margin-right: unit((21px / @base-font-size-px), rem);
-    // Negate first gap.
-    margin-left: unit((-@meta-header-icon-gap / @base-font-size-px), rem);
+
+    .cf-icon-svg {
+      margin-right: unit((5px / @base-font-size-px), rem);
+    }
 
     // Create the divider.
     &::before {
       content: '|';
-      margin-left: unit((-7px / @base-font-size-px), rem);
+      margin-left: unit((-13px / @base-font-size-px), rem);
     }
 
     // Adjustments to default date position.

--- a/packages/cfpb-typography/usage.md
+++ b/packages/cfpb-typography/usage.md
@@ -127,38 +127,46 @@ Can be either a relative or absolute path.
 
 #### Default meta header
 
-<header class="m-meta-header">
-    <div class="m-meta-header_left">
-        {% include icons/credit-card.svg %}
-        Consumer finance
-        <span class="m-meta-header_separator">|</span>
-        {% include icons/bullhorn.svg %}
-        At the CFPB
-        <span class="m-meta-header_separator">|</span>
+<div class="m-meta-header">
+    <div class="m-meta-header_item-group">
+    <div class="m-meta-header_item">
+        {% include icons/chart.svg %}
+        Office of Research Publication
     </div>
-    <div class="m-meta-header_right">
+    <div class="m-meta-header_item">
+        {% include icons/bank.svg %}
+        Policy and compliance
+    </div>
+    </div>
+    <div class="m-meta-header_item">
         <span class="a-date">
-            Nov 4, 2013
+            Published
+            <span class="datetime"><time class="datetime_date" datetime="2024-09-28T00:00:00">SEP 28, 2024</time>
+            </span>
         </span>
     </div>
-</header>
+</div>
 
 ```
-<header class="m-meta-header">
-    <div class="m-meta-header_left">
-        {% include icons/credit-card.svg %}
-        Consumer finance
-        <span class="m-meta-header_separator">|</span>
-        {% include icons/bullhorn.svg %}
-        At the CFPB
-        <span class="m-meta-header_separator">|</span>
+<div class="m-meta-header">
+    <div class="m-meta-header_item-group">
+    <div class="m-meta-header_item">
+        {% include icons/chart.svg %}
+        Office of Research Publication
     </div>
-    <div class="m-meta-header_right">
+    <div class="m-meta-header_item">
+        {% include icons/bank.svg %}
+        Policy and compliance
+    </div>
+    </div>
+    <div class="m-meta-header_item">
         <span class="a-date">
-            Nov 4, 2013
+            Published
+            <span class="datetime"><time class="datetime_date" datetime="2024-09-28T00:00:00">SEP 28, 2024</time>
+            </span>
         </span>
     </div>
-</header>
+</div>
 ```
 
 ## Link patterns


### PR DESCRIPTION
## Changes

- Meta header: Adjust margin values to center the pipe and convert units to rems.

## Testing

1. Compare meta header pipe position on https://deploy-preview-1769--cfpb-design-system.netlify.app/design-system/foundation/headings vs https://cfpb.github.io/design-system/foundation/headings
