### PR TITLE
Notifications: Set max-width of content

### DIFF
--- a/packages/cfpb-design-system/src/components/cfpb-notifications/notification.scss
+++ b/packages/cfpb-design-system/src/components/cfpb-notifications/notification.scss
@@ -66,6 +66,10 @@
     display: block;
   }
 
+  &__content {
+    max-width: 41.875rem;
+  }
+
   // Only adding left padding if an icon is present.
   .cf-icon-svg + &__content {
     padding-left: math.div(25px, $base-font-size-px) + rem;


### PR DESCRIPTION
Notification content should wrap if it gets too wide.

## Changes

- Notifications: Set max-width of content.

## Testing

1. Check PR preview for the alerts page and edit the notification text to be really long and see that it wraps before the width of the notification background/border.

<img width="1013" alt="Screenshot 2025-04-11 at 6 28 01 PM" src="https://github.com/user-attachments/assets/465e4971-d3a9-4aae-8a8d-731ffa77cb30" />

