### PR TITLE
Tweak test to type one character instead of four

### DIFF
--- a/test/cypress/e2e/docs/decap-cms.cy.js
+++ b/test/cypress/e2e/docs/decap-cms.cy.js
@@ -54,11 +54,11 @@ describe('Decap CMS', () => {
       // The button page's title field
       cy.get('#nc-root #title-field-1').should('be.visible');
       cy.get('#nc-root #title-field-1').clear({ force: true });
-      cy.get('#nc-root #title-field-1').type('best');
-      cy.get('#nc-root #title-field-1').should('have.value', 'best');
+      cy.get('#nc-root #title-field-1').type('😄');
+      cy.get('#nc-root #title-field-1').should('have.value', '😄');
       cy.get('#nc-root #title-field-1').blur();
 
-      getIframeBody().find('.frame-content').should('include.text', 'best');
+      getIframeBody().find('.frame-content').should('include.text', '😄');
     });
 
     it('should support switching between the various "show details" tabs', () => {


### PR DESCRIPTION
This test is very brittle and often fails with only 'bes' being typed instead of 'best'. This adjusts the test to type one emoji, which should be less likely to fail the test before it has finished typing, and is also unlikely to be a false positive against the page's existing content. 

## Changes

- Tweak test to type one character instead of four
 
## Testing

1. PR checks should pass.
