### PR TITLE
Fix search

### DIFF
--- a/docs/_includes/search-scripts.html
+++ b/docs/_includes/search-scripts.html
@@ -1,4 +1,7 @@
 <script>
+(function() {
+
+
     {% assign variations_count = 0 %}
     // This is an inline script attached to the window so that we can utilize
     // jekyll's liquid variables, such as site.pages.
@@ -19,20 +22,20 @@
 
                 {% for variation in variation_group.variations %}
                     'variation_name{{ forloop.index }}': '{{ variation.variation_name | escape }}',
-                    'variation_description{{ forloop.index }}': {{ variation.variation_description | markdownify | strip_html | jsonify }},
+                    'variation_description{{ forloop.index }}': {{ variation.variation_description | markdownify | strip_html | url_encode | jsonify }},
                     'variation_code_snippet{{ forloop.index }}': `{{ variation.variation_code_snippet | escape }}`,
                 {% endfor %}
             {% endfor %}
 
 
             'title': '{{ page.title | escape }}',
-            'description': {{ page.description | markdownify | strip_html | jsonify }},
-            'use_cases': {{ page.use_cases | markdownify | strip_html | jsonify }},
-            'guidelines': {{ page.guidelines | markdownify | strip_html | jsonify }},
-            'behavior': {{ page.behavior | markdownify | strip_html | jsonify }},
-            'accessibility': {{ page.accessibility | markdownify | strip_html | jsonify }},
-            'research': {{ page.research | markdownify | strip_html | jsonify }},
-            'related_items': {{ page.related_items | markdownify | strip_html | jsonify }},
+            'description': {{ page.description | markdownify | strip_html | url_encode | jsonify }},
+            'use_cases': {{ page.use_cases | markdownify | strip_html | url_encode | jsonify }},
+            'guidelines': {{ page.guidelines | markdownify | strip_html | url_encode | jsonify }},
+            'behavior': {{ page.behavior | markdownify | strip_html | url_encode | jsonify }},
+            'accessibility': {{ page.accessibility | markdownify | strip_html | url_encode | jsonify }},
+            'research': {{ page.research | markdownify | strip_html | url_encode | jsonify }},
+            'related_items': {{ page.related_items | markdownify | strip_html | url_encode | jsonify }},
             'url': '{{ page.url | escape }}'
         }
         {% unless forloop.last %},{% endunless %}
@@ -58,5 +61,6 @@
             {% unless forloop.last %},{% endunless %}
         {% endfor %}
     ];
+})();
 </script>
 <script src="{{ site.baseurl }}/dist/js/search.js"></script>

--- a/docs/assets/css/search.less
+++ b/docs/assets/css/search.less
@@ -1,5 +1,6 @@
 #search-results {
   list-style: none;
+  padding-left: 0;
 }
 
 #search-results li {

--- a/test/cypress/e2e/docs/search.cy.js
+++ b/test/cypress/e2e/docs/search.cy.js
@@ -1,0 +1,21 @@
+describe('The search feature', () => {
+  beforeEach(() => {
+    cy.visit('/search/');
+  });
+
+  it('should show no search results', () => {
+    cy.get('#search-results').should(
+      'contain',
+      "No search results found for ''.",
+    );
+  });
+
+  it('should show search results', () => {
+    cy.get('#search-box').type('button');
+    cy.get('#search-form button').click();
+    cy.get('#search-results').should(
+      'contain',
+      "5 results for search of 'button'.",
+    );
+  });
+});

--- a/test/cypress/e2e/docs/search.cy.js
+++ b/test/cypress/e2e/docs/search.cy.js
@@ -13,9 +13,6 @@ describe('The search feature', () => {
   it('should show search results', () => {
     cy.get('#search-box').type('button');
     cy.get('#search-form button').click();
-    cy.get('#search-results').should(
-      'contain',
-      "results for search of 'button'.",
-    );
+    cy.get('#search-results').find('li').its('length').should('be.gte', 1);
   });
 });

--- a/test/cypress/e2e/docs/search.cy.js
+++ b/test/cypress/e2e/docs/search.cy.js
@@ -15,7 +15,7 @@ describe('The search feature', () => {
     cy.get('#search-form button').click();
     cy.get('#search-results').should(
       'contain',
-      "5 results for search of 'button'.",
+      "results for search of 'button'.",
     );
   });
 });


### PR DESCRIPTION
Search broke at some point because embedded SVG icons were messing up the quoting of the search string. 


## Changes

- Properly escape search string data.
- Add cypress test for search.
- Left align search results and cfpb logo.

## Testing

1. http://localhost:4000/design-system/search/ should work for searching.
