### PR TITLE
Provide instantiated tooltip object on initialized component

### DIFF
--- a/packages/cfpb-design-system/src/components/cfpb-tooltips/index.js
+++ b/packages/cfpb-design-system/src/components/cfpb-tooltips/index.js
@@ -22,7 +22,7 @@ function Tooltip(element) {
 
   /**
    * Set up and create the tooltip.
-   * @returns {Tooltip} An instance.
+   * @returns {object} An initialized tippy tooltip instance.
    */
   function init() {
     return (this.tooltip = tippy(element, {

--- a/packages/cfpb-design-system/src/components/cfpb-tooltips/index.js
+++ b/packages/cfpb-design-system/src/components/cfpb-tooltips/index.js
@@ -25,7 +25,7 @@ function Tooltip(element) {
    * @returns {Tooltip} An instance.
    */
   function init() {
-    return tippy(element, {
+    return (this.tooltip = tippy(element, {
       theme: 'cfpb',
       maxWidth: 450,
       content: function (reference) {
@@ -63,11 +63,12 @@ function Tooltip(element) {
           },
         },
       ],
-    });
+    }));
   }
 
   // Attach public events.
   this.init = init;
+  this.tooltip = null;
 
   return this;
 }


### PR DESCRIPTION
Some consumers of these tooltips may need access to the underlying tippy object to, eg, check the tooltip state, etc.
This PR provides the initialized tippy object as a `tooltip` key on the initialized component instance (this key is null before initialization).