### PR TITLE
Set underline on link by default

### DIFF
--- a/packages/cfpb-typography/src/atoms/links.less
+++ b/packages/cfpb-typography/src/atoms/links.less
@@ -1,15 +1,18 @@
-//
-// Jump link
-//
-
-.a-link--jump {
-  font-weight: 500;
+.a-link {
   border-bottom-width: 0;
 
   .a-link__text {
     border-bottom-width: 1px;
     border-bottom-style: inherit;
   }
+}
+
+//
+// Jump link
+//
+
+.a-link--jump {
+  font-weight: 500;
 
   // Mobile only.
   .respond-to-max(@bp-xs-max, {


### PR DESCRIPTION
https://github.com/cfpb/design-system/pull/1989 removed `a-link--icon`, but that means the underline goes right under the icon. This PR makes `a-link`, but default run the underline only under the text, and not an accompanying icon.

## Changes

- Set underline on link by default

## Testing

1. https://deploy-preview-1990--cfpb-design-system.netlify.app/design-system/components/links#link-with-icon should not have a line under the icon.

## Screenshots

<img width="781" alt="Screenshot 2024-05-30 at 4 01 12 PM" src="https://github.com/cfpb/design-system/assets/704760/19c031f4-5abe-44d4-9b33-3bdcd699225a">
