### PR TITLE
Add CSS to Jest `moduleNameMapper`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,8 +11,7 @@ export default {
   ],
   coverageDirectory: '<rootDir>/test/unit-test-coverage',
   moduleNameMapper: {
-    '\\.(svg)$': '<rootDir>/test/util/mocks/file-mock.js',
-    '\\.(scss)$': '<rootDir>/test/util/mocks/file-mock.js',
+    '\\.(svg|scss|css)$': '<rootDir>/test/util/mocks/file-mock.js',
   },
   testEnvironmentOptions: {
     url: 'http://localhost',


### PR DESCRIPTION
## Changes

- Add CSS to Jest `moduleNameMapper` and condense multiple lines into one.

## Testing

1. `yarn jest` should pass.