### PR TITLE
Add component reference page

### DIFF
--- a/docs/_data/side-navigation.yml
+++ b/docs/_data/side-navigation.yml
@@ -102,6 +102,7 @@ first-level:
         nav-items:
           - page: Getting Started
           - page: Integrating the Design System into your project
+          - page: Reference for component states
       - heading: Layout
         nav-items:
           - page: Blocks

--- a/docs/_includes/examples/buttons.html
+++ b/docs/_includes/examples/buttons.html
@@ -1,0 +1,135 @@
+<div class="m-btn-group">
+  <button class="a-btn" title="Default state">Default state</button>
+
+  <button class="a-btn hover" title="Hover state">Hover state</button>
+
+  <button class="a-btn focus" title="Focus state">Focus state</button>
+
+  <button class="a-btn active" title="Active state">Active state</button>
+</div>
+
+<br />
+
+<div class="m-btn-group">
+  <button class="a-btn a-btn--secondary" title="Default state">
+    Default state
+  </button>
+
+  <button class="a-btn a-btn--secondary hover" title="Hover state">
+    Hover state
+  </button>
+
+  <button class="a-btn a-btn--secondary focus" title="Focus state">
+    Focus state
+  </button>
+
+  <button class="a-btn a-btn--secondary active" title="Active state">
+    Active state
+  </button>
+</div>
+
+<br />
+
+<div class="m-btn-group">
+  <button class="a-btn a-btn--disabled" title="Default state" disabled>
+    Default state
+  </button>
+
+  <button class="a-btn a-btn--disabled hover" title="Hover state" disabled>
+    Hover state
+  </button>
+
+  <button class="a-btn a-btn--disabled focus" title="Focus state" disabled>
+    Focus state
+  </button>
+</div>
+
+<br />
+
+<div class="m-btn-group">
+  <button class="a-btn a-btn--warning" title="Default state">
+    Default state
+  </button>
+
+  <button class="a-btn a-btn--warning hover" title="Hover state">
+    Hover state
+  </button>
+
+  <button class="a-btn a-btn--warning focus" title="Focus state">
+    Focus state
+  </button>
+
+  <button class="a-btn a-btn--warning active" title="Active state">
+    Active state
+  </button>
+</div>
+
+<br />
+<hr />
+<br />
+
+<h4>Full-width button (on x-small screens)</h4>
+
+<div class="m-btn-group">
+  <button class="a-btn a-btn--full-on-xs" title="Default state">
+    Default state
+  </button>
+
+  <button class="a-btn a-btn--full-on-xs hover" title="Hover state">
+    Hover state
+  </button>
+
+  <button class="a-btn a-btn--full-on-xs focus" title="Focus state">
+    Focus state
+  </button>
+
+  <button class="a-btn a-btn--full-on-xs active" title="Active state">
+    Active state
+  </button>
+</div>
+
+<br />
+<hr />
+<br />
+
+<h4>Button with icon</h4>
+
+<div class="m-btn-group">
+  <button class="a-btn a-btn--secondary">
+    {% include icons/left.svg %}
+    <span>Go back</span>
+  </button>
+  <button class="a-btn">
+    <span>Continue</span>{% include icons/right.svg %}
+  </button>
+</div>
+
+<br />
+
+<button class="a-btn">
+  <span>Upload file</span>{% include icons/upload.svg %}
+</button>
+
+<br />
+
+<button class="a-btn">
+  <span>Submit your complaint</span>
+  {% include icons/updating.svg %}
+</button>
+
+<br />
+<hr />
+<br />
+
+<h4>Button link</h4>
+
+<div class="m-btn-group">
+  <a class="a-btn">
+    <span>Link styled as a button</span>
+    {% include icons/download.svg %}
+  </a>
+  <button class="a-btn a-btn--link" href="#">
+    <span>Button styled as a link</span>
+    {% include icons/download.svg %}
+  </button>
+</div>

--- a/docs/_includes/examples/checkboxes-large-with-helper.html
+++ b/docs/_includes/examples/checkboxes-large-with-helper.html
@@ -1,0 +1,83 @@
+<div class="m-form-field m-form-field--checkbox m-form-field--lg-target">
+  <input class="a-checkbox" type="radio" id="test_checkbox_lg_helper" />
+  <label class="a-label" for="test_checkbox_lg_helper">
+    Label
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Hover-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--lg-target">
+  <input class="a-checkbox hover" type="checkbox" id="test_checkbox_lg_hover" />
+  <label class="a-label" for="test_checkbox_lg_hover">
+    Hover
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Focus-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--lg-target">
+  <input class="a-checkbox focus" type="checkbox" id="test_checkbox_lg_focus" />
+  <label class="a-label" for="test_checkbox_lg_focus">
+    Focus
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Selected-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--lg-target">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_lg_checked"
+    checked
+  />
+  <label class="a-label" for="test_checkbox_lg_checked">
+    Selected
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Disabled-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--lg-target">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_lg_disabled"
+    disabled
+  />
+  <label class="a-label" for="test_checkbox_lg_disabled">
+    Disabled
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Disabled/Selected-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--lg-target">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_lg_disabled_selected"
+    disabled
+    checked
+  />
+  <label class="a-label" for="test_checkbox_lg_disabled_selected">
+    Disabled/Selected
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>

