### PR TITLE
Fix `a-text-input` error/warning/success modifiers

### DIFF
--- a/docs/pages/text-inputs.md
+++ b/docs/pages/text-inputs.md
@@ -55,15 +55,15 @@ variation_groups:
 
           </h4>
 
-          <input class="a-text-input a-text-input-success" type="text" placeholder="Success" id="form-input-success" aria-describedby="form-input-success_message">
+          <input class="a-text-input a-text-input--success" type="text" placeholder="Success" id="form-input-success" aria-describedby="form-input-success_message">
 
           <br><br>
 
-          <input class="a-text-input a-text-input-warning" type="text" placeholder="Warning" id="form-input-warning" aria-describedby="form-input-warning_message">
+          <input class="a-text-input a-text-input--warning" type="text" placeholder="Warning" id="form-input-warning" aria-describedby="form-input-warning_message">
 
           <br><br>
 
-          <input class="a-text-input a-text-input-error" type="text" placeholder="Error" id="form-input-error" aria-describedby="form-input-error_message">
+          <input class="a-text-input a-text-input--error" type="text" placeholder="Error" id="form-input-error" aria-describedby="form-input-error_message">
         variation_specs: ''
         variation_name: Text input
         variation_description:

--- a/packages/cfpb-forms/src/atoms/text-input.less
+++ b/packages/cfpb-forms/src/atoms/text-input.less
@@ -116,15 +116,15 @@
     }
   }
 
-  &-error {
+  &--error {
     .u-border-outline-error();
   }
 
-  &-warning {
+  &--warning {
     .u-border-outline-warning();
   }
 
-  &-success {
+  &--success {
     .u-border-outline-success();
   }
 }


### PR DESCRIPTION
https://github.com/cfpb/design-system/pull/1886 erroneously set the `a-text-input` error/warning/success modifiers to be blocks, apparently because of a mistake I made reconciling conflicts in https://github.com/cfpb/design-system/pull/1886/commits/6f6bbbbc307f1e5dccc7e6b8f9a90fa196743294 

https://github.com/cfpb/design-system/pull/1983/ updated the example to follow the CSS, but the CSS should actually be updated to retain these as modifiers instead of erroneously as blocks.

## Changes

- Fix `a-text-input` error/warning/success modifiers

## Testing

1. Text inputs should have error/warning/success colored border styling on https://deploy-preview-1984--cfpb-design-system.netlify.app/design-system/components/text-inputs
