### PR TITLE
Update "lists" page

### DIFF
--- a/docs/pages/lists.md
+++ b/docs/pages/lists.md
@@ -6,8 +6,7 @@ variation_groups:
   - variation_group_name: Types
     variations:
       - variation_name: Bulleted list
-        variation_description:
-          Use a bulleted list when grouping similar items or short
+        variation_description: Use a bulleted list when grouping similar items or short
           thoughts into “bite-size” chunks. Generally, the order or count of the
           items in a bullet list isn’t important. An exception to this may be a
           list of states, which naturally fits into an alphabetical order.
@@ -24,10 +23,9 @@ variation_groups:
               </li>
               <li class="m-list__item">List item 3</li>
           </ul>
-        variation_specs: ''
+        variation_specs: ""
       - variation_name: Numbered list
-        variation_description:
-          When the order of information presented is important, use
+        variation_description: When the order of information presented is important, use
           a numbered list. This could include chronological items, things
           presented in the order of importance, or a finite list of a counted
           number of items.
@@ -76,7 +74,7 @@ variation_groups:
               <li>List item 9</li>
               <li>List item 10</li>
           </ol>
-        variation_specs: ''
+        variation_specs: ""
   - variations:
       - variation_code_snippet: |-
           <ul class="m-list m-list--unstyled">
@@ -94,11 +92,11 @@ variation_groups:
           </ul>
         variation_description: A modifier for the list to make it show items horizontally.
         variation_name: Horizontal list
-      - variation_description:
-          'Link lists is where each item in a list is a jump link,
-          which converts to a finger-friendly link with a large tap area on
-          smaller screens. See example on the <a
-          href="/design-system/components/links#list-link">links page</a>. '
+      - variation_description: The <a
+          href="/design-system/components/links#list-link">list link</a>
+          component presents each list item as a standalone link, which converts
+          to a touch-friendly link with a large tap area at smaller screen
+          widths.
         variation_name: Link list
     variation_group_name: Variations
 guidelines: >-
@@ -129,10 +127,10 @@ description: Lists are an effective way to visually highlight important
   information so that it can be more easily scanned and read. Before writing a
   list, it’s important to identify the best style needed for the information
   being presented.
-use_cases: ''
-behavior: ''
-accessibility: ''
-related_items: ''
+use_cases: ""
+behavior: ""
+accessibility: ""
+related_items: ""
 last_updated: 2020-01-28T15:55:47.394Z
-research: ''
+research: ""
 ---


### PR DESCRIPTION
## Description of change: 
Minor content change to "List link" component on the "Lists" page for content for greater clarity and consistency. 
https://cfpb.github.io/design-system/components/lists#link-list

- Changes reference to "jump link" in favor of "standalone link" 
- Changes "finger-friendly" to "touch-friendly"

| Before | After|
|------------|------------|
|<img width="846" height="171" alt="Screenshot 2026-02-11 at 10 32 32 AM" src="https://github.com/user-attachments/assets/3893b1d3-a1c4-43f8-8d20-29ae8b5a36fe" />|<img width="855" height="176" alt="Screenshot 2026-02-11 at 10 34 08 AM" src="https://github.com/user-attachments/assets/3c2e8dd7-2b3a-4100-802d-ac91cb4f8804" />|
