### PR TITLE
Remove unused Lighthouse results upload

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -28,10 +28,3 @@ jobs:
         run: yarn lhci autorun
         env:
           LHCI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Attach results as artifact to GitHub Actions run
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: lighthouse-results
-          path: .lighthouseci


### PR DESCRIPTION
A nightly GitHub Action runs Lighthouse against the Design System documentation site, to ensure that it meets with accessibility guidelines.

Currently this Action is generating a warning message, [for example](https://github.com/cfpb/design-system/actions/runs/11524988694):

> No files were found with the provided path: .lighthouseci. No artifacts will be uploaded.

This warning occurs because the upload step can't find the Lighthouse results.

We don't actually use the raw Lighthouse results in any way; as part of the nightly test, HTML reports are uploaded to temporary Google storage and their public URLs are included in the Action log.

Thus there's no need to upload the raw run results. This commit removes the upload step, thus fixing the warning.