--- a/docs/_includes/examples/checkboxes-large.html
+++ b/docs/_includes/examples/checkboxes-large.html
@@ -1,0 +1,67 @@
+<div class="m-form-field m-form-field--checkbox m-form-field--lg-target">
+  <input class="a-checkbox" type="checkbox" id="test_checkbox_lg_default" />
+  <label class="a-label" for="test_checkbox_lg_default">Default</label>
+</div>
+
+<br />
+
+<!--Hover-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--lg-target">
+  <input class="a-checkbox hover" type="checkbox" id="test_checkbox_lg_hover" />
+  <label class="a-label" for="test_checkbox_lg_hover">Hover</label>
+</div>
+
+<br />
+
+<!--Focus-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--lg-target">
+  <input class="a-checkbox focus" type="checkbox" id="test_checkbox_lg_focus" />
+  <label class="a-label" for="test_checkbox_lg_focus">Focus</label>
+</div>
+
+<br />
+
+<!--Selected-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--lg-target">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_lg_checked"
+    checked
+  />
+  <label class="a-label" for="test_checkbox_lg_checked">Selected</label>
+</div>
+
+<br />
+
+<!--Disabled-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--lg-target">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_lg_disabled"
+    disabled
+  />
+  <label class="a-label" for="test_checkbox_lg_disabled">Disabled</label>
+</div>
+
+<br />
+
+<!--Disabled/Selected-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--lg-target">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_lg_disabled_selected"
+    disabled
+    checked
+  />
+  <label class="a-label" for="test_checkbox_lg_disabled_selected"
+    >Disabled/Selected</label
+  >
+</div>

--- a/docs/_includes/examples/checkboxes.html
+++ b/docs/_includes/examples/checkboxes.html
@@ -1,0 +1,345 @@
+<h4>States</h4>
+
+<div class="m-form-field m-form-field--checkbox">
+  <input class="a-checkbox" type="checkbox" id="test_checkbox" />
+  <label class="a-label" for="test_checkbox">Enabled</label>
+</div>
+
+<br />
+
+<!--Hover-->
+
+<div class="m-form-field m-form-field--checkbox">
+  <input
+    class="a-checkbox hover"
+    type="checkbox"
+    id="test_checkbox_basic_hover"
+  />
+  <label class="a-label" for="test_checkbox_basic_hover">Hover</label>
+</div>
+
+<br />
+
+<!--Focus-->
+
+<div class="m-form-field m-form-field--checkbox">
+  <input
+    class="a-checkbox focus"
+    type="checkbox"
+    id="test_checkbox_basic_focus"
+  />
+  <label class="a-label" for="test_checkbox_basic_focus">Focus</label>
+</div>
+
+<br />
+
+<!--Selected-->
+
+<div class="m-form-field m-form-field--checkbox">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_basic_checked"
+    checked
+  />
+  <label class="a-label" for="test_checkbox_basic_checked">Selected</label>
+</div>
+
+<br />
+
+<!--Disabled-->
+
+<div class="m-form-field m-form-field--checkbox">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_basic_disabled"
+    disabled
+  />
+  <label class="a-label" for="test_checkbox_basic_disabled">Disabled</label>
+</div>
+
+<br />
+
+<!--Disabled/selected-->
+
+<div class="m-form-field m-form-field--checkbox">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_basic_disabled_selected"
+    disabled
+    checked
+  />
+  <label class="a-label" for="test_checkbox_basic_disabled_selected"
+    >Disabled/selected</label
+  >
+</div>
+
+<br />
+<hr />
+<br />
+
+<h4>Validation status - success</h4>
+
+<!--Success-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-success">
+  <input class="a-checkbox" type="checkbox" id="test_checkbox_success" />
+  <label class="a-label" for="test_checkbox_success">Success</label>
+</div>
+
+<br />
+
+<!--Hover-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-success">
+  <input
+    class="a-checkbox hover"
+    type="checkbox"
+    id="test_checkbox_success_hover"
+  />
+  <label class="a-label" for="test_checkbox_success_hover"
+    >Success - Hover</label
+  >
+</div>
+
+<br />
+
+<!--Focus-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-success">
+  <input
+    class="a-checkbox focus"
+    type="checkbox"
+    id="test_checkbox_success_focus"
+  />
+  <label class="a-label" for="test_checkbox_success_focus"
+    >Success - Focus</label
+  >
+</div>
+
+<br />
+
+<!--Selected-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-success">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_success_checked"
+    checked
+  />
+  <label class="a-label" for="test_checkbox_success_checked"
+    >Success - Selected</label
+  >
+</div>
+
+<br />
+
+<!--Disabled-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-success">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_success_disabled"
+    disabled
+  />
+  <label class="a-label" for="test_checkbox_success_disabled"
+    >Success - Disabled</label
+  >
+</div>
+
+<br />
+
+<!--Disabled/selected-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-success">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_success_disabled_selected"
+    disabled
+    checked
+  />
+  <label class="a-label" for="test_checkbox_success_disabled_selected"
+    >Success - Disabled/selected</label
+  >
+</div>
+
+<br />
+
+<h4>Validation status - warning</h4>
+
+<!--Warning-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-warning">
+  <input class="a-checkbox" type="checkbox" id="test_checkbox_warning" />
+  <label class="a-label" for="test_checkbox_warning">Warning</label>
+</div>
+
+<br />
+
+<!--Hover-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-warning">
+  <input
+    class="a-checkbox hover"
+    type="checkbox"
+    id="test_checkbox_warning_hover"
+  />
+  <label class="a-label" for="test_checkbox_warning_hover"
+    >Warning - Hover</label
+  >
+</div>
+
+<br />
+
+<!--Focus-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-warning">
+  <input
+    class="a-checkbox focus"
+    type="checkbox"
+    id="test_checkbox_warning_focus"
+  />
+  <label class="a-label" for="test_checkbox_warning_focus"
+    >Warning - Focus</label
+  >
+</div>
+
+<br />
+
+<!--Selected-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-warning">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_warning_checked"
+    checked
+  />
+  <label class="a-label" for="test_checkbox_warning_checked"
+    >Warning - Selected</label
+  >
+</div>
+
+<br />
+
+<!--Disabled-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-warning">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_warning_disabled"
+    disabled
+  />
+  <label class="a-label" for="test_checkbox_warning_disabled"
+    >Warning - Disabled</label
+  >
+</div>
+
+<br />
+
+<!--Disabled/selected-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-warning">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_warning_disabled_selected"
+    disabled
+    checked
+  />
+  <label class="a-label" for="test_checkbox_warning_disabled_selected"
+    >Warning - Disabled/selected</label
+  >
+</div>
+
+<br />
+
+<h4>Validation status - error</h4>
+
+<!--Warning-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-error">
+  <input class="a-checkbox" type="checkbox" id="test_checkbox_error" />
+  <label class="a-label" for="test_checkbox_error">Warning</label>
+</div>
+
+<br />
+
+<!--Hover-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-error">
+  <input
+    class="a-checkbox hover"
+    type="checkbox"
+    id="test_checkbox_error_hover"
+  />
+  <label class="a-label" for="test_checkbox_error_hover">Warning - Hover</label>
+</div>
+
+<br />
+
+<!--Focus-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-error">
+  <input
+    class="a-checkbox focus"
+    type="checkbox"
+    id="test_checkbox_error_focus"
+  />
+  <label class="a-label" for="test_checkbox_error_focus">Warning - Focus</label>
+</div>
+
+<br />
+
+<!--Selected-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-error">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_error_checked"
+    checked
+  />
+  <label class="a-label" for="test_checkbox_error_checked"
+    >Warning - Selected</label
+  >
+</div>
+
+<br />
+
+<!--Disabled-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-error">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_error_disabled"
+    disabled
+  />
+  <label class="a-label" for="test_checkbox_error_disabled"
+    >Warning - Disabled</label
+  >
+</div>
+
+<br />
+
+<!--Disabled/selected-->
+
+<div class="m-form-field m-form-field--checkbox m-form-field--checkbox-error">
+  <input
+    class="a-checkbox"
+    type="checkbox"
+    id="test_checkbox_error_disabled_selected"
+    disabled
+    checked
+  />
+  <label class="a-label" for="test_checkbox_error_disabled_selected"
+    >Warning - Disabled/selected</label
+  >
+</div>

