### PR TITLE
Ignore dist directories in coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,16 +4,10 @@ export default {
   setupFiles: ['<rootDir>/test/util/simulate-event.js'],
   transform: {},
   collectCoverage: true,
-  collectCoverageFrom: ['<rootDir>/packages/**/*.js'],
-  coveragePathIgnorePatterns: [
-    '<rootDir>/.*.config.js',
-    '<rootDir>/node_modules/',
-    '<rootDir>/config/',
-    '<rootDir>/dist/',
-    '<rootDir>/packages/.?/node_modules/',
-    '<rootDir>/test/',
-    '<rootDir>/tmp/',
-    '<rootDir>/scripts/',
+  collectCoverageFrom: [
+    '<rootDir>/packages/**/*.js',
+    '!<rootDir>/packages/**/dist/**/*.js',
+    '!<rootDir>/packages/**/node_modules/**/*.js',
   ],
   coverageDirectory: '<rootDir>/test/unit-test-coverage',
   moduleNameMapper: {


### PR DESCRIPTION
/dist/ directories were showing up in the coverage report. I'm not sure why `coveragePathIgnorePatterns` wasn't working.

## Changes

- Ignore dist directories in coverage
- Remove `coveragePathIgnorePatterns` entirely, since it was checking for root-level directories we do not aggregate for coverage.

## Testing

1. `yarn jest` should not produce a coverage report that has /dist/ directories (report is at `/test/unit-test-coverage/lcov-report/index.html`).
