### PR TITLE
GH Action: Added an action that creates a preview from PR's

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,12 +1,7 @@
-name: Deploy PR preview
-concurrency: preview-${{ github.ref }}
+name: Deploy PR Preview
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+    types: [opened, synchronize, reopened, closed]
 
 permissions:
   contents: write
@@ -19,20 +14,31 @@ jobs:
   deploy-preview:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
+      - name: Checkout repo
         uses: actions/checkout@v4
-      
-      - name: Shared setup
-        uses:  ./.github/actions/shared-action-setup
 
-      - uses: rossjrw/pr-preview-action@v1
+      - name: Shared setup
+        uses: ./.github/actions/shared-action-setup
+
+      - name: Build project assets
+        run: yarn build
+
+      - name: Build documentation site for PR preview
+        # Use a PR-scoped baseurl so preview assets resolve under pr-preview/<PR>.
+        run: bundle exec jekyll build --baseurl "/design-system/pr-preview/${{ github.event.number }}"
+
+      - name: Deploy PR preview
+        uses: rossjrw/pr-preview-action@v1
         id: preview-step
         with:
-          source-dir: ./packages/cfpb-design-system/dist
           preview-branch: ${{ env.PREVIEW_BRANCH }}
+          source-dir: docs/_site/design-system
           comment: false
-          umbrella-dir: ./packages/cfpb-design-system/pr-previews/
-          pages-base-url: cfpb.github.io/design-system/
+          # WARNING: If the umbrella-dir is not set, or set to / we could potentially overwrite the live site
+          umbrella-dir: pr-preview
+          pages-base-url: https://cfpb.github.io/design-system
+          # GH Pages serves from gh-pages root for this repo.
+          pages-base-path: .
           wait-for-pages-deployment: true
           action: auto
           


### PR DESCRIPTION
We would like to be able to vlsualize what changes look like prior to accepting a PR. This pr uses a couple of GH actions to accomplish this for us. That means we can move away from Netlify for this functionality. 

The GH action:

1) When a PR is opened, reopened, sycronized, or closed will
2) checks out the repo
3) builds the DS
4) Creates a PR preview by pulling in ./packages/cfpb-design-system/dist/ and puts it on the gh-pages branch in a dir of ./packages/cfpb-design-system/pr-previews/ so that we are not overwriting anything [PR preview](https://github.com/rossjrw/pr-preview-action)

This action adds a comment to the PR with a link to the preview. 


(that is not how it is formatted but just an example of the contents of the message. )
## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
