### PR TITLE
Remove `a-link--icon-before-text` and `a-link--icon-after-text`

### DIFF
--- a/docs/pages/featured-content-modules.md
+++ b/docs/pages/featured-content-modules.md
@@ -79,8 +79,7 @@ variation_groups:
                       commodo cu.
                   </p>
                   <a class="a-link
-                            a-link--jump
-                            a-link--icon-after-text">
+                            a-link--jump">
                       <span class="a-link__text">Read more about the feature</span>
                   </a>
               </div>
@@ -110,8 +109,7 @@ variation_groups:
                       commodo cu.
                   </p>
                   <a class="a-link
-                            a-link--jump
-                            a-link--icon-after-text">
+                            a-link--jump">
                       <span class="a-link__text">Read more about the feature</span>
                   </a>
               </div>

--- a/docs/pages/links.md
+++ b/docs/pages/links.md
@@ -120,8 +120,7 @@ variation_groups:
           touch area. Reduce screen size to see these in action.
         variation_code_snippet: |-
           <a class="a-link
-                    a-link--jump
-                    a-link--icon-after-text"
+                    a-link--jump"
             href="#">
           <span class="a-link__text">Jump link</span>
               {% include icons/right.svg %}

--- a/packages/cfpb-layout/usage.md
+++ b/packages/cfpb-layout/usage.md
@@ -1148,8 +1148,7 @@ See below for modifiers that change the image's horizontal anchoring.
             commodo cu.
         </p>
         <a class="a-link
-                  a-link--jump
-                  a-link--icon-after-text">
+                  a-link--jump">
             <span class="a-link__text">Read more about the feature</span>
             {% include icons/right.svg %}
         </a>
@@ -1171,8 +1170,7 @@ See below for modifiers that change the image's horizontal anchoring.
             commodo cu.
         </p>
         <a class="a-link
-                  a-link--jump
-                  a-link--icon-after-text">
+                  a-link--jump">
             <span class="a-link__text">Read more about the feature</span>
             {% raw %}{% include icons/right.svg %}{% endraw %}
         </a>
@@ -1204,8 +1202,7 @@ so that the right side remains in view at all screen sizes.
             commodo cu.
         </p>
         <a class="a-link
-                  a-link--jump
-                  a-link--icon-after-text">
+                  a-link--jump">
             <span class="a-link__text">Read more about the feature</span>
             {% include icons/right.svg %}
         </a>
@@ -1228,8 +1225,7 @@ so that the right side remains in view at all screen sizes.
             commodo cu.
         </p>
         <a class="a-link
-                  a-link--jump
-                  a-link--icon-after-text">
+                  a-link--jump">
             <span class="a-link__text">Read more about the feature</span>
             {% raw %}{% include icons/right.svg %}{% endraw %}
         </a>
@@ -1261,8 +1257,7 @@ so that the focal point of the visual remains in view at all screen sizes.
             commodo cu.
         </p>
         <a class="a-link
-                  a-link--jump
-                  a-link--icon-after-text">
+                  a-link--jump">
             <span class="a-link__text">Read more about the feature</span>
             {% include icons/right.svg %}
         </a>
@@ -1285,8 +1280,7 @@ so that the focal point of the visual remains in view at all screen sizes.
             commodo cu.
         </p>
         <a class="a-link
-                  a-link--jump
-                  a-link--icon-after-text">
+                  a-link--jump">
             <span class="a-link__text">Read more about the feature</span>
             {% raw %}{% include icons/right.svg %}{% endraw %}
         </a>

--- a/packages/cfpb-typography/src/atoms/links.less
+++ b/packages/cfpb-typography/src/atoms/links.less
@@ -27,29 +27,12 @@
   // Mobile only.
   .respond-to-max(@bp-xs-max, {
     .u-block-link();
+    display: flex;
+    align-items: center;
+    gap: unit(10px / @base-font-size-px, rem);
 
-    position: relative;
-
-    .cf-icon-svg {
-      position: absolute;
-      margin-bottom: -0.6em;
-      bottom: 50%;
-    }
-
-    &.a-link--icon-after-text {
-      padding-right: 1.25em;
-    }
-
-    &.a-link--icon-after-text .cf-icon-svg {
-      right: 0;
-    }
-
-    &.a-link--icon-before-text {
-      padding-left: 1.25em;
-    }
-
-    &.a-link--icon-before-text .cf-icon-svg {
-      left: 0;
+    .a-link__text {
+      flex-grow: 1;
     }
   });
 }

--- a/packages/cfpb-typography/usage.md
+++ b/packages/cfpb-typography/usage.md
@@ -260,8 +260,7 @@ For more information, email
 to full block links that have a finger-friendly touch area.
 
 <a class="a-link
-          a-link--jump
-          a-link--icon-after-text"
+          a-link--jump"
    href="#">
 <span class="a-link__text">Default jump link</span>
 {% include icons/right.svg %}
@@ -269,8 +268,7 @@ to full block links that have a finger-friendly touch area.
 
 ```
 <a class="a-link
-          a-link--jump
-          a-link--icon-after-text"
+          a-link--jump"
    href="#">
     {% raw %}{% include icons/right.svg %}{% endraw %}
 </a>


### PR DESCRIPTION
Jump links required both the `a-link--jump` and `a-link--icon-after-text` (or `a-link--icon-before-text`) modifiers to correctly layout with an icon. However, using flexbox we can have these links correctly layout whether or not they have an icon and whether or not it's on the left or right-hand side.

## Removals

- Remove `a-link--icon-before-text` and `a-link--icon-after-text`

## Changes

- Convert Jump Links to use flexbox.

## Testing

1. Visit https://deploy-preview-1987--cfpb-design-system.netlify.app/design-system/components/links and check out the jump links across screen sizes.

## Screenshots

<img width="378" alt="Screenshot 2024-05-29 at 6 01 40 PM" src="https://github.com/cfpb/design-system/assets/704760/3f066a17-238f-4849-9571-0c5713ce7699">

<img width="808" alt="Screenshot 2024-05-29 at 6 01 47 PM" src="https://github.com/cfpb/design-system/assets/704760/ce030335-a980-47f1-87d0-cab69a962cdf">