--- a/docs/_includes/examples/multiselects.html
+++ b/docs/_includes/examples/multiselects.html
@@ -1,0 +1,18 @@
+<div class="m-form-field">
+  <label class="a-label a-label--heading" for="test_select__multiple">
+    Example label
+  </label>
+  <select class="o-multiselect" id="test_select__multiple" multiple>
+    <option value="option1" selected>Option 1</option>
+    <option value="option2">Option 2</option>
+    <option value="option3">Option 3</option>
+    <option value="option4" selected>Option 4</option>
+    <option value="option5">Option 5</option>
+    <option value="option6">Option 6</option>
+    <option value="option7">Option 7</option>
+    <option value="option8">
+      Multiselect options can also contain long words like
+      supercalifragilisticexpialidocious
+    </option>
+  </select>
+</div>

--- a/docs/_includes/examples/radio-buttons-large-with-helper.html
+++ b/docs/_includes/examples/radio-buttons-large-with-helper.html
@@ -1,0 +1,83 @@
+<div class="m-form-field m-form-field--radio m-form-field--lg-target">
+  <input class="a-radio" type="radio" id="test_radio_lg_helper" />
+  <label class="a-label" for="test_radio_lg_helper">
+    Default
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Hover-->
+
+<div class="m-form-field m-form-field--radio m-form-field--lg-target">
+  <input class="a-radio hover" type="radio" id="test_radio_hover_lg_helper" />
+  <label class="a-label" for="test_radio_hover_lg_helper">
+    Hover
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Focus-->
+
+<div class="m-form-field m-form-field--radio m-form-field--lg-target">
+  <input class="a-radio focus" type="radio" id="test_radio_focus_lg_helper" />
+  <label class="a-label" for="test_radio_focus_lg_helper">
+    Focus
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Selected-->
+
+<div class="m-form-field m-form-field--radio m-form-field--lg-target">
+  <input
+    class="a-radio"
+    type="radio"
+    id="test_radio_selected_lg_helper"
+    checked
+  />
+  <label class="a-label" for="test_radio_selected_lg_helper">
+    Selected
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Disabled-->
+
+<div class="m-form-field m-form-field--radio m-form-field--lg-target">
+  <input
+    class="a-radio"
+    type="radio"
+    id="test_radio_disabled_lg_helper"
+    disabled
+  />
+  <label class="a-label" for="test_radio_disabled_lg_helper">
+    Disabled
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Disabled/selected-->
+
+<div class="m-form-field m-form-field--radio m-form-field--lg-target">
+  <input
+    class="a-radio"
+    type="radio"
+    id="test_radio_disabled_selected_lg_helper"
+    checked
+    disabled
+  />
+  <label class="a-label" for="test_radio_disabled_selected_lg_helper">
+    Disabled/selected
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>

--- a/docs/_includes/examples/radio-buttons-large.html
+++ b/docs/_includes/examples/radio-buttons-large.html
@@ -1,0 +1,57 @@
+<div class="m-form-field m-form-field--radio m-form-field--lg-target">
+  <input class="a-radio" type="radio" id="test_radio_lg_default" />
+  <label class="a-label" for="test_radio_lg_default">Enabled</label>
+</div>
+
+<br />
+
+<!--Hover-->
+
+<div class="m-form-field m-form-field--radio m-form-field--lg-target">
+  <input class="a-radio hover" type="radio" id="test_radio_lg_hover" />
+  <label class="a-label" for="test_radio_lg_hover">Hover</label>
+</div>
+
+<br />
+
+<!--Focus-->
+
+<div class="m-form-field m-form-field--radio m-form-field--lg-target">
+  <input class="a-radio focus" type="radio" id="test_radio_lg_focus" />
+  <label class="a-label" for="test_radio_lg_focus">Focus</label>
+</div>
+
+<br />
+
+<!--Selected-->
+
+<div class="m-form-field m-form-field--radio m-form-field--lg-target">
+  <input class="a-radio" type="radio" id="test_radio_lg_checked" checked />
+  <label class="a-label" for="test_radio_lg_checked">Selected</label>
+</div>
+
+<br />
+
+<!--Disabled-->
+
+<div class="m-form-field m-form-field--radio m-form-field--lg-target">
+  <input class="a-radio" type="radio" id="test_radio_lg_disabled" disabled />
+  <label class="a-label" for="test_radio_lg_disabled">Disabled</label>
+</div>
+
+<br />
+
+<!--Disabled/selected-->
+
+<div class="m-form-field m-form-field--radio m-form-field--lg-target">
+  <input
+    class="a-radio"
+    type="radio"
+    id="test_radio_lg_disabled_selected"
+    disabled
+    checked
+  />
+  <label class="a-label" for="test_radio_lg_disabled_selected"
+    >Disabled/selected</label
+  >
+</div>

