### PR TITLE
fix: Multiselect - Deselect icon stays positioned in upper right corner even with multiline text

### DIFF
--- a/packages/cfpb-forms/src/organisms/multiselect.less
+++ b/packages/cfpb-forms/src/organisms/multiselect.less
@@ -169,6 +169,7 @@ select.o-multiselect {
       border: none;
       background: none;
       padding: 0;
+      text-align: left;
 
       &:focus {
         border-radius: unit((3px / @size-v), em);
@@ -192,6 +193,7 @@ select.o-multiselect {
     label {
       display: inline-block;
       padding: 4px 10px;
+      padding-right: 25px;
 
       background-color: @teal-20;
       border-radius: unit((3px / @size-v), em);
@@ -210,6 +212,9 @@ select.o-multiselect {
       }
 
       .cf-icon-svg {
+        position: absolute;
+        top: 4px;
+        right: 5px;
         margin-left: 10px;
         fill: @black;
       }


### PR DESCRIPTION
Bug introduced in https://github.com/cfpb/design-system/pull/1777
- Solidifies icon position
- Left-aligns text that wraps


## Screenshots
![Screenshot 2023-11-03 at 4 04 25 PM](https://github.com/cfpb/design-system/assets/2592907/dae0526e-470c-48d1-bf97-8b94da7f2c72)
