### PR TITLE
Remove empty link in getting-started.md

### DIFF
--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -9,7 +9,7 @@ description: >-
   Setting up the framework for your project and creating new components should be quick and easy. [Learn how to integrate CFPB Design System into your project](/design-system/development/integrating-the-design-system-into-your-project).
 
 
-  ## For designing wireframes or prototypes with the CFPB Design System[](https://cfpb.github.io/design-system/#for-designers)
+  ## For designing wireframes or prototypes with the CFPB Design System
 
 
   Check out [CFPB Design System](https://www.figma.com/community/file/1487539003249310850) in the Figma Community.


### PR DESCRIPTION
PR 2351 introduced an empty link to the Getting Started page, which is failing nightly Lighthouse tests:

https://github.com/cfpb/design-system/actions/runs/17253436316/job/48960462569 https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1756254032035-17704.report.html

This commit removes that empty link.