--- a/docs/_includes/examples/radio-buttons-with-helper.html
+++ b/docs/_includes/examples/radio-buttons-with-helper.html
@@ -1,0 +1,80 @@
+<h4>States</h4>
+
+<div class="m-form-field m-form-field--radio">
+  <input class="a-radio" type="radio" id="test_radio_basic_helper" />
+  <label class="a-label" for="test_radio_basic_helper">
+    Default
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Hover-->
+
+<div class="m-form-field m-form-field--radio">
+  <input class="a-radio hover" type="radio" id="test_radio_hover_helper" />
+  <label class="a-label" for="test_radio_hover_helper">
+    Hover
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Focus-->
+
+<div class="m-form-field m-form-field--radio">
+  <input class="a-radio focus" type="radio" id="test_radio_focus_helper" />
+  <label class="a-label" for="test_radio_focus_helper">
+    Focus
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Selected-->
+
+<div class="m-form-field m-form-field--radio">
+  <input class="a-radio" type="radio" id="test_radio_checked_helper" checked />
+  <label class="a-label" for="test_radio_checked_helper">
+    Selected
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Disabled-->
+
+<div class="m-form-field m-form-field--radio">
+  <input
+    class="a-radio"
+    type="radio"
+    id="test_radio_disabled_helper"
+    disabled
+  />
+  <label class="a-label" for="test_radio_disabled_helper">
+    Disabled
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>
+
+<br />
+
+<!--Disabled/selected-->
+
+<div class="m-form-field m-form-field--radio">
+  <input
+    class="a-radio"
+    type="radio"
+    id="test_radio_disabled_checked_helper"
+    checked
+    disabled
+  />
+  <label class="a-label" for="test_radio_disabled_checked_helper">
+    Disabled/Selected
+    <small class="a-label__helper"> (This is optional helper text) </small>
+  </label>
+</div>

--- a/docs/_includes/examples/radio-buttons.html
+++ b/docs/_includes/examples/radio-buttons.html
@@ -1,0 +1,59 @@
+<h4>States</h4>
+
+<div class="m-form-field m-form-field--radio">
+  <input class="a-radio" type="radio" id="test_radio_basic_default" />
+  <label class="a-label" for="test_radio_basic_default">Enabled</label>
+</div>
+
+<br />
+
+<!--Hover-->
+
+<div class="m-form-field m-form-field--radio">
+  <input class="a-radio hover" type="radio" id="test_radio_basic_hover" />
+  <label class="a-label" for="test_radio_basic_hover">Hover</label>
+</div>
+
+<br />
+
+<!--Focus-->
+
+<div class="m-form-field m-form-field--radio">
+  <input class="a-radio focus" type="radio" id="test_radio_basic_focus" />
+  <label class="a-label" for="test_radio_basic_focus">Focus</label>
+</div>
+
+<br />
+
+<!--Selected-->
+
+<div class="m-form-field m-form-field--radio">
+  <input class="a-radio" type="radio" id="test_radio_basic_checked" checked />
+  <label class="a-label" for="test_radio_basic_checked">Selected</label>
+</div>
+
+<br />
+
+<!--Disabled-->
+
+<div class="m-form-field m-form-field--radio">
+  <input class="a-radio" type="radio" id="test_radio_basic_disabled" disabled />
+  <label class="a-label" for="test_radio_basic_disabled">Disabled</label>
+</div>
+
+<br />
+
+<!--Disabled/selected-->
+
+<div class="m-form-field m-form-field--radio">
+  <input
+    class="a-radio"
+    type="radio"
+    id="test_radio_basic_disabled_selected"
+    disabled
+    checked
+  />
+  <label class="a-label" for="test_radio_basic_disabled_selected"
+    >Disabled/selected</label
+  >
+</div>

--- a/docs/_includes/examples/selects.html
+++ b/docs/_includes/examples/selects.html
@@ -1,0 +1,69 @@
+<!--Default state-->
+
+<div class="m-form-field">
+  <label class="a-label a-label--heading" for="test_select_enabled">
+    Default
+  </label>
+  <div class="a-select">
+    <select id="test_select_enabled">
+      <option value="option1">Option 1</option>
+      <option value="option2">Option 2</option>
+      <option value="option3">Option 3</option>
+      <option value="option4">Option 4</option>
+    </select>
+  </div>
+</div>
+
+<br />
+
+<!--Hover state-->
+
+<div class="m-form-field">
+  <label class="a-label a-label--heading" for="test_select__hover">
+    Hover
+  </label>
+  <div class="a-select">
+    <select id="test_select__hover" class="hover">
+      <option value="option1">Option 1</option>
+      <option value="option2">Option 2</option>
+      <option value="option3">Option 3</option>
+      <option value="option4">Option 4</option>
+    </select>
+  </div>
+</div>
+
+<br />
+
+<!--Focus state-->
+
+<div class="m-form-field">
+  <label class="a-label a-label--heading" for="test_select__focus">
+    Focus
+  </label>
+  <div class="a-select">
+    <select id="test_select__focus" class="focus">
+      <option value="option1">Option 1</option>
+      <option value="option2">Option 2</option>
+      <option value="option3">Option 3</option>
+      <option value="option4">Option 4</option>
+    </select>
+  </div>
+</div>
+
+<br />
+
+<!--Disabled state-->
+
+<div class="m-form-field">
+  <label class="a-label a-label--heading" for="test_select__disabled"
+    >Disabled</label
+  >
+  <div class="a-select a-select--disabled">
+    <select id="test_select__disabled" disabled>
+      <option value="option1">Option 1</option>
+      <option value="option2">Option 2</option>
+      <option value="option3">Option 3</option>
+      <option value="option4">Option 4</option>
+    </select>
+  </div>
+</div>

