### PR TITLE
fix: Avoid style bleed for <th> between Colors and Tables pages

### DIFF
--- a/docs/assets/css/color-swatches.less
+++ b/docs/assets/css/color-swatches.less
@@ -49,14 +49,15 @@
 
 /* Small tablet (600px) */
 @media only screen and (min-width: 37.5em) {
-  th {
-    width: unit((70px / @base-font-size-px), em);
-  }
   .swatches {
     .grid_nested-col-group();
   }
   .swatch {
     .grid_column( 6 );
+
+    th {
+      width: unit((70px / @base-font-size-px), em);
+    }
   }
 }
 


### PR DESCRIPTION
Table headers on the [DS Tables](https://cfpb.github.io/design-system/components/tables) page are incorrectly width-restricted due to styles defined in `color-swatches.less`. This PR restricts the application of that width to `.swatch th`.

- [Tables - Preview deployment](https://deploy-preview-1835--cfpb-design-system.netlify.app/design-system/components/tables)

## Screenshots

|Before|After|
|---|---|
|<img width="1167" alt="Screenshot 2023-11-16 at 9 43 59 AM" src="https://github.com/cfpb/design-system/assets/2592907/43119c90-380f-4bdf-8efc-5f921475c3f7">|<img width="1167" alt="Screenshot 2023-11-16 at 9 44 15 AM" src="https://github.com/cfpb/design-system/assets/2592907/6a4ac5bd-e09d-443d-bd28-2be5c03f35ab">|

