### PR TITLE
Fix syntax highlighting a11y failures

### DIFF
--- a/docs/assets/css/code.scss
+++ b/docs/assets/css/code.scss
@@ -10,18 +10,36 @@ pre[class*='language-'] {
   background: none;
   text-shadow: 0 1px white;
   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-size: 1em;
   text-align: left;
+  white-space: pre;
   word-spacing: normal;
+  word-break: normal;
   word-wrap: normal;
   line-height: 1.5;
 
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
   tab-size: 4;
 
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
   hyphens: none;
 }
 
+pre[class*='language-']::-moz-selection,
+pre[class*='language-'] ::-moz-selection,
+code[class*='language-']::-moz-selection,
+code[class*='language-'] ::-moz-selection {
+  text-shadow: none;
+  background: #b3d4fc;
+}
+
 pre[class*='language-']::selection,
-code[class*='language-']::selection {
+pre[class*='language-'] ::selection,
+code[class*='language-']::selection,
+code[class*='language-'] ::selection {
   text-shadow: none;
   background: #b3d4fc;
 }
@@ -63,7 +81,7 @@ pre[class*='language-'] {
   color: #999;
 }
 
-.namespace {
+.token.namespace {
   opacity: 0.7;
 }
 
@@ -91,8 +109,9 @@ pre[class*='language-'] {
 .token.url,
 .language-css .token.string,
 .style .token.string {
-  color: #a67f59;
-  background: rgba(255, 255, 255, 50%);
+  color: #9a6e3a;
+  /* This background color was intended by the author of this theme. */
+  background: hsla(0, 0%, 100%, 0.5);
 }
 
 .token.atrule,
@@ -101,7 +120,8 @@ pre[class*='language-'] {
   color: #07a;
 }
 
-.token.function {
+.token.function,
+.token.class-name {
   color: #dd4a68;
 }
 
@@ -115,7 +135,6 @@ pre[class*='language-'] {
 .token.bold {
   font-weight: bold;
 }
-
 .token.italic {
   font-style: italic;
 }
@@ -284,7 +303,7 @@ pre[class*='language-'] {
 
 /* Name.Decorator */
 .highlight .nd {
-  color: #99f;
+  color: #6a6ab1;
 }
 
 /* Name.Entity */
@@ -460,7 +479,8 @@ pre {
   white-space: pre-wrap;
   word-break: break-all;
   word-wrap: break-word;
-  background-color: #f9f9f9;
+  background-color: #f7f8f9;
+  border: 1px dotted #d2d3d5;
 
   code {
     padding: 0;

--- a/docs/pages/expandables.md
+++ b/docs/pages/expandables.md
@@ -47,7 +47,7 @@ variation_groups:
           #### toggleTargetState( element )
 
 
-          ```
+          ```js
 
           const element = document.querySelector( '.o-expandable__header' );
 
@@ -67,7 +67,7 @@ variation_groups:
           #### getLabelText()
 
 
-          ```
+          ```js
 
           expandables[0].getLabelText();
 

--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -106,7 +106,7 @@ variation_groups:
 
           #### Sass mixin
 
-          ```
+          ```scss
           @include u-grid-wrapper( @grid_wrapper-width: @grid_wrapper-width )
           ```
 
@@ -115,7 +115,7 @@ variation_groups:
 
           #### Example
 
-          ```
+          ```scss
           .main-wrapper {
               @include u-grid-wrapper();
           }
@@ -135,7 +135,7 @@ variation_groups:
           #### Mixin
 
 
-          ```
+          ```scss
 
           .u-grid-column( @columns: 1; @total: @grid_total-columns; @prefix: 0; @suffix: 0 )
 
@@ -158,7 +158,7 @@ variation_groups:
 
 
 
-          ```
+          ```scss
 
           .main-wrapper {
               @include u-grid-wrapper();
@@ -226,7 +226,7 @@ variation_groups:
           #### Mixin
 
 
-          ```
+          ```scss
 
           .u-grid-nested-col-group()
 
@@ -236,7 +236,7 @@ variation_groups:
           #### Usage
 
 
-          ```
+          ```scss
 
           .main-wrapper {
               @include u-grid-wrapper();
@@ -347,7 +347,7 @@ variation_groups:
       to your column wrappers, like this:
 
 
-      ```
+      ```scss
 
       <div class="col-half"> … </div>
 
@@ -361,7 +361,7 @@ variation_groups:
       and apply the mixins to those semantic classes, like this:
 
 
-      ```
+      ```scss
 
       <div class="description"> … </div>
 
@@ -370,7 +370,7 @@ variation_groups:
       ```
 
 
-      ```
+      ```scss
 
       .description,
 

--- a/docs/pages/helper-classes-mixins.md
+++ b/docs/pages/helper-classes-mixins.md
@@ -27,7 +27,7 @@ variation_groups:
 
 
 
-          ```
+          ```html
 
           <html class="no-js">
 
@@ -37,7 +37,7 @@ variation_groups:
           2. Add a script to remove the no-js class after confirming JavaScript is available
 
 
-          ```
+          ```html
 
           <script>
                 // Confirm availability of JavaScript and remove no-js class from html
@@ -50,7 +50,7 @@ variation_groups:
           3. Add the utility class to the element you want to hide
 
 
-          ```
+          ```html
 
           <div class="u-js-only"></div>
 
@@ -81,7 +81,7 @@ variation_groups:
           For example, to create a link with a social network icon, but allow non-sighted users to understand the context, add descriptive text with the `u-visually-hidden` class.
 
 
-          ```
+          ```html
 
           <h1>
               <a href="#">
@@ -103,14 +103,14 @@ variation_groups:
         variation_description: |-
           _DEPRECATED._ Identical to `display: inline-block.`
 
-          ```
+          ```html
           <div class="u-inline-block"></div>
           ```
         variation_name: '"Inline block" helper class [DEPRECATED]'
       - variation_code_snippet: ''
         variation_name: '"Float right" helper class'
         variation_description: |-
-          ```
+          ```html
           <div class="u-right"></div>
           ```
       - variation_code_snippet: >-
@@ -391,7 +391,7 @@ variation_groups:
           `.u-small-text(@context)`
 
 
-          ```
+          ```js
 
           // Ex.
 

--- a/docs/pages/media-queries.md
+++ b/docs/pages/media-queries.md
@@ -12,7 +12,7 @@ variation_groups:
       converts them to the corresponding min or max width media query.
 
 
-      ```
+      ```scss
 
       @include respond-to-min(vars-breakpoints.@bp) {
           @rules
@@ -27,7 +27,7 @@ variation_groups:
 
       Ex.
 
-      ```
+      ```scss
 
       // Tablet and above.
       @include respond-to-min(vars-breakpoints.@bp-sm-min) {
@@ -52,7 +52,7 @@ variation_groups:
       This mixin takes both min and max px values and a set of style rules and
       converts them to the corresponding min and max media query.
 
-      ```
+      ```scss
 
       @include respond-to-range(@bp1, @bp2) {
         @rules
@@ -62,7 +62,7 @@ variation_groups:
 
       Ex.
 
-      ```
+      ```scss
       // Tablet only.
       @include respond-to-range(@bp-sm-min, @bp-sm-max) {
           .title {
@@ -87,7 +87,7 @@ variation_groups:
 
       This mixin allows us to easily write styles that target both `@media print` and `.print`.
 
-      ```
+      ```scss
 
       // The following LESS...
 

--- a/docs/pages/transition-patterns.md
+++ b/docs/pages/transition-patterns.md
@@ -47,7 +47,7 @@ variation_groups:
           MoveTransition instance in JavaScript and calling its methods:
 
 
-          ```
+          ```js
 
           // Create reference to an element in the DOM.
 
@@ -111,7 +111,7 @@ variation_groups:
           new AlphaTransition instance in JavaScript and calling its methods:
 
 
-          ```
+          ```js
 
           // Create reference to an element in the DOM.
 
@@ -183,7 +183,7 @@ variation_groups:
           MaxHeightTransition instance in JavaScript and calling its methods:
 
 
-          ```
+          ```js
 
           // Create reference to an element in the DOM.
 
@@ -300,7 +300,7 @@ variation_groups:
           For example, at its most basic, the structure is:
 
 
-          ```
+          ```html
 
           <div data-js-hook="behavior_flyout-menu">
             <button data-js-hook="behavior_flyout-menu_trigger">
@@ -320,7 +320,7 @@ variation_groups:
           The initialization would then look like:
 
 
-          ```\<div
+          ```js
 
           // Create reference to the container and content element in the DOM.
 


### PR DESCRIPTION
Code syntax highlighting had some contrast errors. This PR (hopefully) fixes them.

## Changes

- Fix syntax highlighting a11y failures

## Testing

1. Easiest is to probably merge this and see how lighthouse does tonight.
