### PR TITLE
Add missing placeholder text to text inputs

### DIFF
--- a/docs/pages/text-inputs.md
+++ b/docs/pages/text-inputs.md
@@ -103,6 +103,7 @@ variation_groups:
               <input class="a-text-input a-text-input__full"
                     type="text"
                     id="full-textinput-example"
+                    placeholder="Placeholder text"
                     value="Input text">
           </div>
       - variation_is_deprecated: false
@@ -173,7 +174,8 @@ variation_groups:
         variation_description: |-
           <div class="m-form-field">
               <textarea class="a-text-input a-text-input__full"
-                        id="full-textarea-example">Input text</textarea>
+                        id="full-textarea-example"
+                        placeholder="Placeholder text">Input text</textarea>
           </div>
 use_cases: ""
 guidelines: >-


### PR DESCRIPTION
The lack of placeholder/labels here was failing Lighthouse checks against the design system:

https://github.com/cfpb/design-system/actions/runs/6950964864 https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1700612503369-84118.report.html

## Screenshots

![image](https://github.com/cfpb/design-system/assets/654645/981fccd0-4daa-4b45-864b-97bc8f84df8f)

## Notes

This error was introduced in commit 89188d2028821e164ede20324e03f3ab3024301c.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests