### PR TITLE
Remove unused `@text-shadow` argument

### DIFF
--- a/packages/cfpb-core/src/base.less
+++ b/packages/cfpb-core/src/base.less
@@ -73,7 +73,7 @@ b {
   text-transform: inherit;
 }
 
-.heading-5( @fs: @size-v, @text-shadow: @text ) {
+.heading-5( @fs: @size-v ) {
   @font-size: @fs;
 
   margin-bottom: unit((15px / @font-size), em);
@@ -84,7 +84,7 @@ b {
   text-transform: uppercase;
 }
 
-.heading-6( @fs: @size-vi, @text-shadow: @text ) {
+.heading-6( @fs: @size-vi ) {
   @font-size: @fs;
 
   margin-bottom: unit((15px / @font-size), em);

--- a/packages/cfpb-typography/src/atoms/date.less
+++ b/packages/cfpb-typography/src/atoms/date.less
@@ -1,5 +1,5 @@
 .a-date {
-  .heading-5( @text-shadow: @date );
+  .heading-5();
 
   color: @date;
   white-space: nowrap;

--- a/packages/cfpb-typography/src/molecules/pull-quote.less
+++ b/packages/cfpb-typography/src/molecules/pull-quote.less
@@ -11,7 +11,7 @@
   }
 
   &_citation {
-    .heading-5( @text-shadow: @pull-quote_citation );
+    .heading-5();
 
     color: @pull-quote_citation;
 


### PR DESCRIPTION
This argument for `heading-5(…)` and `heading-6(…)` does not to be anything more than an argument. There doesn't appear to be an implementation.

## Removals

- Remove unused `@text-shadow` argument

## Testing

1. PR checks should pass.
