### PR TITLE
Fix trim on inputs

### DIFF
--- a/docs/assets/js/admin/widgets/StringTrimmed.js
+++ b/docs/assets/js/admin/widgets/StringTrimmed.js
@@ -18,7 +18,9 @@ export const StringTrimmedControl = ({
       onChange={(e) => onChange(e.target.value)}
       onFocus={setActiveStyle}
       onBlur={(e) => {
-        e.target.value.trim();
+        const trimmed = e.target.value.trim();
+        e.target.value = trimmed;
+        onChange(trimmed);
         setInactiveStyle();
       }}
     />

--- a/docs/assets/js/admin/widgets/StringWithInstructions.js
+++ b/docs/assets/js/admin/widgets/StringWithInstructions.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import PropTypes from 'prop-types';
 
 const instructionsContainerStyle = {
@@ -21,10 +22,6 @@ export const StringWithInstructionsControl = ({
   setActiveStyle,
   setInactiveStyle,
 }) => {
-  const handleChange = (event) => {
-    onChange(event.target.value.trim());
-  };
-
   return (
     <div>
       <input
@@ -32,9 +29,14 @@ export const StringWithInstructionsControl = ({
         id={forID}
         className={classNameWrapper}
         value={value}
-        onChange={handleChange}
+        onChange={(e) => onChange(e.target.value)}
         onFocus={setActiveStyle}
-        onBlur={setInactiveStyle}
+        onBlur={(e) => {
+          const trimmed = e.target.value.trim();
+          e.target.value = trimmed;
+          onChange(trimmed);
+          setInactiveStyle();
+        }}
       />
       <div style={instructionsContainerStyle}>
         Need help? Check out our guide on&nbsp;


### PR DESCRIPTION
Fixes https://github.com/cfpb/design-system/issues/2253

## Changes

- Makes trim happen on blur and properly sets it, as `trim()` isn't mutable on the source value.

## Testing

1. Pull branch and `yarn start` and edit a page in decap and see that you can add spaces to the page title and when you click off the input the extra spaces are trimmed off.
