### PR TITLE
Multiselect: Fix erroneous placeholder reference

### DIFF
--- a/docs/pages/selects.md
+++ b/docs/pages/selects.md
@@ -38,7 +38,7 @@ variation_groups:
               <label class="a-label a-label--heading" for="test_select__multiple">
                   Example label
               </label>
-              <select class="o-multiselect" id="test_select__multiple" multiple>
+              <select class="o-multiselect" id="test_select__multiple" multiple data-placeholder="Select an option">
                   <option value="option1" selected>Option 1</option>
                   <option value="option2">Option 2</option>
                   <option value="option3">Option 3</option>

--- a/packages/cfpb-design-system/src/components/cfpb-forms/multiselect.js
+++ b/packages/cfpb-design-system/src/components/cfpb-forms/multiselect.js
@@ -556,7 +556,7 @@ function Multiselect(element) {
 
     _instance = this;
     _name = _dom.name || _dom.id;
-    _placeholder = _dom.getAttribute('placeholder');
+    _placeholder = _dom.getAttribute('data-placeholder');
     _options = _dom.options || [];
 
     // Allow devs to pass the config settings they want and not worry about the rest


### PR DESCRIPTION
The placeholder on the source `<select>` element for the mulitselect is `data-placeholder`, not `placeholder`, since the `<select>` element doesn't have a native `placeholder` attribute in the HTML spec.

## Changes

- Multiselect: Fix erroneous placeholder reference

## Testing

1. Check the multiselect example and see that if a `data-placeholder` carries over onto the multiselect.