### PR TITLE
Update banner color scheme

### DIFF
--- a/packages/cfpb-design-system/src/components/cfpb-notifications/banner.scss
+++ b/packages/cfpb-design-system/src/components/cfpb-notifications/banner.scss
@@ -8,6 +8,9 @@
 // Global banner in the header.
 //
 
+$banner-dark-background: var(--teal-dark);
+$banner-dark-foreground: var(--white);
+
 .o-banner {
   padding: math.div(math.div($grid-gutter-width, 2), $base-font-size-px) + em 0;
   background: var(--gold-10);
@@ -26,26 +29,26 @@
   }
 
   &--dark {
-    background: var(--teal-mid-dark);
-    border-color: var(--teal-mid-dark);
-    color: var(--white);
-
-    a {
-      // Colors for :link, :visited, :hover, :focus, :active.
-      @include u-link-colors(
-        var(--white),
-        var(--white),
-        var(--gray-15),
-        var(--white),
-        var(--gray-15)
-      );
-    }
+    background: $banner-dark-background;
+    border-color: $banner-dark-background;
+    color: $banner-dark-foreground;
 
     .m-notification {
-      background: var(--teal-mid-dark);
+      background: $banner-dark-background;
 
       .cf-icon-svg {
-        fill: var(--white);
+        fill: $banner-dark-foreground;
+      }
+
+      a {
+        // Colors for :link, :visited, :hover, :focus, :active.
+        @include u-link-colors(
+          $banner-dark-foreground,
+          var(--teal-40),
+          var(--gray-15),
+          var(--white),
+          var(--gray-15)
+        );
       }
     }
   }


### PR DESCRIPTION
## Changes

- Update banner color scheme to change the background color to `teal-dark` instead of `teal-mid-dark` and change the visited color to `teal-40`.

## Testing

1. Visit banner page on PR preview https://deploy-preview-2014--cfpb-design-system.netlify.app/design-system/components/banner-notification

## Screenshots

<img width="781" alt="Screenshot 2024-08-08 at 1 20 27 PM" src="https://github.com/user-attachments/assets/abeefe68-f9a5-431b-98fb-785faf5aef4a">

Visited link is the first link, whereas unvisted link is not visited (sorry, I should I visited the second link to align with the text).
