### PR TITLE
Remove extraneous button-with-icon.scss reference

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -18,7 +18,7 @@ body = """
     {% if previous.version %}\
         ## [{{ version | trim_start_matches(pat="v") }}](<REPO>/compare/{{ previous.version }}..{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
     {% else %}\
-        ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(timezone="America/New_York", format="%Y-%m-%d") }}
+        ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(timezone="America/New_York", format="%B %e, %Y") }}
     {% endif %}\
 {% else %}\
     ## [unreleased]

--- a/packages/cfpb-design-system/src/index.scss
+++ b/packages/cfpb-design-system/src/index.scss
@@ -6,7 +6,6 @@
 @forward 'components/cfpb-buttons/button';
 @forward 'components/cfpb-buttons/button-group';
 @forward 'components/cfpb-buttons/button-link';
-@forward 'components/cfpb-buttons/button-with-icon';
 
 // Expandables.
 @forward 'components/cfpb-expandables/vars';


### PR DESCRIPTION
https://github.com/cfpb/design-system/pull/2091 removed button-with-icon scss, but there was a reference that remained.

## Removals

- Remove extraneous button-with-icon.scss reference
