### PR TITLE
Add footer GH link

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -12,6 +12,10 @@
             If you have a substantial change to an existing page, or a new standard you want to add,
             <a href="{{ '/updating-this-website/#creating-new-pages' | relative_url }}">follow these guidelines</a>.
         </p>
+
+        <p>
+            <small><a href="https://github.com/cfpb/design-system"><cfpb-icon name="github-square"></cfpb-icon> Website source code</a></small>
+        </p>
     </div>
 
 </footer>


### PR DESCRIPTION
## Additions

- Docs: Add link in the footer to the GH repo.

## Testing

1. `yarn start` and look at a page with a footer and you should see a link to the GH repo.
