### PR TITLE
Add `on: workflow_dispatch:` to allow manually triggering of Lighthouse job

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -4,6 +4,8 @@ on:
   # Run every night at midnight UTC.
   schedule:
     - cron: '0 0 * * *'
+  # Allow manual triggering of the action.
+  workflow_dispatch:
 
 jobs:
   lighthouseci:


### PR DESCRIPTION
## Changes

- Add `on: workflow_dispatch:` to allow manually triggering of Lighthouse job

## Testing

1.  After merging, should allow manually running of the lighthouse action from the actions GH tab.