### PR TITLE
Fix Lighthouse a11y failures on two pages

### DIFF
--- a/docs/_includes/examples/buttons.html
+++ b/docs/_includes/examples/buttons.html
@@ -68,7 +68,7 @@
 <hr />
 <br />
 
-<h4>Full-width button (on x-small screens)</h4>
+<h3 class="h4">Full-width button (on x-small screens)</h3>
 
 <div class="m-btn-group">
   <button class="a-btn a-btn--full-on-xs" title="Default state">
@@ -92,7 +92,7 @@
 <hr />
 <br />
 
-<h4>Button with icon</h4>
+<h3 class="h4">Button with icon</h3>
 
 <div class="m-btn-group">
   <button class="a-btn a-btn--secondary">
@@ -121,7 +121,7 @@
 <hr />
 <br />
 
-<h4>Button link</h4>
+<h3 class="h4">Button link</h3>
 
 <div class="m-btn-group">
   <a class="a-btn">

--- a/docs/_includes/examples/checkboxes.html
+++ b/docs/_includes/examples/checkboxes.html
@@ -1,4 +1,4 @@
-<h4>States</h4>
+<h3 class="h4">States</h3>
 
 <div class="m-form-field m-form-field--checkbox">
   <input class="a-checkbox" type="checkbox" id="test_checkbox" />
@@ -80,7 +80,7 @@
 <hr />
 <br />
 
-<h4>Validation status - success</h4>
+<h3 class="h4">Validation status - success</h3>
 
 <!--Success-->
 
@@ -170,7 +170,7 @@
 
 <br />
 
-<h4>Validation status - warning</h4>
+<h3 class="h4">Validation status - warning</h3>
 
 <!--Warning-->
 
@@ -260,7 +260,7 @@
 
 <br />
 
-<h4>Validation status - error</h4>
+<h3 class="h4">Validation status - error</h3>
 
 <!--Warning-->
 

--- a/docs/_includes/examples/radio-buttons-with-helper.html
+++ b/docs/_includes/examples/radio-buttons-with-helper.html
@@ -1,4 +1,4 @@
-<h4>States</h4>
+<h3 class="h4">States</h3>
 
 <div class="m-form-field m-form-field--radio">
   <input class="a-radio" type="radio" id="test_radio_basic_helper" />

--- a/docs/_includes/examples/radio-buttons.html
+++ b/docs/_includes/examples/radio-buttons.html
@@ -1,4 +1,4 @@
-<h4>States</h4>
+<h3 class="h4">States</h3>
 
 <div class="m-form-field m-form-field--radio">
   <input class="a-radio" type="radio" id="test_radio_basic_default" />

--- a/docs/_includes/examples/text-inputs.html
+++ b/docs/_includes/examples/text-inputs.html
@@ -1,4 +1,4 @@
-<h4>States</h4>
+<h3 class="h4">States</h3>
 
 <input
   class="a-text-input"
@@ -40,7 +40,7 @@
 <hr />
 <br />
 
-<h4>Validation status</h4>
+<h3 class="h4">Validation status</h3>
 
 <input
   class="a-text-input a-text-input--success"
@@ -74,7 +74,7 @@
 <hr />
 <br />
 
-<h4>Text input (full width)</h4>
+<h3 class="h4">Text input (full width)</h3>
 
 <div class="m-form-field">
   <input

--- a/docs/pages/info-unit-groups-link-blobs.md
+++ b/docs/pages/info-unit-groups-link-blobs.md
@@ -145,7 +145,9 @@ use_cases: >-
   - When presenting multiple paragraphs of content
 behavior: 'All info units stack to one column at small screen size. '
 accessibility: ''
-related_items: "[](https://cfpb.github.io/design-system/components/links)[](htt\
-  ps://cfpb.github.io/design-system/foundation/typography)"
+related_items: >-
+  * [Links](https://cfpb.github.io/design-system/components/links)
+
+  * [Typography](https://cfpb.github.io/design-system/foundation/typography)
 last_updated: 2019-08-30T16:07:00.000Z
 ---

--- a/docs/pages/info-unit-groups-link-blobs.md
+++ b/docs/pages/info-unit-groups-link-blobs.md
@@ -148,6 +148,6 @@ accessibility: ''
 related_items: >-
   * [Links](https://cfpb.github.io/design-system/components/links)
 
-  * [Typography](https://cfpb.github.io/design-system/foundation/typography)
+  * [Paragraphs](https://cfpb.github.io/design-system/foundation/paragraphs)
 last_updated: 2019-08-30T16:07:00.000Z
 ---


### PR DESCRIPTION
See recent Lighthouse test failures [here](https://github.com/cfpb/design-system/actions/runs/15101356615/job/42442649151).

- Missing "Related Items" links at the bottom of https://cfpb.github.io/design-system/patterns/info-unit-groups.
- Invalid heading hierarchy on https://cfpb.github.io/design-system/development/reference-for-component-states.