--- a/docs/_includes/examples/text-inputs.html
+++ b/docs/_includes/examples/text-inputs.html
@@ -1,0 +1,91 @@
+<h4>States</h4>
+
+<input
+  class="a-text-input"
+  type="text"
+  id="textinput-example-default"
+  placeholder="Placeholder text"
+  value="Enabled"
+/>
+
+<br /><br />
+
+<input
+  class="a-text-input hover"
+  type="text"
+  id="textinput-example-hover"
+  placeholder="Placeholder text"
+  value="Hover"
+/>
+<br /><br />
+
+<input
+  class="a-text-input focus"
+  type="text"
+  id="textinput-example-focus"
+  placeholder="Placeholder text"
+  value="Focus"
+/>
+<br /><br />
+
+<input
+  class="a-text-input"
+  type="text"
+  id="textinput-example-disabled"
+  placeholder="Disabled"
+  disabled
+/>
+
+<br /><br />
+<hr />
+<br />
+
+<h4>Validation status</h4>
+
+<input
+  class="a-text-input a-text-input--success"
+  type="text"
+  placeholder="Success"
+  id="form-input-success"
+  aria-describedby="form-input-success_message"
+/>
+
+<br /><br />
+
+<input
+  class="a-text-input a-text-input--warning"
+  type="text"
+  placeholder="Warning"
+  id="form-input-warning"
+  aria-describedby="form-input-warning_message"
+/>
+
+<br /><br />
+
+<input
+  class="a-text-input a-text-input--error"
+  type="text"
+  placeholder="Error"
+  id="form-input-error"
+  aria-describedby="form-input-error_message"
+/>
+
+<br />
+<hr />
+<br />
+
+<h4>Text input (full width)</h4>
+
+<div class="m-form-field">
+  <input
+    class="a-text-input a-text-input--full"
+    type="text"
+    id="full-textinput-example"
+    placeholder="Placeholder text"
+    value="Input text"
+  />
+</div>
+
+<br />
+<hr />
+<br />

--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -62,6 +62,25 @@
     </section>
     {% endif %}
 
+    {% if page.code_examples and page.code_examples.size > 0 %}
+
+        {% for code_example in page.code_examples %}
+            {% if code_example.code_title and code_example.code_title != '' %}
+            <h2>
+                {{ code_example.code_title }}
+            </h2>
+            {% endif %}
+
+            {% if code_example.code_snippet_url and code_example.code_snippet_url != '' %}
+                {% include {{ code_example.code_snippet_url }} %}
+            {% endif %}
+
+            <br>
+            <hr>
+            <br>
+        {% endfor %}
+    {% endif %}
+
     {% if page.variation_groups and page.variation_groups.size > 0 %}
     {% for variation_group in page.variation_groups %}
     <section class="o-variation-group" id="{{ variation_group.variation_group_name | slugify }}">

--- a/docs/pages/buttons.md
+++ b/docs/pages/buttons.md
@@ -13,15 +13,7 @@ variation_groups:
     variation_group_description: ''
     variations:
       - variation_code_snippet: >-
-          <div class="m-btn-group">
-            <button class="a-btn" title="Default state">Default state</button>
-
-            <button class="a-btn hover" title="Hover state">Hover state</button>
-
-            <button class="a-btn focus" title="Focus state">Focus state</button>
-
-            <button class="a-btn active" title="Active state">Active state</button>
-          </div>
+          <button class="a-btn" title="Primary">Primary</button>
         variation_description:
           Use a primary button for an action that goes to the next
           step. Avoid using multiple primary buttons on a single page; there can
@@ -37,40 +29,17 @@ variation_groups:
         variation_specs: ''
         variation_name: Primary button
       - variation_code_snippet: >-
-          <div class="m-btn-group">
-            <button class="a-btn a-btn--secondary" title="Default state">Default
-            state</button>
-
-            <button class="a-btn a-btn--secondary hover" title="Hover state">Hover state</button>
-
-            <button class="a-btn a-btn--secondary focus" title="Focus state">Focus state</button>
-
-            <button class="a-btn a-btn--secondary active" title="Active state">Active state</button>
-          </div>
+          <button class="a-btn a-btn--secondary" title="Secondary">Secondary</button>
         variation_description: Use a secondary button for actions that happen on the current page.
         variation_name: Secondary button
         variation_specs: ''
       - variation_code_snippet: >-
-          <div class="m-btn-group">
-            <button class="a-btn a-btn--disabled" title="Default state"
-            disabled>Default state</button>
-
-            <button class="a-btn a-btn--disabled hover" title="Hover state" disabled>Hover state</button>
-
-            <button class="a-btn a-btn--disabled focus" title="Focus state" disabled>Focus state</button>
-          </div>
+          <button class="a-btn a-btn--disabled" title="Disabled"
+          disabled>Disabled</button>
         variation_name: Disabled button
         variation_specs: ''
       - variation_code_snippet: >-
-          <div class="m-btn-group">
-            <button class="a-btn a-btn--warning" title="Default state">Default state</button>
-
-            <button class="a-btn a-btn--warning hover" title="Hover state">Hover state</button>
-
-            <button class="a-btn a-btn--warning focus" title="Focus state">Focus state</button>
-
-            <button class="a-btn a-btn--warning active" title="Active state">Active state</button>
-          </div>
+          <button class="a-btn a-btn--warning" title="Destructive">Destructive</button>
         variation_name: Destructive button
         variation_specs: ''
         variation_description:
