### PR TITLE
Fix filter button group

### DIFF
--- a/docs/pages/filterable-list-control-panels.md
+++ b/docs/pages/filterable-list-control-panels.md
@@ -11,7 +11,7 @@ variation_groups:
   - variations:
       - variation_code_snippet: >-
           <div id="o-filterable-list-controls"
-          class="o-filterable-list-controls">
+               class="o-filterable-list-controls">
               <div class="o-expandable
                           o-expandable--background
                           o-expandable--border
@@ -121,14 +121,15 @@ variation_groups:
                                   </div>
                               </div>
                               <div class="content-l__col
-                                  content-l__col-1
-                                  m-btn-group">
-                                  <button class="a-btn" type="submit">
-                                  Apply filters
-                                  </button>
-                                  <a class="a-btn a-btn--link a-btn--warning" href="#">
-                                  Clear filters
-                                  </a>
+                                          content-l__col-1">
+                                    <div class="m-btn-group">
+                                        <button class="a-btn" type="submit">
+                                        Apply filters
+                                        </button>
+                                        <a class="a-btn a-btn--link a-btn--warning" href="#">
+                                        Clear filters
+                                        </a>
+                                    </div>
                               </div>
                           </div>
                       </form>


### PR DESCRIPTION
Filter buttons should appear in a group as the sole parent.

## Changes

- Fix filter button group to move group to its own container.

## Testing

1. Filterable list control panels page should not have a broken filter button group.

## Screenshots

Before:
<img width="234" alt="Screenshot 2024-11-13 at 11 22 58 AM" src="https://github.com/user-attachments/assets/3bc6f9dc-e48a-47fc-a058-ad8ec0f75883">

After:
<img width="269" alt="Screenshot 2024-11-13 at 11 23 11 AM" src="https://github.com/user-attachments/assets/ab485a28-f1b5-40c2-9ca5-82bdacec5328">

