### PR TITLE
cfpb-typography: Remove older WOFF files

### DIFF
--- a/esbuild/docs/build.js
+++ b/esbuild/docs/build.js
@@ -9,7 +9,7 @@ const baseConfig = {
   bundle: true,
   minify: true,
   sourcemap: true,
-  external: ['*.png', '*.woff', '*.woff2', '*.gif'],
+  external: ['*.png', '*.woff2', '*.gif'],
   loader: {
     '.js': 'jsx',
     '.svg': 'text',

--- a/esbuild/packages/build.js
+++ b/esbuild/packages/build.js
@@ -9,7 +9,7 @@ const baseConfig = {
   bundle: true,
   minify: true,
   sourcemap: true,
-  external: ['*.png', '*.woff', '*.woff2', '*.gif'],
+  external: ['*.png', '*.woff2', '*.gif'],
   loader: {
     '.svg': 'text',
   },

--- a/packages/cfpb-typography/src/licensed-fonts.less
+++ b/packages/cfpb-typography/src/licensed-fonts.less
@@ -5,11 +5,8 @@
 
 @font-face {
   font-family: 'Avenir Next';
-  src:
-    url('@{cf-fonts-path}/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2')
-      format('woff2'),
-    url('@{cf-fonts-path}/1e9892c0-6927-4412-9874-1b82801ba47a.woff')
-      format('woff');
+  src: url('@{cf-fonts-path}/2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2')
+    format('woff2');
   font-style: normal;
   font-weight: normal;
   font-display: fallback;
@@ -17,11 +14,8 @@
 
 @font-face {
   font-family: 'Avenir Next';
-  src:
-    url('@{cf-fonts-path}/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2')
-      format('woff2'),
-    url('@{cf-fonts-path}/f26faddb-86cc-4477-a253-1e1287684336.woff')
-      format('woff');
+  src: url('@{cf-fonts-path}/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2')
+    format('woff2');
   font-style: normal;
   font-weight: 500;
   font-display: fallback;

--- a/scripts/fonts.sh
+++ b/scripts/fonts.sh
@@ -4,7 +4,7 @@
 mkdir ./docs/fonts/
 cd ./docs/fonts
 prefix="https://github.com/cfpb/consumerfinance.gov/blob/main/static.in/cfgov-fonts/fonts/"
-fonts=("1e9892c0-6927-4412-9874-1b82801ba47a.woff" "2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2" "627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2" "f26faddb-86cc-4477-a253-1e1287684336.woff")
+fonts=("2cd55546-ec00-4af9-aeca-4a3cd186da53.woff2" "627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2")
 for font in ${fonts[@]}; do
   # Flags: s = silent, L = follow redirects.
   curl -sL "${prefix}${font}?raw=true" > ${font}


### PR DESCRIPTION
WOFF files are only for IE11. We can probably get rid of them at this point https://caniuse.com/woff2

## Removals

- Remove older WOFF files

## Testing

1. PR checks should pass.