### PR TITLE
Button WC: Update `isDisabled` property to `disabled`

### DIFF
--- a/packages/cfpb-design-system/src/elements/cfpb-button/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-button/index.js
@@ -13,14 +13,14 @@ export class CfpbButton extends LitElement {
 
   static get properties() {
     return {
-      isDisabled: { type: Boolean },
+      disabled: { type: Boolean },
       type: { type: String },
     };
   }
 
   constructor() {
     super();
-    this.isDisabled = false;
+    this.disabled = false;
     this.type = '';
   }
 
@@ -43,7 +43,7 @@ export class CfpbButton extends LitElement {
 
   render() {
     return html`
-      <button class="${this._btnClass}" ?disabled=${this.isDisabled}>
+      <button class="${this._btnClass}" ?disabled=${this.disabled}>
         <slot></slot>
       </button>
     `;


### PR DESCRIPTION
The button web component can be disabled with the property `isdisabled="true"`. However, we should probably update this to `disabled="true"`, to make it consistent with https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/disabled

## Changes

- Button WC: Update `isDisabled` property to `disabled`

## Testing

1. In the PR preview, inspect the button web component and manually add `disabled="true"` to `<cfpb-button>` and see that the button gets disabled styling. `<cfpb-button disabled>` should also work.

https://deploy-preview-2335--cfpb-design-system.netlify.app/design-system/components/elements
