### PR TITLE
Add guard that checks if secondary nav is defined

### DIFF
--- a/docs/assets/js/sidebar.js
+++ b/docs/assets/js/sidebar.js
@@ -5,6 +5,9 @@
 function init() {
   const secondaryNavCat = document.querySelector('.ds-nav-container');
 
+  // Guard to bail out if secondary nav is not on the page, such as on the search page.
+  if (!secondaryNavCat) return;
+
   // First collapse the navigation if in mobile.
   const windowWidth = window.innerWidth;
   if (windowWidth < 601) {


### PR DESCRIPTION
The search page doesn't have the secondary nav, so throws the error `Uncaught TypeError: Cannot read properties of null (reading 'setAttribute')` in the dev console. This PR adds a guard to check if the secondary nav exists before trying to do scripting with it.

## Changes

- Add guard that checks if secondary nav is defined

## Testing

1. `yarn build` and start local server. 
2. See on search page that there is no dev console error.
3. See on live search page that there is a dev console error.
