### PR TITLE
Remove @sonnakim for awareness

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -19,6 +19,3 @@ __Current__
 
 
 __Expected__
-
-
-@sonnakim for awareness

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,5 +36,3 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here. 
-
-@sonnakim for awareness

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -21,5 +21,3 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
-
-@sonnakim for awareness


### PR DESCRIPTION
This PR removes "@sonnakim for awareness" from the DS issue templates, because @sonnakim probably doesn't want to be notified every time we have new issues with the DS that used to flag @sonnakim that the issue was opened. If @sonnakim wants to follow the repo's issues, @sonnakim can star or watch the repo, and that is probably a better use of space within @sonnakim's GitHub inbox. 

## Removals

- Remove "@sonnakim for awareness" 

## Testing

1. Confirm that "@sonnakim for awareness" has been removed from GH issue templates.

## Notes

- @sonnakim did not approve this in advance and may speak up now to stop this travesty of a PR.

## Checklist

- [x] "@sonnakim for awareness" has been removed from GH issue templates.
