### PR TITLE
Update `update-gh-pages.sh` to fix production not updating

### DIFF
--- a/scripts/update-gh-pages.sh
+++ b/scripts/update-gh-pages.sh
@@ -25,7 +25,7 @@ yarn install
 yarn after-install
 
 # Build the design system website
-yarn build
+yarn build-netlify
 
 # Remove the built Jekyll website from .gitignore
 sed -i '/_site/d' ./.gitignore


### PR DESCRIPTION
Fixes https://github.com/cfpb/design-system/issues/1941

https://github.com/cfpb/design-system/pull/1909 changed the `build` command to only build the documentation assets, however, the old command included `bundle exec jekyll build`. The `update-gh-pages.sh` script should have been updated to use the `build-netlify` command instead, which includes jekyll building. Without that it was building the assets, but not the pages.

## Changes

- Change `update-gh-pages.sh`  to use `yarn build-netlify` instead of `yarn build`.

## Testing

1. PR checks should pass. I think we just need to merge it and see.