@@ -96,9 +65,10 @@ variation_groups:
           </div>
 
           <br>
-              <button class="a-btn">
-                  <span>Upload file</span>{% include icons/upload.svg %}
-              </button>
+
+          <button class="a-btn">
+              <span>Upload file</span>{% include icons/upload.svg %}
+          </button>
       - variation_is_deprecated: false
         variation_name: Button with animated icon
         variation_code_snippet: |-
@@ -138,27 +108,18 @@ variation_groups:
         variation_name: Full-width button (on x-small screens)
         variation_description: Reduce screen size to see this button in action.
         variation_code_snippet: >-
-          <div class="m-btn-group">
-            <button class="a-btn a-btn--full-on-xs" title="Default state">Default
-            state</button>
-
-            <button class="a-btn a-btn--full-on-xs hover" title="Hover state">Hover state</button>
-
-            <button class="a-btn a-btn--full-on-xs focus" title="Focus state">Focus state</button>
-
-            <button class="a-btn a-btn--full-on-xs active" title="Active state">Active state</button>
-          </div>
+          <button class="a-btn a-btn--full-on-xs" title="Default state">Resize to mobile to see effect</button>
       - variation_is_deprecated: false
         variation_name: Button link
         variation_code_snippet: >-
           <div class="m-btn-group">
               <a class="a-btn">
                   <span>Link styled as a button</span>
-                  <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="cf-icon-svg cf-icon-svg--download" viewBox="0 0 12 19"><path d="M11.16 16.153a.477.477 0 0 1-.476.475H1.316a.476.476 0 0 1-.475-.475V3.046a.476.476 0 0 1 .475-.475h6.95l2.893 2.893zm-1.11-9.925H8.059a.575.575 0 0 1-.574-.573V3.679H1.95v11.84h8.102zm-1.234 5.604L6.388 14.26a.554.554 0 0 1-.784 0l-2.428-2.428a.554.554 0 1 1 .783-.784l1.483 1.482V7.41a.554.554 0 1 1 1.108 0v5.12l1.482-1.482a.554.554 0 0 1 .784.783z"></path></svg>
+                  {% include icons/download.svg %}
               </a>
               <button class="a-btn a-btn--link" href="#">
                   <span>Button styled as a link</span>
-                  <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="cf-icon-svg cf-icon-svg--download" viewBox="0 0 12 19"><path d="M11.16 16.153a.477.477 0 0 1-.476.475H1.316a.476.476 0 0 1-.475-.475V3.046a.476.476 0 0 1 .475-.475h6.95l2.893 2.893zm-1.11-9.925H8.059a.575.575 0 0 1-.574-.573V3.679H1.95v11.84h8.102zm-1.234 5.604L6.388 14.26a.554.554 0 0 1-.784 0l-2.428-2.428a.554.554 0 1 1 .783-.784l1.483 1.482V7.41a.554.554 0 1 1 1.108 0v5.12l1.482-1.482a.554.554 0 0 1 .784.783z"></path></svg>
+                  {% include icons/download.svg %}
               </button>
           </div>
         variation_description:

--- a/docs/pages/checkboxes.md
+++ b/docs/pages/checkboxes.md
@@ -5,13 +5,7 @@ section: components
 variation_groups:
   - variations:
       - variation_code_snippet: >-
-          <!--States are shown for demonstration purposes only-->
-
-          <h4>
-
-          States
-
-          </h4>
+          <h4>Example checkbox</h4>
 
           <div class="m-form-field m-form-field--checkbox">
               <input class="a-checkbox" type="checkbox" id="test_checkbox">
@@ -20,56 +14,17 @@ variation_groups:
 
           <br>
 
-          <!--Hover-->
-
-          <div class="m-form-field m-form-field--checkbox">
-              <input class="a-checkbox hover" type="checkbox" id="test_checkbox_basic_hover">
-              <label class="a-label" for="test_checkbox_basic_hover">Hover</label>
-          </div>
-
-          <br>
-
-          <!--Focus-->
-
-          <div class="m-form-field m-form-field--checkbox">
-              <input class="a-checkbox focus" type="checkbox" id="test_checkbox_basic_focus">
-              <label class="a-label" for="test_checkbox_basic_focus">Focus</label>
-          </div>
-
-          <br>
-
-          <!--Selected-->
-
-          <div class="m-form-field m-form-field--checkbox">
-              <input class="a-checkbox" type="checkbox" id="test_checkbox_basic_checked" checked>
-              <label class="a-label" for="test_checkbox_basic_checked">Selected</label>
-          </div>
-
-          <br>
-
           <!--Disabled-->
 
           <div class="m-form-field m-form-field--checkbox">
-              <input class="a-checkbox" type="checkbox" id="test_checkbox_basic_disabled" disabled>
-              <label class="a-label" for="test_checkbox_basic_disabled">Disabled</label>
+              <input class="a-checkbox" type="checkbox" id="test_checkbox_basic_disabled_selected" disabled>
+              <label class="a-label" for="test_checkbox_basic_disabled_selected">Disabled</label>
           </div>
 
           <br>
+          <br>
 
-          <!--Disabled/selected-->
-
-          <div class="m-form-field m-form-field--checkbox">
-              <input class="a-checkbox" type="checkbox" id="test_checkbox_basic_disabled_selected" disabled checked>
-              <label class="a-label" for="test_checkbox_basic_disabled_selected">Disabled/selected</label>
-          </div>
-
-          <br><br>
-
-          <h4>
-
-          Validation status
-
-          </h4>
+          <h4>Validation status</h4>
 
           <!--Success-->
 
@@ -137,43 +92,6 @@ variation_groups:
           <br>
 
 
