### PR TITLE
Update jump links to handle external icons

### DIFF
--- a/docs/pages/links.md
+++ b/docs/pages/links.md
@@ -119,23 +119,38 @@ variation_groups:
           screens by converting to full block links that have a finger-friendly
           touch area. Reduce screen size to see these in action.
         variation_code_snippet: |-
-          <a class="a-link
+          <p><a class="a-link
                     a-link--jump"
             href="#">
           <span class="a-link__text">Jump link</span>
               {% include icons/right.svg %}
-          </a>
+          </a></p><p>
+          <a class="a-link
+                    a-link--jump"
+            href="#">
+          <span class="a-link__text">External link jump link</span>
+              {% include icons/external-link.svg %}
+              {% include icons/right.svg %}
+          </a></p>
+
       - variation_is_deprecated: false
         variation_name: Jump link with icon on left
         variation_description: Jump links can also have icons before the text, like icon links.
         variation_code_snippet: |-
-          <a class="a-link
+          <p><a class="a-link
                     a-link--jump
                     a-link--icon-before-text"
             href="#">
               {% include icons/left.svg %}
               <span class="a-link__text">Jump link with icon on left</span>
-          </a>
+          </a></p><p>
+          <a class="a-link
+                    a-link--jump"
+            href="#">
+              {% include icons/left.svg %}
+          <span class="a-link__text">External link jump link</span>
+              {% include icons/external-link.svg %}
+          </a></p>
       - variation_is_deprecated: false
         variation_name: Printed links
         variation_description: When a page is printed from

--- a/packages/cfpb-typography/src/atoms/links.less
+++ b/packages/cfpb-typography/src/atoms/links.less
@@ -29,10 +29,11 @@
     .u-block-link();
     display: flex;
     align-items: center;
-    gap: unit(10px / @base-font-size-px, rem);
+    gap: unit(5px / @base-font-size-px, rem);
 
-    .a-link__text {
-      flex-grow: 1;
+    // Only right-hand align arrow icons.
+    .cf-icon-svg--right {
+      margin-left: auto;
     }
   });
 }

--- a/packages/cfpb-typography/src/atoms/links.less
+++ b/packages/cfpb-typography/src/atoms/links.less
@@ -49,7 +49,6 @@
 
 .u-block-link {
   box-sizing: border-box;
-  display: block;
   padding-top: unit(10px / @base-font-size-px, em);
   padding-bottom: unit(10px / @base-font-size-px, em);
   border-top-width: 1px;

--- a/packages/cfpb-typography/src/molecules/list.less
+++ b/packages/cfpb-typography/src/molecules/list.less
@@ -59,6 +59,7 @@
 
   .m-list__link {
     font-weight: 500;
+    display: block;
 
     // Mobile only.
     .respond-to-max(@bp-xs-max, {


### PR DESCRIPTION
## Changes

- Update jump links to handle external icons and only right-align right arrows.

## Testing

1. Jump links on https://deploy-preview-1988--cfpb-design-system.netlify.app/design-system/components/links have a jump links with external links.

## Screenshots

<img width="403" alt="Screenshot 2024-05-30 at 11 03 46 AM" src="https://github.com/cfpb/design-system/assets/704760/fc1c5e62-ad13-47e2-b9e6-316e50ae8a1e">

<img width="828" alt="Screenshot 2024-05-30 at 11 03 58 AM" src="https://github.com/cfpb/design-system/assets/704760/56237eab-8422-4fe9-9733-08d83a5578fa">
