### PR TITLE
Multiselect: Enable configuration at instantiation

### DIFF
--- a/docs/pages/alerts.md
+++ b/docs/pages/alerts.md
@@ -7,7 +7,8 @@ variation_groups:
     variations:
       - variation_is_deprecated: false
         variation_name: Information
-        variation_description: The information alert is the base alert type without any
+        variation_description:
+          The information alert is the base alert type without any
           modifiers. If your alert message requires further explanation, include
           that content in a paragraph following the main message.
         variation_code_snippet: >-
@@ -60,7 +61,8 @@ variation_groups:
                   </ul>
               </div>
           </div>
-        variation_implementation: Alerts are hidden by default; you can toggle their
+        variation_implementation:
+          Alerts are hidden by default; you can toggle their
           visibility by adding or removing the `m-notification__visible` class
           to the base element.
       - variation_code_snippet: |-
@@ -72,9 +74,10 @@ variation_groups:
                   <div class="h4 m-notification_message">11 results</div>
               </div>
           </div>
-        variation_description: The success alert displays when an operation has run as
+        variation_description:
+          The success alert displays when an operation has run as
           expected, such as returning the number of results in a search.
-        variation_implementation: ""
+        variation_implementation: ''
         variation_name: Success
         variation_specs: |-
           * Border: 1 px, CFPB Green (#20aa3f)
@@ -89,13 +92,14 @@ variation_groups:
                   <div class="h4 m-notification_message">No results found.</div>
               </div>
           </div>
-        variation_description: The warning alert displays when an operation has run as
+        variation_description:
+          The warning alert displays when an operation has run as
           expected, but doesn’t have the expected results, such as a search that
           returned no result. This alert can also be used to display additional
           critical information to a user before they submit a form, such as how
           their data will be used and protected or a reminder that they can’t
           edit their responses after submitting.
-        variation_implementation: ""
+        variation_implementation: ''
         variation_name: Warning
         variation_specs: |-
           * Border: 1 px, Gold (#ff9e1b)
@@ -110,7 +114,8 @@ variation_groups:
                   <div class="h4 m-notification_message">Page not found.</div>
               </div>
           </div>
-        variation_description: The error alert displays when an operation has not run as
+        variation_description:
+          The error alert displays when an operation has not run as
           expected and encounters an error. Use after validating on the server
           side to call out input errors preventing form submission.
         variation_implementation: >-
@@ -140,7 +145,7 @@ variation_groups:
           icons](https://cfpb.github.io/design-system/foundation/iconography) to
           reassure the user that an action is functioning as intended.
         variation_name: In-progress
-    variation_group_description: ""
+    variation_group_description: ''
   - variation_group_name: Field-level alerts
     variations:
       - variation_is_deprecated: false
@@ -155,7 +160,7 @@ variation_groups:
                   </span>
               </div>
           </div>
-        variation_code_snippet_rendered: ""
+        variation_code_snippet_rendered: ''
         variation_specs: |-
           * Border: 2 px, CFPB Green (#20aa3f)
           * Icons: 18 px, CFPB Green (#20aa3f)
@@ -190,10 +195,11 @@ variation_groups:
         variation_specs: |-
           * Border: 2 px, Red (#d14124)
           * Icon: 18 px, Red (#d14124)
-    variation_group_description: Field-level alerts reflect validation status and
+    variation_group_description:
+      Field-level alerts reflect validation status and
       include success, warning, and error. Field-level alerts (icon and message)
       should always appear below the input field.
-guidelines: ""
+guidelines: ''
 eyebrow: Components
 title: Alerts
 description: Alerts draw a user's attention to a change in the status of a form
@@ -201,7 +207,7 @@ description: Alerts draw a user's attention to a change in the status of a form
   the form title. Field-level alerts appear inline with input fields and can
   highlight successful submissions, errors that need to be corrected, or details
   to know before submitting a form.
-use_cases: ""
+use_cases: ''
 behavior: >-
   ### Placement
 
@@ -232,7 +238,7 @@ related_items: "* [Notifications
   variables](https://cfpb.github.io/design-system/development/variables#notific\
   ations)"
 last_updated: 2020-01-28T15:55:47.394Z
-research: ""
+research: ''
 
 redirect_from:
   - /notifications

--- a/docs/pages/banner-notification.md
+++ b/docs/pages/banner-notification.md
@@ -36,7 +36,8 @@ variation_groups:
                   </div>
               </div>
           </div>
-        variation_description: The warning banner is used to display high-priority
+        variation_description:
+          The warning banner is used to display high-priority
           system or product level notifications that are not specific to an
           immediate task.
         variation_name: Warning banner
@@ -72,7 +73,8 @@ variation_groups:
               </div>
           </div>
         variation_name: Archived content banner
-        variation_description: The archived content banner is used to identify website
+        variation_description:
+          The archived content banner is used to identify website
           pages that are outdated and should no longer be referenced for
           guidance. These pages may have historical value or significance to
           researchers, historians, and the public.
@@ -85,7 +87,7 @@ use_cases: Use the banner notification to communicate important information
 guidelines: Banner notifications are positioned at the top of the page content
   area and span the full width.
 eyebrow: Components
-behavior: ""
+behavior: ''
 related_items: "[N﻿otifications](https://cfpb.github.io/design-system/component\
   s/notifications)"
 last_updated: 2020-01-28T15:55:47.394Z

--- a/docs/pages/banner-us-gov.md
+++ b/docs/pages/banner-us-gov.md
@@ -25,5 +25,5 @@ variation_groups:
     variation_group_name: Types
 guidelines: The US gov banner is positioned at the top of the page above the
   header and spans the full width.
-related_items: "[Taglines](https://cfpb.github.io/design-system/components/taglines)"
+related_items: '[Taglines](https://cfpb.github.io/design-system/components/taglines)'
 ---

--- a/docs/pages/buttons.md
+++ b/docs/pages/buttons.md
@@ -9,7 +9,7 @@ description: Buttons signal actions. They should be used sparingly; each
   should lead users to another page or further information.
 variation_groups:
   - variation_group_name: Types
-    variation_group_description: ""
+    variation_group_description: ''
     variations:
       - variation_code_snippet: >-
           <button class="a-btn" title="Default state">Default state</button>
@@ -22,7 +22,8 @@ variation_groups:
 
 
           <button class="a-btn active" title="Active state">Active state</button>
-        variation_description: Use a primary button for an action that goes to the next
+        variation_description:
+          Use a primary button for an action that goes to the next
           step. Avoid using multiple primary buttons on a single page; there can
           be multiple secondary buttons per page.
         variation_implementation: >-
@@ -146,8 +147,9 @@ variation_groups:
         variation_description: When paired with a primary action, indicate the
           destructive action using a destructive action button link to the right
           of the primary button.
-        variation_specs: "* Destructive action link: Avenir Next Medium, 16px, Mid dark
-          red (#c3381c)"
+        variation_specs:
+          '* Destructive action link: Avenir Next Medium, 16px, Mid dark
+          red (#c3381c)'
       - variation_is_deprecated: false
         variation_name: Full-width button (on x-small screens)
         variation_description: Reduce screen size to see this button in action.
@@ -173,7 +175,8 @@ variation_groups:
           </div>
       - variation_is_deprecated: false
         variation_name: Button with icon
-        variation_description: An icon should appear after the text it represents. The
+        variation_description:
+          An icon should appear after the text it represents. The
           only exception is the back button, in which the icon should appear
           before the button’s text. Each icon should be used exclusively and
           consistently for one action. Icons should never be underlined.
@@ -226,7 +229,7 @@ guidelines: >-
   * Use clear, succinct, and informative language.
 
   * Limit the copy length to 22 characters.
-behavior: ""
+behavior: ''
 restrictions:
   - restrictions_do: <button class="a-btn" title="Test button">Short label</button>
     restrictions_do_not: <button class="a-btn" title="Test button">This label is
@@ -248,10 +251,10 @@ restrictions:
           </span>
       </button>
 eyebrow: Components
-accessibility: ""
+accessibility: ''
 related_items: "* [Button
   variables](https://cfpb.github.io/design-system/development/variables#buttons\
   )"
 last_updated: 2020-01-28T15:55:47.394Z
-research: ""
+research: ''
 ---

--- a/docs/pages/checkboxes.md
+++ b/docs/pages/checkboxes.md
@@ -54,7 +54,7 @@ variation_groups:
               <input class="a-checkbox" type="checkbox" id="test_checkbox_basic_disabled_selected" disabled checked>
               <label class="a-label" for="test_checkbox_basic_disabled_selected">Disabled/selected</label>
           </div>
-        variation_description: ""
+        variation_description: ''
         variation_name: Standard checkbox
         variation_specs: >-
           #### Default checkbox
@@ -125,7 +125,8 @@ variation_groups:
           </div>
       - variation_is_deprecated: false
         variation_name: Large target area checkbox
-        variation_description: For better usability, consider using the checkboxes with
+        variation_description:
+          For better usability, consider using the checkboxes with
           large target areas. These are easier to interact with (especially on
           smaller screens) and harder to miss. They are especially desirable
           when the form will have heavy mobile usage. Given the amount of real
@@ -286,7 +287,7 @@ description: Use checkboxes when the user can select more than one option from a
   group. Make clear with helper text that this is the case. Use [radio
   buttons](/design-system/components/radio-buttons) when the user can select
   only one choice from a group.
-use_cases: ""
+use_cases: ''
 behavior: >-
   Selecting the checkbox or touching the label text next to it should toggle the
   state of the checkbox on and off.
@@ -296,5 +297,5 @@ behavior: >-
 accessibility: To optimize screen reader accessibility, lay out checkboxes
   vertically rather than horizontally.
 last_updated: 2019-09-17T14:30:15.293Z
-research: ""
+research: ''
 ---

--- a/docs/pages/date-picker.md
+++ b/docs/pages/date-picker.md
@@ -21,5 +21,5 @@ accessibility: >-
 
 
   Users of screen readers use the tab key to move focus from one form control to another. Make sure that tab focus order reflects the way you would like users to navigate through the form. Consider whether tabs should move a user down or across the page.
-related_items: "* [Text inputs ](https://cfpb.github.io/design-system/components/text-inputs)"
+related_items: '* [Text inputs ](https://cfpb.github.io/design-system/components/text-inputs)'
 ---

--- a/docs/pages/fieldsets.md
+++ b/docs/pages/fieldsets.md
@@ -38,7 +38,7 @@ variation_groups:
                   </fieldset>
               </div>
           </form>
-        variation_description: ""
+        variation_description: ''
         variation_name: Fieldset with checkboxes
       - variation_code_snippet: >-
           <form class="o-form">
@@ -61,10 +61,10 @@ variation_groups:
                   </fieldset>
               </div>
           </form>
-        variation_description: ""
+        variation_description: ''
         variation_name: Fieldset with radio buttons
     variation_group_name: Types
-    variation_group_description: ""
+    variation_group_description: ''
   - variation_group_name: Sizes
     variations:
       - variation_name: Large target fieldset with checkboxes
@@ -131,11 +131,11 @@ variation_groups:
                                   </label>
                           </div>
               </fieldset>
-use_cases: ""
-guidelines: ""
+use_cases: ''
+guidelines: ''
 eyebrow: Components
-behavior: ""
-accessibility: ""
+behavior: ''
+accessibility: ''
 last_updated: 2020-01-28T15:55:47.394Z
-research: ""
+research: ''
 ---

--- a/docs/pages/helper-text.md
+++ b/docs/pages/helper-text.md
@@ -13,10 +13,11 @@ variation_groups:
 
 
           <input class="a-text-input" type="text" id="helper-block-example">
-        variation_description: "Block helper text appears directly beneath a form label.
+        variation_description:
+          'Block helper text appears directly beneath a form label.
           Use it to explain why a piece of information is being requested,
           address security and privacy concerns, or to suggest ways of providing
-          answers other than providing formatting examples. "
+          answers other than providing formatting examples. '
         variation_name: Block helper text
         variation_specs: >-
           [Color variables for helper
@@ -36,7 +37,8 @@ variation_groups:
           </label>
 
           <input class="a-text-input" type="text" id="helper-inline-example">
-        variation_description: Inline helper text appears directly after a form label.
+        variation_description:
+          Inline helper text appears directly after a form label.
           Use it to indicate whether a field is optional. See the [behavior
           section](#behavior) for more information.
         variation_name: Inline helper text
@@ -59,7 +61,8 @@ variation_groups:
                 type="text"
                 id="textinput-example-email-default"
                 placeholder="email@example.com">
-        variation_description: Placeholder text appears within a text input field, and
+        variation_description:
+          Placeholder text appears within a text input field, and
           disappears once a user begins typing in that field. Use it for
           formatting examples only.
         variation_name: Placeholder text
@@ -67,7 +70,7 @@ variation_groups:
           #### Placeholder text
           Avenir Next Regular, 16 px, Dark Gray (#43484e)
     variation_group_name: Types
-    variation_group_description: ""
+    variation_group_description: ''
 guidelines: >-
   ### Required vs. optional fields
 
@@ -80,8 +83,8 @@ title: Helper text
 description: Helper text is used with form elements to give the user context
   about their usage. Types of helper text include block helper text, inline
   helper text, and placeholder text.
-use_cases: ""
-behavior: ""
+use_cases: ''
+behavior: ''
 accessibility: For screen reader accessibility, consider using the
   `aria-describedby` attribute for helper text, which gives screen readers users
   the information if they need while allowing more flexibility with placement.

--- a/docs/pages/heroes.md
+++ b/docs/pages/heroes.md
@@ -180,7 +180,8 @@ variation_groups:
 
 
       - variation_name: Hero with photograph
-        variation_description: Note hero text overlays the photograph at larger screen
+        variation_description:
+          Note hero text overlays the photograph at larger screen
           sizes. See an example of a [hero with
           photograph](https://www.consumerfinance.gov/consumer-tools/auto-loans/).
           For implementation details and production specs, click on the "Show
@@ -316,12 +317,14 @@ variation_groups:
 
 
           ![Image of smaller photographic hero graphic with dimensions](/design-system/images/uploads/hero_style_photo_small.png "Image of smaller photographic hero graphic with dimensions")
-        variation_implementation: "It’s best to avoid a non-button call to action in
+        variation_implementation:
+          'It’s best to avoid a non-button call to action in
           these, as it’s unlikely that the Pacific Blue will have accessible
-          contrast with a non-white (or light gray) background. "
+          contrast with a non-white (or light gray) background. '
       - variation_is_deprecated: false
         variation_name: Jumbo hero
-        variation_description: Jumbo heroes have supersized headings on large screens
+        variation_description:
+          Jumbo heroes have supersized headings on large screens
           and standard-sized headings on smaller screens. The image visibly
           fills the right-most third of the element while using a gradient to
           seamlessly fade behind the text.
@@ -446,7 +449,8 @@ variation_groups:
 
           * Photo dimensions for small screens: 600px (exact) x 338px (maximum)
       - variation_is_deprecated: false
-        variation_description: For more visually-driven layouts, 50/50 heroes have
+        variation_description:
+          For more visually-driven layouts, 50/50 heroes have
           supersized headings while also dedicating half their space to the
           image. The image takes up the full right half of the hero and bleeds
           to the top and bottom edges on larger screens. On smaller screens and
@@ -565,7 +569,8 @@ variation_groups:
                   }
               </style>
           </section>
-        variation_implementation: 50/50 heroes have a 1px `@gray-40` border on the sides
+        variation_implementation:
+          50/50 heroes have a 1px `@gray-40` border on the sides
           because, unlike standard heroes, their background does not
           horizontally bleed to the edges of the screen.
         variation_specs: >-
@@ -582,7 +587,8 @@ variation_groups:
         variation_name: 50/50 hero
       - variation_is_deprecated: false
         variation_name: Hero with knockout text
-        variation_description: When using a dark background, add the `__knockout`
+        variation_description:
+          When using a dark background, add the `__knockout`
           modifier to the hero to switch the text to white. For reference, see
           this [example of a hero with knockout
           text](https://www.consumerfinance.gov/data-research/consumer-credit-trends/).
@@ -787,7 +793,7 @@ behavior: >-
   | Text and hero image appear side-by-side  | Text and hero image stack vertically |
 
   | ![Mockup of hero graphic at desktop size](/design-system/images/uploads/hero_behavior_large.png "Mockup of hero graphic at desktop size") | ![Mockup of hero graphic at small size](/design-system/images/uploads/hero_behavior_small.png "Mockup of hero graphic at small size") |
-accessibility: ""
+accessibility: ''
 related_items: >-
   -
   [Variables](https://cfpb.github.io/design-system/development/variables#heroes-and-featured-content-modules)
@@ -800,5 +806,5 @@ related_items: >-
 
   - [Item introductions](https://cfpb.github.io/design-system/patterns/item-introductions)
 last_updated: 2020-01-28T15:55:47.394Z
-research: ""
+research: ''
 ---

--- a/docs/pages/links.md
+++ b/docs/pages/links.md
@@ -24,14 +24,16 @@ variation_groups:
 
 
           <p>Here's the <a href="#">default link style</a>. For reference, here's the <a href="#" class="hover">hover link style</a>. Train your eyes on the <a href="#" class="focus">focused link style</a>. Jump to the <a href="#" class="active">active link style</a>. We’ve all been to the <a href="#" class="visited">visited link style</a>.</p>
-        variation_description: Inline links are regular weight and appear within the
+        variation_description:
+          Inline links are regular weight and appear within the
           text flow. They are regular weight and are used within paragraph of
           text.
         variation_name: Inline link
-        variation_implementation: "Links that appear in body text (`p`), link lists
+        variation_implementation:
+          'Links that appear in body text (`p`), link lists
           (`li`), or definitions (`dd`) are automatically underlined. To enable
           underlines elsewhere, e.g. to underline links in a `nav` element,
-          simply add a `border-bottom-width: 1px;` to the link."
+          simply add a `border-bottom-width: 1px;` to the link.'
         variation_specs: >-
           [Color variables for
           links](https://cfpb.github.io/design-system/development/variables#typography-1)
@@ -84,7 +86,8 @@ variation_groups:
                   <a class="m-list_link" href="#">List link 2</a>
               </li>
           </ul>
-        variation_description: List links (or call-to-action links) are standalone links
+        variation_description:
+          List links (or call-to-action links) are standalone links
           that highlight a users' next steps. They are medium weight and often
           used in unordered lists.
         variation_implementation: Call-to-action links are used in
@@ -92,7 +95,7 @@ variation_groups:
           unit
           groups](https://cfpb.github.io/design-system/patterns/info-unit-groups),
           among other places.
-        variation_jinja_code_snippet: ""
+        variation_jinja_code_snippet: ''
         variation_specs: >-
           * Avenir Next Medium, 16px
 
@@ -117,7 +120,8 @@ variation_groups:
           <a class="a-btn a-btn__link a-btn__warning" href="#">
                Destructive link
           </a>
-        variation_description: Destructive links provide a visual warning to users that
+        variation_description:
+          Destructive links provide a visual warning to users that
           clicking them will perform a destructive action, such as clearing
           entries in a form.
         variation_specs: |-
@@ -125,13 +129,14 @@ variation_groups:
           * Mid Dark Red (#c3381c)
       - variation_is_deprecated: false
         variation_name: Link with icon
-        variation_description: When used, an icon should appear after the text it
+        variation_description:
+          When used, an icon should appear after the text it
           represents. Each icon should be used exclusively and consistently for
           one action. The color and font-size of an icon should be the same as
           the text it represents, including state changes. Icons should never be
           underlined.
         variation_implementation: >-
-          
+
 
           * To prevent the link’s underline from extending under the icon, wrap the link text with a `span.icon-link_text`. There can be no whitespace between the text and the opening and closing span tags. Include the icon either prior to or after the `a-link_text`. It is important the text and icon are siblings to correctly handle underlines.
         variation_code_snippet: |-
@@ -153,7 +158,8 @@ variation_groups:
           </p>
       - variation_is_deprecated: false
         variation_name: Non-wrapping link with icon
-        variation_description: Icons added to inline links can sometimes break onto the
+        variation_description:
+          Icons added to inline links can sometimes break onto the
           next line. If you want to prevent this, you can add the `__no-wrap`
           modifier to `.a-link__icon`.
         variation_code_snippet: |-
@@ -169,7 +175,8 @@ variation_groups:
           </p>
       - variation_is_deprecated: false
         variation_name: Jump link
-        variation_description: Jump links are standalone links that respond to small
+        variation_description:
+          Jump links are standalone links that respond to small
           screens by converting to full block links that have a finger-friendly
           touch area. Reduce screen size to see these in action.
         variation_code_snippet: |-
@@ -198,16 +205,16 @@ variation_groups:
           appear in the following style and include both the original link text
           as well as a shortened URL.
         variation_code_snippet: Here's the <a href="#">link style</a> when printed.
-        variation_code_snippet_rendered: "<p>Here's the <a
-          href=\"https://consumerfinance.gov/about-us/blog\"
-          style=\"font-weight: 500;\">link style<span style=\"border-bottom: 1px
-          solid #ffffff; font-weight: 300;\">
-          (cfpb.gov/about-us/blog)</span></a> when printed.</p>"
+        variation_code_snippet_rendered: '<p>Here''s the <a
+          href="https://consumerfinance.gov/about-us/blog"
+          style="font-weight: 500;">link style<span style="border-bottom: 1px
+          solid #ffffff; font-weight: 300;">
+          (cfpb.gov/about-us/blog)</span></a> when printed.</p>'
         variation_implementation: When a page is printed, cf.gov's [print
           stylesheet](https://github.com/cfpb/consumerfinance.gov/blob/c9637160e14da5093b43c78fc2c87fa0ba190887/cfgov/unprocessed/css/print.less)
           appends link URLs in parentheses next to their link text.
         variation_specs: >-
-          
+
 
           ### Style
 
@@ -228,15 +235,15 @@ variation_groups:
           * Shorten "consumerfinance.gov” to “cfpb.gov”  
 
           * For Ask CFPB pages, abbreviate to “askcfpb” and the page’s associated number
-    variation_group_description: ""
-guidelines: ""
+    variation_group_description: ''
+guidelines: ''
 eyebrow: Components
 title: Links
 description: Links are navigational elements that connect users to other
   locations, either on the current page or to a different page or site. In
   contrast, [buttons](/design-system/components/buttons) are used to signal
   important actions.
-use_cases: ""
+use_cases: ''
 behavior: >-
   ### Opening a link in the current tab (default)
 
@@ -273,5 +280,5 @@ related_items: >-
 
   * [Iconography](https://cfpb.github.io/design-system/foundation/iconography)
 last_updated: 2019-09-17T14:52:22.684Z
-research: ""
+research: ''
 ---

--- a/docs/pages/pagination.md
+++ b/docs/pages/pagination.md
@@ -52,9 +52,10 @@ variation_groups:
                           type="submit">Go</button>
               </form>
           </nav>
-        variation_description: ""
+        variation_description: ''
         variation_name: Default pagination
-        variation_implementation: To enable the component to jump directly to the
+        variation_implementation:
+          To enable the component to jump directly to the
           paginated content, include an `id` on a wrapper of the paginated
           content (or an element directly above it), e.g.,
           `id="pagination_content"`.
@@ -92,13 +93,15 @@ variation_groups:
           <button class="a-btn a-btn__link m-pagination_btn-submit" id="m-pagination_btn-submit-first-last" type="submit">Go</button> </form>
 
           </nav>
-        variation_description: When on the first or last page of paginated content, be
+        variation_description:
+          When on the first or last page of paginated content, be
           sure to disable the appropriate buttons by adding the
           `a_btn__disabled` modifier and removing their `href` attribute.
-        variation_jinja_code_snippet: ""
+        variation_jinja_code_snippet: ''
         variation_name: First and last pages
     variation_group_name: Standard pagination
-    variation_group_description: Pagination consists of buttons to navigate through
+    variation_group_description:
+      Pagination consists of buttons to navigate through
       content, along with an inline form (input field, submit button) to enable
       users to navigate to specific pages by number.
 guidelines: >-
@@ -111,7 +114,7 @@ eyebrow: Components
 title: Pagination
 description: Pagination is used for splitting up content or data into several
   pages, so as to make it easier for users to consume information.
-use_cases: ""
+use_cases: ''
 behavior: >-
   On small screens, the buttons display next to each other, stacked on top of
   the form (`@bp-xs-max`).
@@ -122,10 +125,10 @@ behavior: >-
   | ------------ | ------------ |
 
   | ![Pagination at breakpoints above 600 px](/design-system/images/uploads/screen-shot-2021-01-22-at-5.02.03-pm.png) | ![Pagination at breakpoints below 601 px](/design-system/images/uploads/screen-shot-2021-01-22-at-5.02.30-pm.png) |
-accessibility: ""
+accessibility: ''
 related_items: "* [Pagination
   variables](https://cfpb.github.io/design-system/development/variables#paginat\
   ion-1)"
 last_updated: 2020-01-28T15:55:47.394Z
-research: ""
+research: ''
 ---

--- a/docs/pages/radio-buttons.md
+++ b/docs/pages/radio-buttons.md
@@ -96,7 +96,8 @@ variation_groups:
           * Avenir Next Regular, 16 px, Gray (#5a5d61)
         variation_name: Standard radio button
       - variation_name: Standard radio button with helper text
-        variation_description: Radio button inputs can have labels that span multiple
+        variation_description:
+          Radio button inputs can have labels that span multiple
           lines and can include optional helper text that appears below the main
           label text.
         variation_code_snippet: |-
@@ -168,7 +169,8 @@ variation_groups:
           * Avenir Next Regular, 16 px, Dark Gray (#43484e)
       - variation_is_deprecated: false
         variation_name: Large target area radio button
-        variation_description: For better usability, consider using radio buttons with
+        variation_description:
+          For better usability, consider using radio buttons with
           large target areas. These are easier to interact with (especially on
           smaller screens) and harder to miss. They are especially desirable
           when the form will have heavy mobile usage. Given the amount of real
@@ -247,7 +249,7 @@ variation_groups:
                   </small>
                 </label>
           </div>
-guidelines: ""
+guidelines: ''
 eyebrow: Components
 title: Radio buttons
 description: Use radio buttons when the user can select exactly one option from
@@ -265,10 +267,10 @@ use_cases: >-
 
 
   Consider using radio buttons with large target areas. If these won’t fit into your design and you need to use the standard radio button make sure the target area is at least 45 x 45 px and includes the label text.
-behavior: ""
+behavior: ''
 accessibility: There are some issues with Voiceover reading radio buttons. To
   get around this, consider using the aria-describedby attribute.
-related_items: ""
+related_items: ''
 last_updated: 2020-01-28T15:55:47.394Z
-research: ""
+research: ''
 ---

--- a/docs/pages/selects.md
+++ b/docs/pages/selects.md
@@ -86,7 +86,8 @@ variation_groups:
                   </select>
               </div>
           </div>
-        variation_description: Allows the user to select a single item from a dropdown
+        variation_description:
+          Allows the user to select a single item from a dropdown
           list of options.
         variation_name: Single select
         variation_specs: |-
@@ -120,7 +121,8 @@ variation_groups:
           * Avenir Next Regular, 16 px, Dark Gray (#43484e)
       - variation_is_deprecated: false
         variation_name: Multiselect
-        variation_description: Allows the user to select multiple items from a dropdown
+        variation_description:
+          Allows the user to select multiple items from a dropdown
           list of options.
         variation_code_snippet: >-
           <div class="m-form-field m-form-field__select">
@@ -138,11 +140,12 @@ variation_groups:
                   <option value="option8">Multiselect options can also contain long words that will be wrapped like supercalifragilisticexpialidocious</option>
               </select>
           </div>
-        variation_implementation: "Custom JavaScript may be required to make the default
+        variation_implementation:
+          'Custom JavaScript may be required to make the default
           multiselect component accessible for the visually impaired. See the
-          [accessibility](#accessibility) section for more information. "
+          [accessibility](#accessibility) section for more information. '
     variation_group_name: Types
-guidelines: ""
+guidelines: ''
 eyebrow: Components
 use_cases: >-
   While selects are easy to implement, they aren’t always the best choice from a
@@ -180,6 +183,6 @@ related_items: "* [Forms
 redirect_from:
   - /components/dropdowns-and-multiselects
 last_updated: 2020-01-06T20:31:06.632Z
-behavior: ""
-research: ""
+behavior: ''
+research: ''
 ---

--- a/docs/pages/tables.md
+++ b/docs/pages/tables.md
@@ -65,7 +65,7 @@ variation_groups:
           * Border-bottom: 1px, Gray (#5a5d61)
 
           * Padding: 10px
-        variation_implementation: ""
+        variation_implementation: ''
   - variation_group_name: Responsive tables
     variation_group_description: >-
       Responsive tables fall into two main types: stacked, which stacks
@@ -112,7 +112,7 @@ variation_groups:
                   </tr>
               </tbody>
           </table>
-        variation_specs: ""
+        variation_specs: ''
       - variation_name: Responsive stacked table with header (directory table)
         variation_description: >-
           The directory table is a variation of the stacked table. At the small
@@ -156,7 +156,7 @@ variation_groups:
                   </tr>
               </tbody>
           </table>
-        variation_specs: ""
+        variation_specs: ''
       - variation_name: Responsive table with horizontal scroll
         variation_description: >-
           Use a table with horizontal scroll when the data you’re presenting has
@@ -300,7 +300,7 @@ variation_groups:
 
           Left-align columns of numbers when they're nominal (ZIP codes, room numbers) or non-numeric values (names, phrases).
         variation_name: Right-aligned table
-        variation_specs: "* Alternate row background: Grey-05 #F8F8F8"
+        variation_specs: '* Alternate row background: Grey-05 #F8F8F8'
       - variation_code_snippet: |-
           <table class="o-table">
               <thead>
@@ -525,10 +525,10 @@ related_items: "* [Tables
 last_updated: 2019-08-30T15:18:28.960Z
 title: Tables
 status: Released
-description: "Tables allow for the presentation of many data points grouped
+description: 'Tables allow for the presentation of many data points grouped
   together in a visual way. They serve a unique purpose of allowing easy
   organization or comparison of more complex data than a chart or graph. They
-  can be read either vertically (by columns) or horizontally (by rows). "
-behavior: ""
-research: ""
+  can be read either vertically (by columns) or horizontally (by rows). '
+behavior: ''
+research: ''
 ---

--- a/docs/pages/taglines.md
+++ b/docs/pages/taglines.md
@@ -12,8 +12,9 @@ variation_groups:
                   <span class="u-nowrap">United States government</span>
               </div>
           </div>
-        variation_description: ""
-        variation_implementation: The flag itself is a stand-alone element of `<span
+        variation_description: ''
+        variation_implementation:
+          The flag itself is a stand-alone element of `<span
           class="u-usa-flag"></span>` that uses a utility class that embeds a
           double-resolution flag png via a data URI.
       - variation_name: Large tagline
@@ -25,8 +26,9 @@ variation_groups:
                   <span class="u-nowrap">United States government</span>
               </div>
           </div>
-        variation_description: ""
-        variation_implementation: The `u-nowrap` container prevents wrapping of the
+        variation_description: ''
+        variation_implementation:
+          The `u-nowrap` container prevents wrapping of the
           "United States government" text. If the content of the tagline
           contains markup it needs to go inside a generic `div` container.
       - variation_name: Extra large tagline
@@ -39,19 +41,19 @@ variation_groups:
               </div>
           </div>
         variation_description: An extra large tagline, which stacks on mobile.
-        variation_implementation: ""
+        variation_implementation: ''
         variation_is_deprecated: true
     variation_group_name: Types
-use_cases: ""
-guidelines: ""
+use_cases: ''
+guidelines: ''
 eyebrow: Components
-accessibility: ""
-related_items: ""
+accessibility: ''
+related_items: ''
 last_updated: 2019-10-21T20:38:39.851Z
 title: Taglines
 status: Released
 description: Taglines are short paragraphs of text with the USA flag to their
   left that are used in the header and footer across consumerfinance.gov.
-behavior: ""
-research: ""
+behavior: ''
+research: ''
 ---

--- a/docs/pages/text-inputs.md
+++ b/docs/pages/text-inputs.md
@@ -91,7 +91,8 @@ variation_groups:
 
           * Border: 2 px, Red (#d14124)
         variation_name: Text input
-        variation_description: Use when the expected user input is a single line of
+        variation_description:
+          Use when the expected user input is a single line of
           text, for example email addresses, names, or search queries. The
           length of the input field should be proportional to the expected user
           input, so that the user can see what they've typed without having to
@@ -120,7 +121,8 @@ variation_groups:
           </div>
       - variation_is_deprecated: false
         variation_name: Button inside text input
-        variation_description: Use to offer the user an action to take related to the
+        variation_description:
+          Use to offer the user an action to take related to the
           input, typically to clear the input.
         variation_code_snippet: >-
           <div class="m-btn-inside-input">
@@ -135,7 +137,8 @@ variation_groups:
           </div>
       - variation_is_deprecated: false
         variation_name: Button inside text input with another button
-        variation_description: This example combines both of the previous patterns,
+        variation_description:
+          This example combines both of the previous patterns,
           creating a typical site search form.
         variation_code_snippet: >-
           <div class="o-form__input-w-btn">
@@ -155,12 +158,13 @@ variation_groups:
                   <button class="a-btn">Search</button>
               </div>
           </div>
-    variation_group_description: ""
+    variation_group_description: ''
   - variation_group_name: Text area inputs
     variations:
       - variation_is_deprecated: false
         variation_name: Text area input
-        variation_description: Use when the expected user input is more than a few words
+        variation_description:
+          Use when the expected user input is more than a few words
           and could span multiple lines. Make sure the input size is big enough
           that the user can see what they've typed without having to scroll to
           reveal hidden content, and small enough that the user doesn't have  to
@@ -177,7 +181,7 @@ variation_groups:
                         id="full-textarea-example"
                         placeholder="Placeholder text">Input text</textarea>
           </div>
-use_cases: ""
+use_cases: ''
 guidelines: >-
   ### Stylistic guidelines
 
@@ -220,5 +224,5 @@ behavior: As the screen size gets smaller, break multi-column inputs into a
   single, stacked column. Fields that are next to each other on a large screen,
   should stack at smaller screen sizes. When possible, fields should span the
   entire width of the screen at the smallest screen sizes.
-research: ""
+research: ''
 ---

--- a/docs/pages/text-introductions.md
+++ b/docs/pages/text-introductions.md
@@ -26,13 +26,14 @@ variation_groups:
               </li>
             </ul>
           </div>
-        variation_description: Text introductions consist of a heading, lead paragraph,
+        variation_description:
+          Text introductions consist of a heading, lead paragraph,
           and optional descriptive paragraph, and link text. They should be used
           on every page except in cases when a
           [hero](https://cfpb.github.io/design-system/patterns/heroes) or [item
           introduction](https://cfpb.github.io/design-system/patterns/item-introductions)
           is used.
-        variation_jinja_code_snippet: ""
+        variation_jinja_code_snippet: ''
         variation_name: Text introduction
         variation_specs: >-
           ![Image of text intro showing desktop and mobile design
@@ -50,9 +51,9 @@ variation_groups:
 
           * At breakpoints below 600: Page title and lead paragraph drop down one type size to make reading on smaller devices easier.
     variation_group_name: Types
-    variation_group_description: ""
+    variation_group_description: ''
   - variation_group_name: Variation
-    variation_group_description: ""
+    variation_group_description: ''
     variations:
       - variation_specs: >-
           ![Image of text intro with breakout sidebar showing grid and design
@@ -127,7 +128,7 @@ description: The text introduction is the standard page introduction pattern
   introduction](https://cfpb.github.io/design-system/patterns/item-introductions).
   They introduce a page, or collection of pages, with a brief description of the
   goals of that section.
-use_cases: ""
+use_cases: ''
 behavior: >-
   ### Text introduction
 
@@ -151,13 +152,13 @@ behavior: >-
   | Breakout sidebar on the right                                                         | Breakout sidebar stacked immediately after text intro                                          |
 
   | ![Mockup of 900+ pixel layout](/design-system/images/uploads/breakout_sidebar_breakpoint_large.png) | ![Mockup of 900 pixel and below layout](/design-system/images/uploads/breakout_sidebar_breakpoint_small.png) |
-accessibility: ""
+accessibility: ''
 related_items: >-
   * [Heroes](https://cfpb.github.io/design-system/patterns/heroes)
 
   * [Item introductions](https://cfpb.github.io/design-system/patterns/item-introductions)
 last_updated: 2020-01-28T15:55:47.394Z
-research: ""
+research: ''
 
 redirect_from:
   - /patterns/introductions/introductions

--- a/docs/pages/typography.md
+++ b/docs/pages/typography.md
@@ -16,7 +16,7 @@ variation_groups:
 
           0123456789</h4>
 
-        variation_name: ""
+        variation_name: ''
       - variation_code_snippet: |+
           <h3 style="font-weight: 500;">Avenir Next Medium</h3>
 
@@ -26,7 +26,7 @@ variation_groups:
           0123456789</h4>
 
 
-        variation_name: ""
+        variation_name: ''
       - variation_code_snippet: |-
           <h3>Avenir Next Regular</h3>
 
@@ -34,8 +34,9 @@ variation_groups:
           ABCDEFGHIJKLMNOPQRSTUVWXYZ<br>
           abcdefghijklmnopqrstuvwxyz<br>
           0123456789</h4>
-        variation_name: ""
-    variation_group_description: Avenir Next is the primary brand typeface and can
+        variation_name: ''
+    variation_group_description:
+      Avenir Next is the primary brand typeface and can
       be used across all formats from print to digital. Its round and geometric
       letterforms are approachable and modern.
 guidelines: >-
@@ -123,8 +124,8 @@ description: A clear typographic hierarchy is critical to the effective
   scale, and capitalization to convey the relative importance of each heading
   within a document. Readability, accessibility, and font smoothing to allow all
   users to efficiently read and absorb textual information.
-use_cases: ""
-behavior: ""
+use_cases: ''
+behavior: ''
 accessibility: >-
   Web Content Accessibility (WCAG) standards ensure that content is accessible
   by everyone, regardless of any disability or user device. To learn more, refer

--- a/docs/pages/video.md
+++ b/docs/pages/video.md
@@ -23,22 +23,25 @@ variation_groups:
           allow="accelerometer; autoplay; clipboard-write; encrypted-media;
           gyroscope; picture-in-picture" allowfullscreen title="Branded
           Content"></iframe>
-        variation_description: A custom-designed video that incorporates design elements
+        variation_description:
+          A custom-designed video that incorporates design elements
           for specific solutions. This type of video is usually consumer or
           industry facing and is representative of the Bureau's priorities.
         variation_name: Branded content
-        variation_code_snippet_rendered: ""
+        variation_code_snippet_rendered: ''
       - variation_code_snippet: <iframe width="560" height="315"
           src="https://www.youtube.com/embed/YB_7cy1poGA" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media;
           gyroscope; picture-in-picture" allowfullscreen
           title="Documentary"></iframe>
-        variation_description: This style utilizes interview footage and b-roll of real
+        variation_description:
+          This style utilizes interview footage and b-roll of real
           people. It can be used to communicate a personal, trustworthy
           aesthetic to a given message.
         variation_name: Documentary
       - variation_name: iPhone
-        variation_description: Mobile videos are sometimes used for quick turnaround
+        variation_description:
+          Mobile videos are sometimes used for quick turnaround
           messages that are urgent in nature and provide a transparent look and
           feel that's relevant.
         variation_code_snippet: <iframe width="560" height="315"
@@ -51,19 +54,21 @@ variation_groups:
           allow="accelerometer; autoplay; clipboard-write; encrypted-media;
           gyroscope; picture-in-picture" allowfullscreen
           title="Educational"></iframe>
-        variation_description: Educational videos help answer questions or explain
+        variation_description:
+          Educational videos help answer questions or explain
           complex ideas about specific issues, tools, regulations, and more.
         variation_name: Educational
       - variation_code_snippet: <iframe width="560" height="315"
           src="https://www.youtube.com/embed/D8mS1tZMJ70" frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media;
           gyroscope; picture-in-picture" allowfullscreen title="Event"></iframe>
-        variation_description: The bureau livestreams field hearings, consumer advisory
+        variation_description:
+          The bureau livestreams field hearings, consumer advisory
           board meetings, town halls, and more. After these events are broadcast
           live, we upload them to YouTube for documentation purposes.
         variation_name: Event
-        variation_code_snippet_rendered: ""
-    variation_group_description: ""
+        variation_code_snippet_rendered: ''
+    variation_group_description: ''
 use_cases: |-
   Typically, we find video is best used to:
 
@@ -599,7 +604,7 @@ guidelines: >-
   If exporting finished video, the export format depends on where the video will be shown or hosted. For most uses, we export a ProRes HQ file and an H.264 mp4 file for social media use.
 restrictions: []
 eyebrow: Multimedia
-behavior: ""
+behavior: ''
 accessibility: >-
   ### Include text alternatives for non-text content.
 

--- a/docs/pages/wells.md
+++ b/docs/pages/wells.md
@@ -18,7 +18,7 @@ variation_groups:
           </ul>
 
           </div>
-        variation_description: ""
+        variation_description: ''
         variation_name: Well
         variation_specs: >-
           * Border: 1px, Gray 40 (#b4b5b6)
@@ -49,7 +49,8 @@ variation_groups:
                   cu. <a href="#">Example link</a>.
               </p>
           </div>
-        variation_description: T﻿he inkwell was originally developed for use on the
+        variation_description:
+          T﻿he inkwell was originally developed for use on the
           cf.gov home page, but was not implemented.
         variation_name: Inkwell
         variation_is_deprecated: true
@@ -87,8 +88,8 @@ use_cases: >-
   Ideally, content within a well should not take up more than a third of page content.
 behavior: Wells are full width. At breakpoints 600px and under there are slight
   padding adjustments to maximize real estate on smaller displays.
-accessibility: ""
-related_items: "* [Featured content module](/design-system/patterns/featured-content-module)"
+accessibility: ''
+related_items: '* [Featured content module](/design-system/patterns/featured-content-module)'
 last_updated: 2019-10-21T20:38:39.851Z
-research: ""
+research: ''
 ---

--- a/packages/cfpb-atomic-component/src/utilities/atomic-helpers.js
+++ b/packages/cfpb-atomic-component/src/utilities/atomic-helpers.js
@@ -100,9 +100,9 @@ function setInitFlag(element) {
 
 /**
  * @param {string} selector - Selector to search for in the document.
- * @param {Object} config - Configuration will be provided to the Constructor's init()
  * @param {Function} Constructor - A constructor function.
  * @param {HTMLElement} [scope] - A dom node in which to query the selector.
+ * @param {object} config - Configuration will be provided to the Constructor's init()
  *   If not supplied, it defaults to the `document`.
  * @returns {Array} List of instances that were instantiated.
  */

--- a/packages/cfpb-atomic-component/src/utilities/atomic-helpers.js
+++ b/packages/cfpb-atomic-component/src/utilities/atomic-helpers.js
@@ -100,12 +100,13 @@ function setInitFlag(element) {
 
 /**
  * @param {string} selector - Selector to search for in the document.
+ * @param {Object} config - Configuration will be provided to the Constructor's init()
  * @param {Function} Constructor - A constructor function.
  * @param {HTMLElement} [scope] - A dom node in which to query the selector.
  *   If not supplied, it defaults to the `document`.
  * @returns {Array} List of instances that were instantiated.
  */
-function instantiateAll(selector, Constructor, scope) {
+function instantiateAll(selector, Constructor, scope, config = {}) {
   const base = scope || document;
   const elements = base.querySelectorAll(selector);
   const insts = [];
@@ -115,7 +116,7 @@ function instantiateAll(selector, Constructor, scope) {
     element = elements[i];
     if (contains(element, INIT_FLAG) === false) {
       inst = new Constructor(element);
-      inst.init();
+      inst.init(config);
       insts.push(inst);
     }
   }

--- a/packages/cfpb-atomic-component/src/utilities/atomic-helpers.js
+++ b/packages/cfpb-atomic-component/src/utilities/atomic-helpers.js
@@ -102,8 +102,8 @@ function setInitFlag(element) {
  * @param {string} selector - Selector to search for in the document.
  * @param {Function} Constructor - A constructor function.
  * @param {HTMLElement} [scope] - A dom node in which to query the selector.
- * @param {object} config - Configuration will be provided to the Constructor's init()
  *   If not supplied, it defaults to the `document`.
+ * @param {object} config - Configuration will be provided to the Constructor's init()
  * @returns {Array} List of instances that were instantiated.
  */
 function instantiateAll(selector, Constructor, scope, config = {}) {

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -555,10 +555,12 @@ function Multiselect(element) {
     _placeholder = _dom.getAttribute('placeholder');
     _options = _dom.options || [];
 
+    // Allow devs to pass the config settings they want and not worry about the rest
+    _config = { ...DEFAULT_CONFIG, ...multiselectConfig };
+
     if (_options.length > 0) {
       // Store underlying model so we can expose it externally
-      _model = new MultiselectModel(_options, _name, multiselectConfig).init();
-      _config = multiselectConfig;
+      _model = new MultiselectModel(_options, _name, _config).init();
       const newDom = _populateMarkup();
 
       /* Removes <select> element,

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -5,7 +5,7 @@ import {
   isMobileUserAgent,
   instantiateAll,
 } from '@cfpb/cfpb-atomic-component';
-import MultiselectModel from './MultiselectModel.js';
+import MultiselectModel, { MAX_SELECTIONS } from './MultiselectModel.js';
 import { create } from './MultiselectUtils.js';
 
 import * as closeIconSrc from '@cfpb/cfpb-icons/src/icons/error.svg';
@@ -26,6 +26,12 @@ const KEY_ESCAPE = 'Escape';
 const KEY_UP = 'ArrowUp';
 const KEY_DOWN = 'ArrowDown';
 const KEY_TAB = 'Tab';
+
+// Configuration default
+const DEFAULT_CONFIG = {
+  renderTags: true, // Allow the Multiselect to generate the Tag elements in the DOM
+  maxSelections: MAX_SELECTIONS, // Maximum number of options a user can select
+};
 
 /**
  * Multiselect
@@ -49,7 +55,7 @@ function Multiselect(element) {
   let _placeholder;
   let _model;
   let _options;
-  let _config; // Configuration object
+  let _config; // Multiselect configuration object
 
   // Markup elems, convert this to templating engine in the future.
   let _containerDom;
@@ -532,10 +538,10 @@ function Multiselect(element) {
 
   /**
    * Set up and create the multiselect.
-   * @param _modelConfig Multiselect configuration options
+   * @param multiselectConfig Multiselect configuration options
    * @returns {Multiselect} An instance.
    */
-  function init(_modelConfig) {
+  function init(multiselectConfig = DEFAULT_CONFIG) {
     if (!setInitFlag(_dom)) {
       return this;
     }
@@ -551,8 +557,8 @@ function Multiselect(element) {
 
     if (_options.length > 0) {
       // Store underlying model so we can expose it externally
-      _model = new MultiselectModel(_options, _name, _modelConfig).init();
-      _config = _modelConfig;
+      _model = new MultiselectModel(_options, _name, multiselectConfig).init();
+      _config = multiselectConfig;
       const newDom = _populateMarkup();
 
       /* Removes <select> element,

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -29,6 +29,7 @@ const KEY_TAB = 'Tab';
 
 // Configuration default
 const DEFAULT_CONFIG = {
+  // TODO: renderTags was added as a workaround for DS icons not rendering correctly when integrating with a React implementation.
   renderTags: true, // Allow the Multiselect to generate the Tag elements in the DOM
   maxSelections: MAX_SELECTIONS, // Maximum number of options a user can select
 };

--- a/packages/cfpb-forms/src/organisms/Multiselect.js
+++ b/packages/cfpb-forms/src/organisms/Multiselect.js
@@ -538,7 +538,7 @@ function Multiselect(element) {
 
   /**
    * Set up and create the multiselect.
-   * @param multiselectConfig Multiselect configuration options
+   * @param {object} multiselectConfig - Multiselect configuration options
    * @returns {Multiselect} An instance.
    */
   function init(multiselectConfig = DEFAULT_CONFIG) {

--- a/packages/cfpb-forms/src/organisms/MultiselectModel.js
+++ b/packages/cfpb-forms/src/organisms/MultiselectModel.js
@@ -34,6 +34,8 @@ function stringMatch(x, y) {
 function MultiselectModel(options, name, config) {
   const _options = options;
   const _name = name;
+  const _max = config?.maxSelections || MAX_SELECTIONS;
+
   let _optionsData = [];
 
   let _selectedIndices = [];
@@ -60,7 +62,6 @@ function MultiselectModel(options, name, config) {
    *   True if the maximum number of options are checked, false otherwise.
    */
   function isAtMaxSelections() {
-    const _max = config?.maxSelections || MAX_SELECTIONS;
     return _selectedIndices.length >= _max;
   }
 
@@ -110,10 +111,7 @@ function MultiselectModel(options, name, config) {
   function toggleOption(index) {
     _optionsData[index].checked = !_optionsData[index].checked;
 
-    if (
-      _selectedIndices.length < MAX_SELECTIONS &&
-      _optionsData[index].checked
-    ) {
+    if (_selectedIndices.length < _max && _optionsData[index].checked) {
       _selectedIndices.push(index);
       _selectedIndices.sort();
 

--- a/packages/cfpb-forms/src/organisms/MultiselectModel.js
+++ b/packages/cfpb-forms/src/organisms/MultiselectModel.js
@@ -29,8 +29,9 @@ function stringMatch(x, y) {
  * @param {HTMLOptionsCollection} options -
  *   Set of options from a <select> element.
  * @param {string} name - a unique name for this multiselect.
+ * @param {Object} config - Customization of Multiselect behavior
  */
-function MultiselectModel(options, name) {
+function MultiselectModel(options, name, config) {
   const _options = options;
   const _name = name;
   let _optionsData = [];
@@ -59,7 +60,8 @@ function MultiselectModel(options, name) {
    *   True if the maximum number of options are checked, false otherwise.
    */
   function isAtMaxSelections() {
-    return _selectedIndices.length === MAX_SELECTIONS;
+    const _max = config?.maxSelections || MAX_SELECTIONS;
+    return _selectedIndices.length >= _max;
   }
 
   /**

--- a/packages/cfpb-forms/src/organisms/MultiselectModel.js
+++ b/packages/cfpb-forms/src/organisms/MultiselectModel.js
@@ -2,7 +2,7 @@
 let UNDEFINED;
 
 // How many options may be checked.
-const MAX_SELECTIONS = 5;
+export const MAX_SELECTIONS = 5;
 
 /**
  * Escapes a string.

--- a/packages/cfpb-forms/src/organisms/MultiselectModel.js
+++ b/packages/cfpb-forms/src/organisms/MultiselectModel.js
@@ -29,7 +29,7 @@ function stringMatch(x, y) {
  * @param {HTMLOptionsCollection} options -
  *   Set of options from a <select> element.
  * @param {string} name - a unique name for this multiselect.
- * @param {Object} config - Customization of Multiselect behavior
+ * @param {object} config - Customization of Multiselect behavior
  */
 function MultiselectModel(options, name, config) {
   const _options = options;

--- a/packages/cfpb-forms/src/organisms/multiselect.less
+++ b/packages/cfpb-forms/src/organisms/multiselect.less
@@ -45,13 +45,6 @@ select.o-multiselect {
     }
   }
 
-  // Reverse arrow when search drop-down is open.
-  &.u-active {
-    .o-multiselect_header::after {
-      .u-svg-inline-bg( 'up' );
-    }
-  }
-
   &_search[type='text'] {
     display: block;
 
@@ -90,6 +83,11 @@ select.o-multiselect {
       border-color: @pacific;
       border-width: 2px;
       border-top: 0;
+    }
+
+    // Reverse arrow when search drop-down is open.
+    .o-multiselect_header::after {
+      .u-svg-inline-bg( 'up' );
     }
   }
 

--- a/packages/cfpb-forms/src/organisms/multiselect.less
+++ b/packages/cfpb-forms/src/organisms/multiselect.less
@@ -132,7 +132,7 @@ select.o-multiselect {
       pointer-events: none;
 
       &::after {
-        content: 'Reached maximum of five selections';
+        content: 'Reached maximum number of selections';
       }
     }
 

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/atomic-helpers.spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/atomic-helpers.spec.js
@@ -4,6 +4,7 @@ import {
   setInitFlag,
 } from '../../../../../../packages/cfpb-atomic-component';
 import { Expandable } from '../../../../../../packages/cfpb-expandables';
+import { Multiselect } from '../../../../../../packages/cfpb-forms/src';
 
 let containerDom;
 let componentDom;
@@ -34,6 +35,12 @@ const HTML_SNIPPET = `
           </p>
       </div>
   </div>
+  <select name="test-select" id="test-select" class='o-multiselect' multiple>
+    <option value="Debt collection">Debt collection</option>
+    <option value="consumers-responses">Consumer&#39;s Responses</option>
+    <option value="Mortgage disclosure">Mortgage disclosure</option>
+    <optgroup label="All other topics">
+  </select>
   <div class="container">
     <div class="o-footer"></div>
     <div class="o-footer"></div>
@@ -105,6 +112,24 @@ describe('atomic-helpers', () => {
       const instArr = instantiateAll('.o-expandable', Expandable);
       expect(instArr).toBeInstanceOf(Array);
       expect(instArr.length).toBe(1);
+    });
+
+    it('should pass configuration to the Constructor init() method', () => {
+      componentDom.setAttribute('data-js-hook', 'state_atomic_init');
+      const option = document.querySelector('option');
+      option.defaultSelected = true;
+      const configuration = {
+        maxSelections: 1,
+      };
+      const instArr = instantiateAll(
+        '.o-multiselect',
+        Multiselect,
+        null,
+        configuration,
+      );
+      expect(instArr).toBeInstanceOf(Array);
+      expect(instArr.length).toBe(1);
+      expect(instArr[0].getModel().isAtMaxSelections()).toBe(true);
     });
   });
 

--- a/test/unit-test/src/cfpb-forms/src/organisms/Multiselect.spec.js
+++ b/test/unit-test/src/cfpb-forms/src/organisms/Multiselect.spec.js
@@ -43,6 +43,19 @@ describe('Multiselect', () => {
       expect(choices.length).toBe(1);
       expect(choices[0].innerHTML).toContain('Debt collection');
     });
+
+    it('accepts configuration options', () => {
+      const option = document.querySelector('option');
+      option.defaultSelected = true;
+      multiselect.init({ maxSelections: 1, renderTags: false });
+
+      // maxSelections
+      expect(multiselect.getModel().isAtMaxSelections()).toBe(true);
+
+      // renderTags
+      const choices = document.querySelectorAll('.o-multiselect_choices li');
+      expect(choices.length).toBe(0);
+    });
   });
 
   describe('public methods', () => {


### PR DESCRIPTION
These changes are in support of development for `design-system-react`.  In order to integrate the DS Multiselect into our React implementation, we need to be able to apply configuration for: 
- Max number of selections (number)
- Should display Tag/Pill (boolean)


## Additions

- feat: Support configuration options for Atomic components
- feat: [Mulitselect] Make rendering of selected Tags configurable
- feat: [Multiselect] Make maximum number of selections configurable

## Pending
- Should we support configuration per-Multiselect when calling `instantiateAll()`? Currently it takes a single configuration object but this could be updated to accept an array of configurations. 

## Testing

In parallel I'm integrating this component into the Design System React and these proposed changes are working great!