-          <!--Hover-->
-
-          <div class="m-form-field
-                      m-form-field--checkbox
-                      m-form-field--lg-target">
-              <input class="a-checkbox hover" type="checkbox" id="test_checkbox_lg_hover">
-              <label class="a-label" for="test_checkbox_lg_hover">Hover</label>
-          </div>
-
-          <br>
-
-
-          <!--Focus-->
-
-          <div class="m-form-field
-                      m-form-field--checkbox
-                      m-form-field--lg-target">
-              <input class="a-checkbox focus" type="checkbox" id="test_checkbox_lg_focus">
-              <label class="a-label" for="test_checkbox_lg_focus">Focus</label>
-          </div>
-
-
-          <br>
-
-
-          <!--Selected-->
-
-          <div class="m-form-field
-                      m-form-field--checkbox
-                      m-form-field--lg-target">
-              <input class="a-checkbox" type="checkbox" id="test_checkbox_lg_checked" checked>
-              <label class="a-label" for="test_checkbox_lg_checked">Selected</label>
-          </div>
-
-          <br>
-
-
           <!--Disabled-->
 
           <div class="m-form-field
@@ -182,26 +100,6 @@ variation_groups:
               <input class="a-checkbox" type="checkbox" id="test_checkbox_lg_disabled" disabled>
               <label class="a-label" for="test_checkbox_lg_disabled">Disabled</label>
           </div>
-
-          <br>
-
-
-          <!--Disabled/Selected-->
-
-          <!--
-
-          <div class="m-form-field
-                      m-form-field--checkbox
-                      m-form-field--lg-target">
-              <input class="a-checkbox"
-                     type="checkbox"
-                     id="test_checkbox_lg_disabled"
-                     disabled
-                     checked>
-              <label class="a-label" for="test_checkbox_lg_disabled">Disabled/Selected</label>
-          </div>
-
-          -->
         variation_specs: ''
       - variation_is_deprecated: false
         variation_name: Large target area checkbox (with helper text)
@@ -215,7 +113,7 @@ variation_groups:
                   <small class="a-label__helper">
                       (This is optional helper text)
                   </small>
-                </label>
+              </label>
           </div>
     variation_group_name: Types
 guidelines: >-

--- a/docs/pages/radio-buttons.md
+++ b/docs/pages/radio-buttons.md
@@ -8,61 +8,7 @@ variation_groups:
       - variation_code_snippet: >
           <div class="m-form-field m-form-field--radio">
               <input class="a-radio" type="radio" id="test_radio_basic_default">
-              <label class="a-label" for="test_radio_basic_default">Enabled</label>
-          </div>
-
-
-          <br>
-
-          <!--Hover-->
-
-          <div class="m-form-field m-form-field--radio">
-              <input class="a-radio hover" type="radio" id="test_radio_basic_hover">
-              <label class="a-label" for="test_radio_basic_hover">Hover</label>
-          </div>
-
-          <br>
-
-
-          <!--Focus-->
-
-          <div class="m-form-field m-form-field--radio">
-              <input class="a-radio focus" type="radio" id="test_radio_basic_focus">
-              <label class="a-label" for="test_radio_basic_focus">Focus</label>
-          </div>
-
-          <br>
-
-
-          <!--Selected-->
-
-          <div class="m-form-field m-form-field--radio">
-              <input class="a-radio" type="radio" id="test_radio_basic_checked" checked>
-              <label class="a-label" for="test_radio_basic_checked">Selected</label>
-          </div>
-
-          <br>
-
-
-          <!--Disabled-->
-
-          <div class="m-form-field m-form-field--radio">
-              <input class="a-radio" type="radio" id="test_radio_basic_disabled" disabled>
-              <label class="a-label" for="test_radio_basic_disabled">Disabled</label>
-          </div>
-
-          <br>
-
-
-          <!--Disabled/selected-->
-
-          <div class="m-form-field m-form-field--radio">
-              <input class="a-radio"
-                     type="radio"
-                     id="test_radio_basic_disabled_selected"
-                     disabled
-                     checked>
-              <label class="a-label" for="test_radio_basic_disabled_selected">Disabled/selected</label>
+              <label class="a-label" for="test_radio_basic_default">Default</label>
           </div>
         variation_specs: ''
         variation_name: Radio button
@@ -93,62 +39,7 @@ variation_groups:
         variation_code_snippet: >-
           <div class="m-form-field m-form-field--radio m-form-field--lg-target">
               <input class="a-radio" type="radio" id="test_radio_lg_default">
-              <label class="a-label" for="test_radio_lg_default">Enabled</label>
-          </div>
-
-          <br>
-
-
-          <!--Hover-->
-
-          <div class="m-form-field m-form-field--radio m-form-field--lg-target">
-              <input class="a-radio hover" type="radio" id="test_radio_lg_hover">
-              <label class="a-label" for="test_radio_lg_hover">Hover</label>
-          </div>
-
-          <br>
-
-
-          <!--Focus-->
-
-          <div class="m-form-field m-form-field--radio m-form-field--lg-target">
-              <input class="a-radio focus" type="radio" id="test_radio_lg_focus">
-              <label class="a-label" for="test_radio_lg_focus">Focus</label>
-          </div>
-
-          <br>
-
-
-          <!--Selected-->
-
-
-          <div class="m-form-field m-form-field--radio m-form-field--lg-target">
-              <input class="a-radio" type="radio" id="test_radio_lg_checked" checked>
-              <label class="a-label" for="test_radio_lg_checked">Selected</label>
-          </div>
-
-          <br>
-
-
-          <!--Disabled-->
-
-          <div class="m-form-field m-form-field--radio m-form-field--lg-target">
-              <input class="a-radio" type="radio" id="test_radio_lg_disabled" disabled>
-              <label class="a-label" for="test_radio_lg_disabled">Disabled</label>
-          </div>
-
-          <br>
-
-
-          <!--Disabled/selected-->
-
-          <div class="m-form-field m-form-field--radio m-form-field--lg-target">
-              <input class="a-radio"
-                     type="radio"
-                     id="test_radio_lg_disabled_selected"
-                     disabled
-                     checked>
-              <label class="a-label" for="test_radio_lg_disabled_selected">Disabled/selected</label>
+              <label class="a-label" for="test_radio_lg_default">Default</label>
           </div>
         variation_specs: ''
       - variation_is_deprecated: false

