### PR TITLE
Fix version link in changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.\n
 body = """
 {% if version %}\
     {% if previous.version %}\
-        ## [{{ version | trim_start_matches(pat="v") }}](<REPO>/compare/{{ previous.version }}..{{ version }}) - {{ timestamp | date(timezone="America/New_York", format="%B %e, %Y") }}
+        ## [{{ version | trim_start_matches(pat="v") }}](<REPO>/compare/{{ previous.version }}..v{{ version }}) - {{ timestamp | date(timezone="America/New_York", format="%B %e, %Y") }}
     {% else %}\
         ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(timezone="America/New_York", format="%B %e, %Y") }}
     {% endif %}\

--- a/packages/cfpb-design-system/CHANGELOG.md
+++ b/packages/cfpb-design-system/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [3.11.0](https://github.com/cfpb/design-system/compare/v3.10.0..3.11.0) - June  5, 2025
+## [3.11.0](https://github.com/cfpb/design-system/compare/v3.10.0..v3.11.0) - June  5, 2025
 
 ### PRs in this release
 


### PR DESCRIPTION
The changelog wasn't including the `v` in the version comparison URL.

## Changes

- Fix version link in changelog.