### PR TITLE
Correct label on large checkbox with helper text

### DIFF
--- a/docs/pages/checkboxes.md
+++ b/docs/pages/checkboxes.md
@@ -260,7 +260,7 @@ variation_groups:
         variation_code_snippet: >-
           <div class="m-form-field m-form-field__checkbox
           m-form-field__lg-target">
-              <input class="a-checkbox" type="radio" id="test_radio_lg_helper">
+              <input class="a-checkbox" type="radio" id="test_checkbox_lg_helper">
               <label class="a-label" for="test_checkbox_lg_helper">
                  Checkbox label
                   <small class="a-label_helper">


### PR DESCRIPTION
This mismatch is causing the automated Lighthouse tests to fail when run against this repository, for example:

https://github.com/cfpb/design-system/actions/runs/6462905361/job/17545244336

This seems to be due to commit d056169b64b0b228ee3dfc2079327d673e36e3bc. The automated accesslint bot commented on this on the PR (https://github.com/cfpb/design-system/pull/1740#discussion_r1340562961) but this was missed before it got merged in.

![image](https://github.com/cfpb/design-system/assets/654645/ecfbcc16-57fe-4566-8a0b-7d7a0546b32f)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)