### PR TITLE
Provide icon exports

### DIFF
--- a/packages/cfpb-design-system/package.json
+++ b/packages/cfpb-design-system/package.json
@@ -4,7 +4,8 @@
   "description": "CFPB's UI framework",
   "exports": {
     ".": "./src/index.js",
-    "./tooltips": "./src/components/cfpb-tooltips/index.js"
+    "./tooltips": "./src/components/cfpb-tooltips/index.js",
+    "./icons/": "./src/components/cfpb-icons/icons/"
   },
   "author": {
     "name": "Consumer Financial Protection Bureau",


### PR DESCRIPTION
One piece of fallout from https://github.com/cfpb/design-system/commit/005bce900a9652fff77c746c108e05b5a9a778ab is that the way code is imported by dependent js is actually quite different. With an `exports` key provided, **only** those exports are allowed rather than falling back to walking the filesystem (which we do a bunch in cf.gov).

This provides an `icons` export so that icons can be imported into js (which will need to be updated in dependent projects, namely cfgov, from existing `@cfpb/cfpb-design-system/src/components/cfpb-icons/icons/<icon.svg>` style imports. I'll do this for cfgov once this PR is merged and a release created (along with changes to js imports which 005bce9 also requires).