### PR TITLE
Remove empty link from tags page

### DIFF
--- a/docs/pages/tags.md
+++ b/docs/pages/tags.md
@@ -40,8 +40,6 @@ variation_groups:
     variation_group_name: Types
 behavior: To clear a filter tag selection, click the “x” icon inside of the filter tag.
 related_items: >-
-  *
-  [Multiselect](https://cfpb.github.io/design-system/components/selects#multiselect)[](https://cfpb.github.io/design-system/patterns/filterable-list-control-panels)
-
+  * [Multiselect](https://cfpb.github.io/design-system/components/selects#multiselect)
   * [Filterable list control panels](https://cfpb.github.io/design-system/patterns/filterable-list-control-panels)
 ---

--- a/docs/pages/tags.md
+++ b/docs/pages/tags.md
@@ -41,5 +41,6 @@ variation_groups:
 behavior: To clear a filter tag selection, click the “x” icon inside of the filter tag.
 related_items: >-
   * [Multiselect](https://cfpb.github.io/design-system/components/selects#multiselect)
+
   * [Filterable list control panels](https://cfpb.github.io/design-system/patterns/filterable-list-control-panels)
 ---


### PR DESCRIPTION
An empty link on this page is causing the Lighthouse tests to fail:

https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1724718029743-49279.report.html

## Screenshots

<img width="718" alt="image" src="https://github.com/user-attachments/assets/6ba540f7-de7c-413e-bebb-cc38dc72cdf7">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Passes all existing automated tests