### PR TITLE
Make cfpb-icons always presentational

### DIFF
--- a/docs/pages/reference-for-custom-elements.md
+++ b/docs/pages/reference-for-custom-elements.md
@@ -33,7 +33,7 @@ variation_groups:
 
             <p>Color set by `color` style set on parent element:</p>
 
-            <span style="color:blue;"><cfpb-icon name="bank-round" /></span>
+            <span style="color:blue;"><cfpb-icon name="github-square" /></span>
 
             <br>
             <br>

--- a/packages/cfpb-design-system/src/elements/cfpb-icon/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-icon/index.js
@@ -35,7 +35,13 @@ export class CfpbIcon extends LitElement {
     }
 
     return html`<span style="--icon-mask-image-url:url('${iconPath}')">
-      <img src="${iconPath}" loading="lazy" decoding="async" />
+      <img
+        src="${iconPath}"
+        loading="lazy"
+        decoding="async"
+        alt=""
+        aria-hidden="true"
+      />
     </span>`;
   }
 


### PR DESCRIPTION
Make <cfpb-icon>s always presentational.

## Changes

- Add `alt=""` and `aria-hidden:true` to cfpb-icon.
