### PR TITLE
Update outdated SASS utility syntax in docs | remove unused mixins

### DIFF
--- a/docs/pages/helper-classes-mixins.md
+++ b/docs/pages/helper-classes-mixins.md
@@ -294,7 +294,7 @@ variation_groups:
                     controls>
               </video>
           </div>
-      - variation_name: '"Link color" SASS mixin'
+      - variation_name: '"Link color" mixin'
         variation_description: >-
           Calling the mixin without arguments will set the following states:
           default - `#0071bc`, `:hover` - `#205493`, `:focus` - `#0071bc`,
@@ -330,7 +330,7 @@ variation_groups:
 
           **A base mixin of `@include u-link-colors-base` exists, but please refrain from using this mixin directly in order to promote consistent naming throughout this project. If you need to set colors for all states of a link, use `@include u-link-colors(@c, @v, @h, @f, @a)`.**
         variation_code_snippet: ''
-      - variation_name: '"Link border" SASS mixins'
+      - variation_name: '"Link border" mixins'
         variation_description: >-
           Turn off the default bottom `border` on the default and `:hover` states.
 
@@ -356,7 +356,7 @@ variation_groups:
           To use on text set to another size, use the mixin below.*
 
 
-          `.u-small-text`
+          `@include u-small-text`
 
 
           There is also a modifier, `u-small-text--subtle`, which sets the color
@@ -368,7 +368,7 @@ variation_groups:
           Sets the element to `14px` (in `em`s) based on the text size passed as `@context`.
 
 
-          `.u-small-text(@context)`
+          ` @include u-small-text(@context)`
 
 
           ```scss
@@ -379,7 +379,7 @@ variation_groups:
             font-size: math.div(20px, @base-font-size-px) + em;
 
             small {
-              .u-small-text(20px);
+              @include u-small-text(20px);
             }
           }
 

--- a/docs/pages/helper-classes-mixins.md
+++ b/docs/pages/helper-classes-mixins.md
@@ -294,75 +294,54 @@ variation_groups:
                     controls>
               </video>
           </div>
-      - variation_name: '"Link color" mixin'
+      - variation_name: '"Link color" SASS mixin'
         variation_description: >-
           Calling the mixin without arguments will set the following states:
           default - `#0071bc`, `:hover` - `#205493`, `:focus` - `#0071bc`,
           `:visited` - `#4c2c92`, `:active` - `#046b99`.
 
 
-          `u-link-colors()`
+          `@include u-link-colors()`
 
 
           Passing a single argument into the mixin will set the color for the default, `:visited`, `:hover`, `:focus`, and `:active` states.
 
 
-          `u-link-colors(@c)`
+          `@include u-link-colors(@c)`
 
 
           Passing two arguments into the mixin will set the color for the default, `:visited`, and `:active` states as the first argument, and `:hover` and `:focus` as the second argument.
 
 
-          `u-link-colors(@c, @h)`
+          `@include u-link-colors(@c, @h)`
 
 
           Passing five arguments will set the color for the default, `:visited`, `:hover`, `:focus`, and `:active` states respectively.
 
 
-          `u-link-colors(@c, @v, @h, @f, @a)`
+          `@include u-link-colors(@c, @v, @h, @f, @a)`
 
 
           Passing ten arguments will set the text (default, `:visited`, `:hover`, `:focus`, and `:active` states in the first five arguments) and border colors (default, `:visited`, `:hover`, `:focus`, and `:active` states in the following five arguments) separately.
 
 
-          `u-link-colors(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba)`
+          `@include u-link-colors(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba)`
 
 
-          **A base mixin of `u-link-colors-base()` exists, but please refrain from using this mixin directly in order to promote consistent naming throughout this project. If you need to set colors for all states of a link, use `.u-link-colors(@c, @v, @h, @f, @a)`.**
+          **A base mixin of `@include u-link-colors-base` exists, but please refrain from using this mixin directly in order to promote consistent naming throughout this project. If you need to set colors for all states of a link, use `@include u-link-colors(@c, @v, @h, @f, @a)`.**
         variation_code_snippet: ''
-      - variation_name: '"Link border" mixin'
+      - variation_name: '"Link border" SASS mixins'
         variation_description: >-
-          Force the default bottom `border` on the default and `:hover` states.
-
-
-          `.u-link__border()`
-
-
           Turn off the default bottom `border` on the default and `:hover` states.
 
 
-          `.u-link__no-border()`
+          `@include u-link-no-border`
 
 
           Turn off the default bottom `border` on the default state but force a bottom border on the `:hover` state.
 
 
-          `.u-link__hover-border()`
-        variation_code_snippet: ''
-      - variation_name: '"Link children" mixin'
-        variation_description: >-
-          Calling this mixin without arguments will set the default color for
-          the `:hover` state of a child within a link, without affecting the
-          link itself.
-
-
-          `.u-link__hover-child()`
-
-
-          Passing a single argument into the mixin will set a custom color for the `:hover` state of a child within a link, without affecting the link itself.
-
-
-          `.u-link__hover-child(@c)`
+          `@include u-link-hover-border`
         variation_code_snippet: ''
       - variation_name: '"Small text utility" mixin'
         variation_code_snippet: ''

--- a/packages/cfpb-design-system/src/utilities/utilities.scss
+++ b/packages/cfpb-design-system/src/utilities/utilities.scss
@@ -273,14 +273,13 @@ $ba: Link underline active color.
 }
 /* stylelint-enable */
 
-@mixin u-link-border() {
-  border-bottom-width: 1px;
-}
-
+// Turn off the default bottom `border` on the default and `:hover` states.
 @mixin u-link-no-border() {
   border-bottom-width: 0 !important;
 }
 
+// Turn off the default bottom `border` on the default state,
+// but force a bottom border on the `:hover` state.
 @mixin u-link-hover-border() {
   border-bottom-width: 0 !important;
 


### PR DESCRIPTION
I couldn't find a use for `u-link-border` mixin, so removed it.

## Changes

- Update outdated u-link and u-small-text utility syntax in docs.
- Remove unused `u-link-border` mixin.
- Remove unused `u-link__hover-child` mixin.

## Testing

1. See updated docs in https://deploy-preview-2307--cfpb-design-system.netlify.app/design-system/development/helper-classes-and-mixins
