### PR TITLE
Add `u-small-text--subtle`

### DIFF
--- a/docs/pages/helper-classes-mixins.md
+++ b/docs/pages/helper-classes-mixins.md
@@ -379,6 +379,7 @@ variation_groups:
           `.u-link__hover-child(@c)`
         variation_code_snippet: ''
       - variation_name: '"Small text utility" mixin'
+        variation_code_snippet: ''
         variation_description: >-
           #### **Class**
 
@@ -386,11 +387,15 @@ variation_groups:
           Sets the element to `14px` (in `em`s).
 
 
-          *To be used on default `16px` text only. To use on text set to another size, use the mixin below.*
+          *To be used on default `16px` text only.
+          To use on text set to another size, use the mixin below.*
 
 
           `.u-small-text`
 
+
+          There is also a modifier, `u-small-text--subtle`, which sets the color
+          to be gray.
 
           #### **Mixin**
 
@@ -424,9 +429,6 @@ variation_groups:
           }
 
           ```
-
-          There is also a modifier, `u-small-text--subtle`, which sets the color
-          to be gray.
 guidelines: ''
 eyebrow: Utilities
 status: Released

--- a/docs/pages/helper-classes-mixins.md
+++ b/docs/pages/helper-classes-mixins.md
@@ -401,7 +401,7 @@ variation_groups:
           `.u-small-text(@context)`
 
 
-          ```js
+          ```scss
 
           // Ex.
 
@@ -413,19 +413,20 @@ variation_groups:
             }
           }
 
-
           // Compiles to
 
           .example {
             font-size: 1.25em;
           }
 
-
           .example small {
             font-size: 0.7em;
           }
 
           ```
+
+          There is also a modifier, `u-small-text--subtle`, which sets the color
+          to be gray.
 guidelines: ''
 eyebrow: Utilities
 status: Released

--- a/packages/cfpb-design-system/src/utilities/utilities.scss
+++ b/packages/cfpb-design-system/src/utilities/utilities.scss
@@ -425,4 +425,8 @@
 small,
 .u-small-text {
   @include u-small-text;
+
+  &--subtle {
+    color: var(--gray);
+  }
 }


### PR DESCRIPTION
This class is used in TCCP.

## Additions

- Add `u-small-text--subtle` modifier for making gray small text.

## Testing

1. There should be mention of the modifier in the docs at https://deploy-preview-2097--cfpb-design-system.netlify.app/design-system/development/helper-classes-and-mixins
