### PR TITLE
Multiselect: Remove `display: -webkit-box` property

### DIFF
--- a/packages/cfpb-forms/src/organisms/multiselect.less
+++ b/packages/cfpb-forms/src/organisms/multiselect.less
@@ -78,12 +78,6 @@ select.o-multiselect {
     width: 100%;
 
     transition: max-height 0.25s ease-out;
-
-    // Chrome doesn't properly handle fieldset display properties
-    // See https://bugs.chromium.org/p/chromium/issues/detail?id=375693
-    // and https://codepen.io/contolini/pen/rNLXrvP
-    // and https://codepen.io/pembe180/pen/wCsIk
-    display: -webkit-box;
   }
 
   &.u-active {


### PR DESCRIPTION
https://github.com/cfpb/design-system/pull/1117 set `display: -webkit-box` to fix an issue with a Chrome v87. Since that time the underlying chromium bug has been closed, and it appears that this property is now causing a more serious issue in Safari. See https://github.com/cfpb/design-system/issues/1728

Fixes https://github.com/cfpb/design-system/issues/1728 


## Changes

- Remove `display: -webkit-box` property

## Testing

1. Check the PR preview in Safari and Chrome and see that the multiselect opens the same in both.

## Screenshots

Before: 

<img width="808" alt="Screenshot 2023-10-25 at 8 15 29 PM" src="https://github.com/cfpb/design-system/assets/704760/12c08ecc-6bf1-4505-a3c8-4cafabbdf065">

After: 

<img width="838" alt="Screenshot 2023-10-25 at 8 15 45 PM" src="https://github.com/cfpb/design-system/assets/704760/1ead4099-3402-4742-ab63-dd2c0ac53526">

