### PR TITLE
Add global wc-fallback script and styles

### DIFF
--- a/packages/cfpb-design-system/src/elements/cfpb-utilities/fallback/wc-fallback.css
+++ b/packages/cfpb-design-system/src/elements/cfpb-utilities/fallback/wc-fallback.css
@@ -1,0 +1,31 @@
+/*
+This fallback CSS assumes a web component that contains a <noscript> fallback,
+as well as author-supplied content, and separately has a script to swap the
+<noscript> with `<div class="fallback">` if JS is enabled, but the web component
+definition is not defined.
+
+Ex.
+
+<cfpb-example-btn hasfallback>
+  <!-- author-supplied no-js fallback -->
+  <noscript><button>Click this basic button!</button>
+
+  <!-- author-supplied slotted content -->
+  Click this fancy button!
+</cfpb-example-btn>
+*/
+
+/* 1. If JS is disabled, hide everything except <noscript> */
+[hasfallback] > :not(noscript) {
+  display: none;
+}
+
+/* 2. If JS is enabled, but web component definition is not defined, show fallback. */
+[hasfallback] > .fallback {
+  display: block;
+}
+
+/* 3. If JS is enabled and web component definition is defined, operate as normal. */
+[hasfallback]:defined > :not(noscript) {
+  display: block;
+}

--- a/packages/cfpb-design-system/src/elements/cfpb-utilities/fallback/wc-fallback.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-utilities/fallback/wc-fallback.js
@@ -1,0 +1,47 @@
+(function () {
+  function applyFallback(el) {
+    if (!el) return;
+
+    const tag = el.tagName.toLowerCase();
+    const isDefined = !!customElements.get(tag);
+    const noscript = el.querySelector('noscript');
+
+    // Only act if the element is NOT defined and there is a <noscript>
+    if (!isDefined && noscript) {
+      // Create a <div> with the fallback content.
+      const fallbackDiv = document.createElement('div');
+      fallbackDiv.className = 'fallback';
+      fallbackDiv.innerHTML = noscript.innerHTML;
+
+      // Insert fallback at the top.
+      el.insertBefore(fallbackDiv, el.firstChild);
+
+      // Hide the original <noscript> to avoid duplicates.
+      noscript.style.display = 'none';
+
+      /*
+    // Hide other non-fallback children (optional; fallback.css handles this).
+    Array.from(el.children).forEach((child) => {
+      if (child !== fallbackDiv && child !== noscript) {
+        child.style.display = 'none';
+      }
+    });
+    */
+    }
+  }
+
+  function applyAllFallbacks(selector = '[fallback]') {
+    document.querySelectorAll(selector).forEach((el) => applyFallback(el));
+  }
+
+  // Web Component support detection.
+  const supportsWC =
+    'customElements' in window &&
+    'attachShadow' in Element.prototype &&
+    'content' in document.createElement('template');
+
+  // Only apply fallback globally if web components are NOT supported.
+  if (!supportsWC) {
+    document.addEventListener('DOMContentLoaded', applyAllFallbacks);
+  }
+})();


### PR DESCRIPTION
This PR adds the architecture to handle fallback content relatively gracefully. It aims to provide a workflow for addressing the states of: JS disabled, JS enabled + no web component support, JS enabled + web component support. The architecture is as follows:

Given the component `my-custom-btn`. It wraps a fallback, and as needed, slotted content:

```html
<my-custom-btn>
  <!-- author-supplied no-js fallback -->
  <noscript>
    <button>Click this basic button!</button>
  </noscript>

  <!-- author supplied slotted content -->
  Click this fancy button!
</my-custom-btn>
```

---

**JS disabled**
The `<noscript>` content is rendered AND the author supplied slotted content is rendered. So it looks like this:

```html
<button>Click this basic button!</button>
Click this fancy button!
```

To fix this, we can provide CSS that hide everything but the `<noscript>` tag, however we can't generically target all web components in CSS:

```css
my-custom-btn > :not(noscript) { display: none; }
```

To make this more generic, we could have the author add a `<noscript>` tag and, also, if they want to hide other content in the component, add a boolean attribute `hasfallback` or similar. Then we can make the selector more generic:

```css
[hasfallback] > :not(noscript) { display: none; }
```

---

**JS enabled, web components not supported**

In this case, we can globally check if web components are supported, and if not, we can load a polyfill, or just let it fall back to the `<noscript>` content. *However*, the problem here is that if JS is enabled, but web components are not supported, then the `<noscript>` content will not show. So, in this case we need to use JavaScript to turn `<noscript>` inside the web component into `<div class="fallback">` or similar. This would now show that content, except non-noscript tags are hidden via the CSS, so we need to add more CSS to show `.fallback` classes:

```css
[hasfallback] > .fallback { display: block; }
```

```js
// wc-fallback.js (see files added)
```

---

**JS enabled, web components are supported**

If JS is enabled, the `<noscript>` content is hidden and it is not swapped with `<div class="fallback">` and then the web component uses the author-supplied slotted content to render. However, because of the existing CSS that hides everything but the `noscript` content, that means everything will be hidden. So in this case, we add another CSS rule:

```css
[hasfallback]:defined > :not(noscript) { display: block; }
```

## Additions

- Add global wc-fallback script and styles

## Testing

1. PR checks should pass.
