### PR TITLE
Remove non-clickable `a-tag-filter` pattern

### DIFF
--- a/docs/_includes/examples/tags.html
+++ b/docs/_includes/examples/tags.html
@@ -82,9 +82,3 @@
     </a>
   </li>
 </ul>
-
-<br />
-<hr />
-<br />
-
-<div class="a-tag-filter">Non-clickable tag</div>

--- a/docs/pages/tags.md
+++ b/docs/pages/tags.md
@@ -100,16 +100,6 @@ variation_groups:
               </button>
             </li>
           </ul>
-      - variation_is_deprecated: false
-        variation_name: Non-clickable filter tag
-        variation_description:
-          There can be elements that have the appearance of a
-          filter tag, but are not clickable. This is used like an inline
-          notification.
-        variation_code_snippet: |-
-          <div class="a-tag-filter">
-            Note
-          </div>
     variation_group_name: Types
 behavior: To clear a filter tag selection, click the “x” icon inside of the filter tag.
 related_items: >-


### PR DESCRIPTION
@natalia-fitzgerald recommends removing this non-clickable tag pattern. Companion PR to https://github.com/cfpb/consumerfinance.gov/pull/8871

## Removals

- Remove non-clickable `a-tag-filter` pattern.

## Testing

1. PR preview should not have a non-clickable tag pattern.
