### PR TITLE
Prevent squeezing of icon on long jump link text

### DIFF
--- a/docs/pages/links.md
+++ b/docs/pages/links.md
@@ -55,6 +55,13 @@ variation_groups:
                     {% include icons/right.svg %}
                   </a>
               </li>
+              <li class="m-list__item">
+                  <a class="a-link a-link--jump" href="#">
+                    <span class="a-link__text">Read a report on our post-proposal qualitative testing of the new Spanish and refinance disclosures
+                    </span>
+                    {% include icons/download.svg %}
+                  </a>
+              </li>
           </ul>
         variation_description: List links (or call-to-action links) are links
           that highlight a users' next steps. They are medium weight and often

--- a/packages/cfpb-typography/src/atoms/links.less
+++ b/packages/cfpb-typography/src/atoms/links.less
@@ -35,6 +35,9 @@
 
     .a-link__text {
       border-bottom-width: 0;
+      // Arbitrary high value for flex-shrink to prevent squeezing of the icon
+      // when the link text is very long.
+      flex-shrink: 10;
     }
   });
 }


### PR DESCRIPTION
## Changes

- Add `flex-shrink` to prevent squeezing of icon on long jump link text.

## Testing

1. Visit links example page and resize to mobile and see long jump link does not crush the accompanying icon.

## Screenshots

Before:
<img width="397" alt="Screenshot 2024-05-30 at 5 37 10 PM" src="https://github.com/cfpb/design-system/assets/704760/a52f558a-63fb-4b63-9e7f-44e8752b4312">


After:
<img width="405" alt="Screenshot 2024-05-30 at 5 36 56 PM" src="https://github.com/cfpb/design-system/assets/704760/8f5901e1-687a-4ffa-aa44-e6cc56c92baf">


