### PR TITLE
cfpb-search-form: Hide autocomplete list on page load

### DIFF
--- a/docs/_includes/search.html
+++ b/docs/_includes/search.html
@@ -1,6 +1,6 @@
 <form id="search-form" action="{{ site.baseurl }}/search" method="get">
     <cfpb-form-search id="search-box" form="search-form" name="searchQuery">
-        <ul>
+        <ul hidden>
             <li><a href="/design-system/components/alerts">Alerts</a></li>
             <li><a href="/design-system/components/banner-notification">Banner (notification)</a></li>
             <li><a href="/design-system/components/banner-us-gov">Banner (US gov)</a></li>

--- a/docs/pages/fallback-strategies.md
+++ b/docs/pages/fallback-strategies.md
@@ -45,6 +45,25 @@ description: >-
 
   In modern browsers with web component support, this component will incorporate the slotted content within the shadow DOM content and render the component. In legacy browsers, or with JavaScript disabled, the slotted content will appear on the page without any other content from the shadow DOM, thus functioning as a textual fallback.
 
+  ## Dealing with the dreaded Flash Of Unstyled Content (FOUC)
+
+  One potential problem with slotted content is that it may briefly appear on the page before the web component markup is initialized, leading to an unsightly flash of unstyled content (FOUC). This may be acceptable if the slotted content is roughly the same dimensions as the initialized component. However, if the slotted content spills outside of the component boundaries (e.g. through absolute positioning), this might cause an unsightly flash. In this situation it may be best to add a standard `hidden` attribute to the slotted content, and then deal with its visibility within the component CSS/JS.
+
+
+  ```html
+
+  <my-fancy-list>
+    <ul hidden>
+     <li>Earth</li>
+     <li>Moon</li>
+    </ul>
+  </my-fancy-list>
+
+  ```
+
+
+
+  However, note that this'll negate using the slotted content as a fallback.
 
   ## Fallback content
 

--- a/docs/pages/reference-for-custom-elements.md
+++ b/docs/pages/reference-for-custom-elements.md
@@ -894,7 +894,7 @@ variation_groups:
         variation_code_snippet_rendered: >-
           <div>
             <cfpb-form-search>
-              <ul>
+              <ul hidden>
                 <li>How do I add money to my prepaid card?</li>
                 <li>What are credit card “add-on products?”</li>
                 <li>How do I qualify for an advertised 0% auto financing?</li>
@@ -908,7 +908,7 @@ variation_groups:
           </div>
         variation_code_snippet: >-
           <cfpb-form-search>
-            <ul>
+            <ul hidden>
               <li>How do I add money to my prepaid card?</li>
               <li>What are credit card “add-on products?”</li>
               <li>How do I qualify for an advertised 0% auto financing?</li>


### PR DESCRIPTION
The autocomplete list for the cfpb-search-form was flashing on page load, and also appearing when JS was disabled. This adds a `hidden` attribute to the slotted autocomplete list.

## Changes

- cfpb-search-form: Adds a `hidden` attribute to the slotted autocomplete list.
- Add FOUC section to fallback docs.

## Testing

1. `yarn build` and visit http://localhost:4000/design-system/components/reference-for-custom-elements and see the search form doesn't flash a drop-down list on page load. 
