### PR TITLE
cfpb-expandables: Fix incorrect selector target

### DIFF
--- a/packages/cfpb-expandables/src/expandable.less
+++ b/packages/cfpb-expandables/src/expandable.less
@@ -159,8 +159,10 @@
 
 // Used when the set language reads right-to-left
 html[lang='ar'] {
-  .o-expandable_header {
-    text-align: right;
+  .o-expandable {
+    &_header {
+      text-align: right;
+    }
 
     &_cues {
       text-align: left;


### PR DESCRIPTION
The selector is `.o-expandable_cues`, not `.o-expandable_header_cues`

## Changes

- cfpb-expandables: Fix incorrect selector target

## Testing

1. Visit the expandables preview page and edit the html element to have the value `ar` instead of `en`. Add `dir="rtl"` to the main element. The cues should then be left-aligned.