### PR TITLE
Add `a-link__text` class to jump links

### DIFF
--- a/docs/pages/alerts.md
+++ b/docs/pages/alerts.md
@@ -56,12 +56,16 @@ variation_groups:
                   <ul class="m-list m-list--links">
                       <li class="m-list__item">
                           <a class="a-link a-link--jump" href="/">
+                            <span class="a-link__text">
                               This is a link below the explanation
+                            </span>
                           </a>
                       </li>
                       <li class="m-list__item">
                           <a class="a-link a-link--jump" href="/">
+                            <span class="a-link__text">
                               This is an external link {% include icons/external-link.svg %}
+                            </span>
                           </a>
                       </li>
                   </ul>
@@ -84,7 +88,9 @@ variation_groups:
                   <ul class="m-list m-list--links">
                       <li class="m-list__item">
                           <a class="a-link a-link--jump" href="/">
+                            <span class="a-link__text">
                               This is an external link {% include icons/external-link.svg %}
+                            </span>
                           </a>
                       </li>
                   </ul>
@@ -109,7 +115,9 @@ variation_groups:
                   <ul class="m-list m-list--links">
                       <li class="m-list__item">
                           <a class="a-link a-link--jump" href="/">
+                            <span class="a-link__text">
                               This is an external link {% include icons/external-link.svg %}
+                            </span>
                           </a>
                       </li>
                   </ul>
@@ -138,7 +146,9 @@ variation_groups:
                   <ul class="m-list m-list--links">
                       <li class="m-list__item">
                           <a class="a-link a-link--jump" href="/">
+                            <span class="a-link__text">
                               This is an external link {% include icons/external-link.svg %}
+                            </span>
                           </a>
                       </li>
                   </ul>

--- a/docs/pages/banner-notification.md
+++ b/docs/pages/banner-notification.md
@@ -23,12 +23,16 @@ variation_groups:
                           <ul class="m-list m-list--links">
                               <li class="m-list__item">
                                   <a class="a-link a-link--jump" href="#">
-                                      A link can be added
+                                      <span class="a-link__text">
+                                        A link can be added
+                                      </span>
                                   </a>
                               </li>
                               <li class="m-list__item">
                                   <a class="a-link a-link--jump" href="#">
+                                    <span class="a-link__text">
                                       Multiple links are supported
+                                    </span>
                                   </a>
                               </li>
                           </ul>
@@ -59,12 +63,16 @@ variation_groups:
                           <ul class="m-list m-list--links">
                               <li class="m-list__item">
                                   <a class="a-link a-link--jump" href="#test-link">
-                                      Links can be added
+                                      <span class="a-link__text">
+                                          Links can be added
+                                      </span>
                                   </a>
                               </li>
                               <li class="m-list__item">
                                   <a class="a-link a-link--jump" href="#">
-                                      Visited links are also white
+                                      <span class="a-link__text">
+                                          Visited links are also white
+                                      </span>
                                   </a>
                               </li>
                           </ul>

--- a/docs/pages/text-introductions.md
+++ b/docs/pages/text-introductions.md
@@ -22,7 +22,7 @@ variation_groups:
             </p>
             <ul class="m-list m-list--links">
               <li class="m-list__item">
-                <a class="a-link a-link--jump" href="#"> Call-to-action link </a>
+                <a class="a-link a-link--jump" href="#"> <span class="a-link__text">Call-to-action link</span> </a>
               </li>
             </ul>
           </div>

--- a/docs/pages/wells.md
+++ b/docs/pages/wells.md
@@ -13,7 +13,7 @@ variation_groups:
 
           <ul class="m-list m-list--links">
               <li class="m-list__item">
-                  <a class="a-link a-link--jump" href="#">Call-to-action link</a>
+                  <a class="a-link a-link--jump" href="#"><span class="a-link__text">Call-to-action link</span></a>
               </li>
           </ul>
 

--- a/packages/cfpb-notifications/usage.md
+++ b/packages/cfpb-notifications/usage.md
@@ -124,12 +124,16 @@ include them below the message or explanation as a `m-list` unordered list.
         <ul class="m-list m-list--links">
             <li class="m-list__item">
                 <a class="a-link a-link--jump" href="/">
-                    This is a link below the message
+                    <span class="a-link__text">
+                        This is a link below the message
+                    </span>
                 </a>
             </li>
             <li class="m-list__item">
                 <a class="a-link a-link--jump" href="/">
