### PR TITLE
cfpb-icons: Change inline SVG fill color argument to grayscale boolean flag

### DIFF
--- a/docs/pages/iconography.md
+++ b/docs/pages/iconography.md
@@ -565,7 +565,7 @@ guidelines: >-
   ### Icon artboard
 
 
-  Because our icons typically appear beside text we designed our icon artboards (in Illustrator) to match the vertical footprint of Avenir Next. Avenir Next text set to a font size of 16px has a rendered height of 19px. To account for the additional white space, we set the icon artboards to 19px (h). 
+  Because our icons typically appear beside text we designed our icon artboards (in Illustrator) to match the vertical footprint of Avenir Next. Avenir Next text set to a font size of 16px has a rendered height of 19px. To account for the additional white space, we set the icon artboards to 19px (h).
 
 
   ![Diagram of illustrator artboard icon grid](/design-system/images/uploads/icon_artboard.png)
@@ -574,7 +574,7 @@ guidelines: >-
   ### Relative sizing
 
 
-  When typing or placing an icon next to Avenir Next in print or web, all icons should have a similar size. Refer to our guidelines on [how type should scale relative to neighboring text](https://cfpb.github.io/design-system/foundation/iconography#scale). 
+  When typing or placing an icon next to Avenir Next in print or web, all icons should have a similar size. Refer to our guidelines on [how type should scale relative to neighboring text](https://cfpb.github.io/design-system/foundation/iconography#scale).
 
 
   When designing these icons, we used two sizing grids: a smaller one that fits within the standard circle, and a larger one for non-circle icons. This allows icons to have a similar visual prominence, whether inside or outside of the circle.
@@ -601,7 +601,7 @@ guidelines: >-
   The color of an icon should match the color of neighboring text. This setting is built into our code and happens automatically, provided that the icon is within the same parent element as the text. If the icon sits outside of the text’s parent element the color must be applied manually but should still match the color of the text.
 
 
-  Code examples: 
+  Code examples:
 
 
   * Heading color automatically applied to the icon: `<h2>{icon} Heading text</h2>`
@@ -615,10 +615,10 @@ guidelines: >-
   Icons should be scaled relative to the size of neighboring text. This setting is built into our code and happens automatically, provided that the icon is within the same parent element as the text. If the icon sits outside of the text’s parent element the scaling must be applied manually but the icon should still be scaled relative to the size of the text.
 
 
-  In code, the SVG height is scaled to match the rendered text height, calculated by dividing the rendered height by the assigned font size (19/16 = 1.1875em). This appears in the code as @cf-icon-height: 1.1875em. 
+  In code, the SVG height is scaled to match the rendered text height, calculated by dividing the rendered height by the assigned font size (19/16 = 1.1875em). This appears in the code as @cf-icon-height: 1.1875em.
 
 
-  Code examples: 
+  Code examples:
 
 
   * Icon is automatically scaled relative to the heading size: `<h2>{icon} Heading text</h2>`
@@ -684,7 +684,7 @@ behavior: >-
   #### What the Less is doing
 
 
-  If you look in [cfpb-icons.less](https://github.com/cfpb/design-system/blob/main/packages/cfpb-icons/src/cfpb-icons.less)  you can see that we have encoded `class="cf-icon-svg"` in the root element of each of our SVG icons. As a result, the Less rule gets applied to all of the SVGs on the page, just like any other HTML element. 
+  If you look in [cfpb-icons.less](https://github.com/cfpb/design-system/blob/main/packages/cfpb-icons/src/cfpb-icons.less)  you can see that we have encoded `class="cf-icon-svg"` in the root element of each of our SVG icons. As a result, the Less rule gets applied to all of the SVGs on the page, just like any other HTML element.
 
 
   We start by limiting the size of the SVG to a proportion of the text height, using the `@cf-icon-height` variable’s em value. To align the canvas of the icon with the canvas of neighboring text, we set `vertical-align: text-top;`. Finally, setting `fill: currentColor;` tells the SVG to set its path’s fill `color` to match the color value of its parent element.
@@ -693,7 +693,7 @@ behavior: >-
   #### Inline SVG background
 
 
-  In some cases we embed an SVG as a background image. To accomplish this, a custom Less plugin is used to inject the SVG icon source file inline into the CSS background-image property. This is exposed via a mixin, `.u-svg-inline-bg( @name, @color: @black )`, where @name is the SVG icon canonical name and `@color` is the SVG fill color (which defaults to black). 
+  In some cases we embed an SVG as a background image. To accomplish this, a custom Less plugin is used to inject the SVG icon source file inline into the CSS background-image property. This is exposed via a mixin, `.u-svg-inline-bg( @name, @is-grayscale )`, where @name is the SVG icon canonical name and `@is-grayscale` is whether the SVG fill color is gray (true) or black (false).
 
 
   ### Interaction details

--- a/packages/cfpb-forms/src/atoms/select.less
+++ b/packages/cfpb-forms/src/atoms/select.less
@@ -76,6 +76,6 @@
   // Unfortunately, we can't target this to apply when only
   // the select[disabled] is present and need the additional class.
   &__disabled::after {
-    .u-svg-inline-bg( 'down', @gray );
+    .u-svg-inline-bg( 'down', true );
   }
 }

--- a/packages/cfpb-forms/src/molecules/form-fields.less
+++ b/packages/cfpb-forms/src/molecules/form-fields.less
@@ -117,7 +117,7 @@
       &:disabled:checked + .a-label::before {
         // rgb values are CFPB gray-40.
         // For some reason SVG isn't accepting hex values for the fill.
-        .u-svg-inline-bg( 'approved', @gray );
+        .u-svg-inline-bg( 'approved', true );
       }
     }
 

--- a/packages/cfpb-icons/src/cfpb-icons.less
+++ b/packages/cfpb-icons/src/cfpb-icons.less
@@ -24,12 +24,8 @@
 // into a background-image property.
 @plugin "icons-svg-inline.cjs";
 
-.u-svg-inline-bg( @name, @color: @black ) {
-  @red: red(@color);
-  @green: green(@color);
-  @blue: blue(@color);
-  @rgb-color: 'rgb(@{red}, @{green}, @{blue})';
-  @svg: icons-svg-inline(@name, @rgb-color);
+.u-svg-inline-bg( @name, @is-grayscale: false ) {
+  @svg: icons-svg-inline(@name, @is-grayscale);
 
   background-image: url('data:image/svg+xml;charset=UTF-8,@{svg}');
 }

--- a/packages/cfpb-icons/src/icons-svg-inline.cjs
+++ b/packages/cfpb-icons/src/icons-svg-inline.cjs
@@ -14,10 +14,10 @@ module.exports = {
   install: function (less, pluginManager, functions) {
     /**
      * @param {string} svgName - The canonical name of the icon.
-     * @param {string} svgFillColor - The fill color of the icon (defaults to CFPB Black).
+     * @param {boolean} isGrayscale - Whether the icon is gray or black.
      * @returns {string} SVG icon markup.
      */
-    functions.add('icons-svg-inline', (svgName, svgFillColor) => {
+    functions.add('icons-svg-inline', (svgName, isGrayscale) => {
       // Retrieve this plugin script's path so we can fake __dirname.
       let filenamePathPieces;
       let thisScriptPath;
@@ -47,9 +47,12 @@ module.exports = {
         'utf8',
       );
 
+      const fillColor =
+        isGrayscale.value === 'true' ? 'rgb(90,93,97)' : 'rgb(0,0,0)';
+
       /* Replace the cf-icon-svg class (used only in the embedded markup)
          with a fill color. */
-      svg = svg.replace('class="cf-icon-svg"', `fill="${svgFillColor.value}"`);
+      svg = svg.replace(/class="cf-icon-svg .+" /, `fill="${fillColor}" `);
 
       return encodeURI(svg);
     });


### PR DESCRIPTION
The inline SVG helper can be passed a color value to fill an inline SVG with any color that is desired. This depends on the Less utilities `red(…)`, `green(…)`, and `blue(…)` to pick out the color channels of the passed in color. While this is a flexible approach that would allow coloring the icons any color we want, in practice we currently only use this to color the icons gray or black. If and when we move to Sass the color channel utilities would need to be migrated to Sass equivalents (as will the whole inline SVG plugin). The color channel utilities also only currently take Less variables for colors, and not CSS properties (custom variables).

With all that in mind, this PR simplifies the inline SVG utility so that the arbitrary color argument is replaced with a boolean flag for grayscale or not (gray or black fill), which should aid in our future migration off of Less. In the future if we have a use-case for additional colors of embedded SVGs, then we can re-introduce this functionality at that time.

Additionally, this PR fixes https://github.com/cfpb/design-system/issues/1917, which is a bug where a disabled select didn't have a gray down arrow SVG icon, but had black instead.

## Changes

- Change inline SVG fill color argument to grayscale boolean flag.
- Fix issue where inline SVG class was not being replaced with fill color.

## Testing

1. In the PR preview selects page, the disabled select should have a gray dropdown arrow instead of black.