--- a/docs/pages/reference-for-component-states.md
+++ b/docs/pages/reference-for-component-states.md
@@ -1,0 +1,35 @@
+---
+title: Reference for component states
+layout: variation
+section: development
+description: |-
+  This is a reference page for various states of the <a href="/design-system/components/">components found within the
+  design system</a>. Refer to the individual component pages for their usage
+  guidance.
+
+code_examples:
+  - code_title: Buttons
+    code_snippet_url: examples/buttons.html
+  - code_title: Checkboxes
+    code_snippet_url: examples/checkboxes.html
+  - code_title: Large target area checkbox
+    code_snippet_url: examples/checkboxes-large.html
+  - code_title: Large target area checkbox (with helper text)
+    code_snippet_url: examples/checkboxes-large-with-helper.html
+  - code_title: Radio buttons
+    code_snippet_url: examples/radio-buttons.html
+  - code_title: Radio buttons (with helper text)
+    code_snippet_url: examples/radio-buttons-with-helper.html
+  - code_title: Large target area radio button
+    code_snippet_url: examples/radio-buttons-large.html
+  - code_title: Large target area radio button (with helper text)
+    code_snippet_url: examples/radio-buttons-large-with-helper.html
+  - code_title: Text inputs
+    code_snippet_url: examples/text-inputs.html
+  - code_title: Selects
+    code_snippet_url: examples/selects.html
+  - code_title: Multiselects
+    code_snippet_url: examples/multiselects.html
+
+last_updated: 2019-09-13T13:48:42.692Z
+---

--- a/docs/pages/selects.md
+++ b/docs/pages/selects.md
@@ -10,75 +10,12 @@ description: Selects allow users to make a single selection or multiple
 variation_groups:
   - variations:
       - variation_code_snippet: >-
-          <!--Enabled state-->
-
-
           <div class="m-form-field">
               <label class="a-label a-label--heading" for="test_select_enabled">
-                  Enabled
+                  Example label
               </label>
               <div class="a-select">
                   <select id="test_select_enabled">
-                      <option value="option1">Option 1</option>
-                      <option value="option2">Option 2</option>
-                      <option value="option3">Option 3</option>
-                      <option value="option4">Option 4</option>
-                  </select>
-              </div>
-          </div>
-
-
-          <br>
-
-
-          <!--Hover state-->
-
-          <div class="m-form-field">
-              <label class="a-label a-label--heading" for="test_select__hover">
-                 Hover
-              </label>
-              <div class="a-select">
-                  <select id="test_select__hover" class="hover">
-                      <option value="option1">Option 1</option>
-                      <option value="option2">Option 2</option>
-                      <option value="option3">Option 3</option>
-                      <option value="option4">Option 4</option>
-                  </select>
-              </div>
-          </div>
-
-
-          <br>
-
-
-          <!--Focus state-->
-
-
-          <div class="m-form-field">
-              <label class="a-label a-label--heading" for="test_select__focus">
-                  Focus
-              </label>
-              <div class="a-select">
-                  <select id="test_select__focus" class="focus">
-                      <option value="option1">Option 1</option>
-                      <option value="option2">Option 2</option>
-                      <option value="option3">Option 3</option>
-                      <option value="option4">Option 4</option>
-                  </select>
-              </div>
-          </div>
-
-
-          <br>
-
-
-          <!--Disabled state-->
-
-
-          <div class="m-form-field">
-              <label class="a-label a-label--heading" for="test_select__disabled">Disabled</label>
-              <div class="a-select a-select--disabled">
-                  <select id="test_select__disabled" disabled>
                       <option value="option1">Option 1</option>
                       <option value="option2">Option 2</option>
                       <option value="option3">Option 3</option>
@@ -99,7 +36,7 @@ variation_groups:
         variation_code_snippet: >-
           <div class="m-form-field">
               <label class="a-label a-label--heading" for="test_select__multiple">
-                  Label
+                  Example label
               </label>
               <select class="o-multiselect" id="test_select__multiple" multiple>
                   <option value="option1" selected>Option 1</option>

--- a/docs/pages/text-inputs.md
+++ b/docs/pages/text-inputs.md
@@ -6,35 +6,12 @@ variation_groups:
   - variation_group_name: Types
     variations:
       - variation_code_snippet: >-
-          <!--States are shown for demonstration purposes only-->
-
-
-          <h4>
-
-          States
-
-          </h4>
-
           <input class="a-text-input"
                 type="text"
                 id="textinput-example-default"
                 placeholder="Placeholder text"
           value="Enabled">
 
-          <br><br>
-
-          <input class="a-text-input hover"
-                 type="text"
-                 id="textinput-example-hover"
-                 placeholder="Placeholder text"
-                 value="Hover">
-          <br><br>
-
-          <input class="a-text-input focus"
-                 type="text"
-                 id="textinput-example-focus"
-                 placeholder="Placeholder text"
-                 value="Focus">
           <br><br>
 
           <input class="a-text-input"


### PR DESCRIPTION
Adds initial component reference page and moves components that show multiple states from their component pages to the reference page.


## Changes

- Add component reference page

## Testing

1. See https://deploy-preview-2236--cfpb-design-system.netlify.app/design-system/development/reference-for-component-states and individual component pages to see that "states" have been moved to the reference sheet.

## Screenshots

<img width="1246" alt="Screenshot 2025-05-14 at 10 14 45 AM" src="https://github.com/user-attachments/assets/028cfffb-3690-4058-b798-1ad98c455eb9" />


## Todos

- Additional component examples can be moved over. I just moved the existing "states" examples over for now.