-                    This is another link
+                    <span class="a-link__text">
+                        This is another link
+                    </span>
                 </a>
             </li>
          </ul>
@@ -145,12 +149,16 @@ include them below the message or explanation as a `m-list` unordered list.
         <ul class="m-list m-list--links">
             <li class="m-list__item">
                 <a class="a-link a-link--jump" href="/">
-                    This is a link below the message
+                    <span class="a-link__text">
+                        This is a link below the message
+                    </span>
                 </a>
             </li>
             <li class="m-list__item">
                 <a class="a-link a-link--jump" href="/">
-                    This is another link
+                    <span class="a-link__text">
+                        This is another link
+                    </span>
                 </a>
             </li>
         </ul>
@@ -169,12 +177,16 @@ include them below the message or explanation as a `m-list` unordered list.
         <ul class="m-list m-list--links">
             <li class="m-list__item">
                 <a class="a-link a-link--jump" href="/">
-                    This is a link below the explanation
+                    <span class="a-link__text">
+                        This is a link below the explanation
+                    </span>
                 </a>
             </li>
             <li class="m-list__item">
                 <a class="a-link a-link--jump" href="/">
-                    This is an external link {% include icons/external-link.svg %}
+                    <span class="a-link__text">
+                        This is an external link {% include icons/external-link.svg %}
+                    </span>
                 </a>
             </li>
          </ul>
@@ -193,12 +205,16 @@ include them below the message or explanation as a `m-list` unordered list.
         <ul class="m-list m-list--links">
             <li class="m-list__item">
                 <a class="a-link a-link--jump" href="/">
-                    This is a link below the explanation
+                    <span class="a-link__text">
+                        This is a link below the explanation
+                    </span>
                 </a>
             </li>
             <li class="m-list__item">
                 <a class="a-link a-link--jump" href="/">
-                    This is an external link {% raw %}{% include icons/external-link.svg %}{% endraw %}
+                    <span class="a-link__text">
+                        This is an external link {% raw %}{% include icons/external-link.svg %}{% endraw %}
+                    </span>
                 </a>
             </li>
         </ul>

--- a/packages/cfpb-typography/usage.md
+++ b/packages/cfpb-typography/usage.md
@@ -357,26 +357,50 @@ screens.
 
 <ul class="m-list m-list--links">
     <li class="m-list__item">
-        <a class="a-link a-link--jump" href="#">List item 1</a>
+        <a class="a-link a-link--jump" href="#">
+            <span class="a-link__text">
+                List item 1
+            <span>
+        </a>
     </li>
     <li class="m-list__item">
-        <a class="a-link a-link--jump" href="#">List item 2</a>
+        <a class="a-link a-link--jump" href="#">
+            <span class="a-link__text">
+                List item 2
+            </span>
+        </a>
     </li>
     <li class="m-list__item">
-        <a class="a-link a-link--jump" href="#">List item 3</a>
+        <a class="a-link a-link--jump" href="#">
+            <span class="a-link__text">
+                List item 3
+            </span>
+        </a>
     </li>
 </ul>
 
 ```
 <ul class="m-list m-list--links">
     <li class="m-list__item">
-        <a class="a-link a-link--jump" href="#">List item 1</a>
+        <a class="a-link a-link--jump" href="#">
+            <span class="a-link__text">
+                List item 1
+            </span>
+        </a>
     </li>
     <li class="m-list__item">
-        <a class="a-link a-link--jump" href="#">List item 2</a>
+        <a class="a-link a-link--jump" href="#">
+            <span class="a-link__text">
+                List item 2
+            </span>
+        </a>
     </li>
     <li class="m-list__item">
-        <a class="a-link a-link--jump" href="#">List item 3</a>
+        <a class="a-link a-link--jump" href="#">
+            <span class="a-link__text">
+                List item 3
+            </span>
+        </a>
     </li>
 </ul>
 ```


### PR DESCRIPTION
Jump links without the `a-link__text` class do not get an underline, and should (aside from the DS sidebar links).

## Changes

- Add missing `a-link__text` class to jump links

## Testing

1. Check the banner page in the PR preview and see that the links have underlines.

## Screenshots

Before:
<img width="544" alt="Screenshot 2024-07-30 at 1 24 05 PM" src="https://github.com/user-attachments/assets/b0252732-3102-4e22-aef9-ca1cc3582e04">

After:
<img width="536" alt="Screenshot 2024-07-30 at 1 23 52 PM" src="https://github.com/user-attachments/assets/9757e932-7586-45cc-b09c-aace733728e6">


