### PR TITLE
Lighthouse action: Update yarn cache path

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -20,7 +20,7 @@ jobs:
       # https://github.com/actions/cache/blob/master/examples.md#node---yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
+        run: echo "dir=.yarn/cache" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)


### PR DESCRIPTION
Yarn 4 doesn't have a `yarn cache dir` command. We also have the global cache turned off. This PR updates the lighthouse GH action to use the literal cache directory path.

## Changes

- Lighthouse action: Update yarn cache path

## Testing

1. We'll need to merge and see how this runs tonight.
