### PR TITLE
Add id and role to search results main element

### DIFF
--- a/docs/search-results.html
+++ b/docs/search-results.html
@@ -4,7 +4,7 @@ title: Search
 section: search
 ---
 
-<main>
+<main id="main" role="main">
   <ul id="search-results"></ul>
 </main>
 {% include search-scripts.html %}


### PR DESCRIPTION
This was failing lighthouse because the skip link didn't have a target.

## Changes

- Add id and role to search results main element

## Testing

1. Lighthouse should pass tonight.
