### PR TITLE
cfpb-notification: Add color contrast safe colors for links in an error notification

### DIFF
--- a/packages/cfpb-notifications/src/molecules/notification.less
+++ b/packages/cfpb-notifications/src/molecules/notification.less
@@ -39,6 +39,11 @@
     & > .cf-icon-svg {
       fill: @notification-icon-error;
     }
+
+    & a {
+      // Colors for :link, :visited, :hover, :focus, :active.
+      .u-link__colors( var(--pacific-mid-dark), var(--teal), var(--pacific-dark), var(--pacific-mid-dark), var(--navy-dark) );
+    }
   }
 
   &__visible {


### PR DESCRIPTION
Fixes https://github.com/cfpb/design-system/issues/1943

The standard link color on a red background in the alert notifications is not accessible.

## Changes

- cfpb-notification: Add color contrast safe colors for links in an error notification

## Testing

1. PR checks should pass. Visit the alert page in the PR preview and run Google Lighthouse and it should pass the accessibility check with 100%.
