### PR TITLE
Remove `o-expandable__padded` from docs

### DIFF
--- a/packages/cfpb-expandables/usage.md
+++ b/packages/cfpb-expandables/usage.md
@@ -238,7 +238,7 @@ Should you need an expandable thing that is not covered by the expandables above
             </p>
         </div>
     </div>
-    <div class="o-expandable o-expandable__padded">
+    <div class="o-expandable">
         <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
@@ -263,7 +263,7 @@ Should you need an expandable thing that is not covered by the expandables above
             </p>
         </div>
     </div>
-    <div class="o-expandable o-expandable__padded">
+    <div class="o-expandable">
         <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
@@ -292,7 +292,7 @@ Should you need an expandable thing that is not covered by the expandables above
 
 ```
 <div class="o-expandable-group">
-    <div class="o-expandable o-expandable__padded">
+    <div class="o-expandable">
         <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
@@ -317,7 +317,7 @@ Should you need an expandable thing that is not covered by the expandables above
             </p>
         </div>
     </div>
-    <div class="o-expandable o-expandable__padded">
+    <div class="o-expandable">
         <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
@@ -342,7 +342,7 @@ Should you need an expandable thing that is not covered by the expandables above
             </p>
         </div>
     </div>
-    <div class="o-expandable o-expandable__padded">
+    <div class="o-expandable">
         <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
@@ -377,7 +377,7 @@ Add the `o-expandable-group__accordion` class to the expandable group
 to activate the accordion mode.
 
 <div class="o-expandable-group o-expandable-group__accordion">
-    <div class="o-expandable o-expandable__padded">
+    <div class="o-expandable">
         <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
@@ -402,7 +402,7 @@ to activate the accordion mode.
             </p>
         </div>
     </div>
-    <div class="o-expandable o-expandable__padded">
+    <div class="o-expandable">
         <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
@@ -427,7 +427,7 @@ to activate the accordion mode.
             </p>
         </div>
     </div>
-    <div class="o-expandable o-expandable__padded">
+    <div class="o-expandable">
         <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
@@ -456,7 +456,7 @@ to activate the accordion mode.
 
 ```
 <div class="o-expandable-group o-expandable-group__accordion">
-    <div class="o-expandable o-expandable__padded">
+    <div class="o-expandable">
         <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
@@ -481,7 +481,7 @@ to activate the accordion mode.
             </p>
         </div>
     </div>
-    <div class="o-expandable o-expandable__padded">
+    <div class="o-expandable">
         <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">
@@ -506,7 +506,7 @@ to activate the accordion mode.
             </p>
         </div>
     </div>
-    <div class="o-expandable o-expandable__padded">
+    <div class="o-expandable">
         <button class="o-expandable_header"
                 title="Expand content">
             <h3 class="h4 o-expandable_label">

--- a/test/unit-test/src/cfpb-atomic-component/src/utilities/atomic-helpers.spec.js
+++ b/test/unit-test/src/cfpb-atomic-component/src/utilities/atomic-helpers.spec.js
@@ -10,7 +10,7 @@ let containerDom;
 let componentDom;
 const testClass = 'o-footer';
 const HTML_SNIPPET = `
-  <div class="o-expandable o-expandable__padded" id="test-subject-two">
+  <div class="o-expandable" id="test-subject-two">
       <button class="o-expandable_header"
               title="Expand content">
           <span class="o-expandable_label">


### PR DESCRIPTION
Some docs cleanup from https://github.com/cfpb/design-system/pull/1924 to remove unneeded `o-expandable__padded` references.

## Changes

- Remove `o-expandable__padded` from docs

## Testing

1. PR checks should pass.
