### PR TITLE
Migrate form alert variables to CSS custom properties

### DIFF
--- a/packages/cfpb-design-system/src/abstracts/vars.scss
+++ b/packages/cfpb-design-system/src/abstracts/vars.scss
@@ -106,14 +106,14 @@ $input-text: var(--black);
 $input-text-disabled: var(--gray-dark);
 $input-text-placeholder: var(--gray-dark);
 
-// .a-text-input icons
-$input-icon: var(--gray);
-$input-icon-success: var(--green);
-$input-icon-warning: var(--gold);
-$input-icon-error: var(--red);
-
-// .a-select
 :root {
+  // .a-form-alert icons
+  --form-alert-icon-color-default: var(--gray);
+  --form-alert-icon-color-success: var(--green);
+  --form-alert-icon-color-warning: var(--gold);
+  --form-alert-icon-color-error: var(--red);
+
+  // .a-select
   --select-border-default: var(--gray-60); // $input-text
   --select-border-width-default: 1px;
   --select-border-error: var(--red);

--- a/packages/cfpb-design-system/src/components/cfpb-forms/form-alert.scss
+++ b/packages/cfpb-design-system/src/components/cfpb-forms/form-alert.scss
@@ -2,11 +2,13 @@
 @use '@cfpb/cfpb-design-system/src/abstracts' as *;
 
 .a-form-alert {
+  --form-alert-icon-color: var(--form-alert-icon-color-default);
+
   display: flex;
   gap: math.div(5px, $base-font-size-px) + rem;
 
   .cf-icon-svg {
-    color: $input-icon;
+    color: var(--form-alert-icon-color);
     flex: none;
     margin-top: math.div(1px, $base-font-size-px) + rem;
   }
@@ -16,14 +18,14 @@
   }
 
   &--success .cf-icon-svg {
-    color: $input-icon-success;
-  }
-
-  &--error .cf-icon-svg {
-    color: $input-icon-error;
+    --form-alert-icon-color: var(--form-alert-icon-color-success);
   }
 
   &--warning .cf-icon-svg {
-    color: $input-icon-warning;
+    --form-alert-icon-color: var(--form-alert-icon-color-warning);
+  }
+
+  &--error .cf-icon-svg {
+    --form-alert-icon-color: var(--form-alert-icon-color-error);
   }
 }


### PR DESCRIPTION
## Changes

- Migrate form alert variables to CSS custom properties.

## Testing

1. Check the reference page and see that the form field-level alerts are unchanged in their coloration. 
https://deploy-preview-2286--cfpb-design-system.netlify.app/design-system/development/reference-for-component-states#field-level-alert