### PR TITLE
Refactor `u-show-on-mobile` to not force display state when visible

### DIFF
--- a/packages/cfpb-design-system/src/utilities/utilities.scss
+++ b/packages/cfpb-design-system/src/utilities/utilities.scss
@@ -80,11 +80,9 @@
 }
 
 .u-show-on-mobile {
-  display: none;
-
-  // Mobile only.
-  @include respond-to-max($bp-xs-max) {
-    display: block;
+  // Tablet and above.
+  @include respond-to-min($bp-sm-min) {
+    display: none;
   }
 }
 


### PR DESCRIPTION
The `u-show-on-mobile` utility sets `display: block`, which can break some elements that use flexbox. This PR makes it so that it only hides the element.

## Changes

- Refactor `u-show-on-mobile` to not force display state when visible.
