### PR TITLE
Buttons: add `justify-content: center`

### DIFF
--- a/packages/cfpb-design-system/src/components/cfpb-buttons/button.scss
+++ b/packages/cfpb-design-system/src/components/cfpb-buttons/button.scss
@@ -24,6 +24,7 @@ input.a-btn::-moz-focus-inner {
   appearance: none;
   display: flex;
   gap: math.div(10px, $base-font-size-px) + rem;
+  justify-content: center;
 
   box-sizing: border-box;
   padding: math.div($btn-v-padding, $btn-font-size) + em


### PR DESCRIPTION
If the width of the buttons is set by a parent container, such as is done in https://www.consumerfinance.gov/paying-for-college/your-financial-path-to-graduation/, then the button text will be left-aligned by default. This makes it so it is center aligned.

## Changes

- Buttons: add `justify-content: center`

## Testing

1. Visit the buttons preview page and inspect the buttons. Manually set their width to 100% and see that the text is centered in the button.
