### PR TITLE
cfpb-file-upload fixes/adjustments and add initial unit test

### DIFF
--- a/packages/cfpb-design-system/src/elements/cfpb-file-upload/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-file-upload/index.js
@@ -14,47 +14,52 @@ export class CfpbFileUpload extends LitElement {
     ${unsafeCSS(styles)}
   `;
 
+  #fileInput = createRef();
+
   static properties = {
+    accept: { type: String, reflect: true }, // The accepted file types.
     isDetailHidden: {
       type: Boolean,
-      attribute: 'hidden', // Maps 'hidden' to 'isDetailHidden' property.
-      reflect: true, // Reflects the property change back to the attribute.
+      state: true, // Internal property.
     },
-    fileName: { type: String }, // The file name.
-    accept: { type: String }, // The accepted file types.
-    value: { type: String }, // The raw file name.
-    files: { type: FileList }, // A FileList object.
+    fileName: { type: String, state: true }, // An internal file name.
+    files: { type: FileList, state: true }, // An internal FileList object.
   };
 
   constructor() {
     super();
-    this.#hideDetails();
-  }
 
-  #fileInput = createRef();
-  #fileDetails = createRef();
-
-  #getUploadName(fileName) {
-    let uploadName = fileName;
-    if (uploadName.indexOf('\\') > -1) {
-      const uploadNameParts = uploadName.split('\\');
-      uploadName = uploadNameParts[uploadNameParts.length - 1];
-    }
-
-    return uploadName;
+    // Hide the details.
+    this.isDetailHidden = true;
+    this.fileName = '';
+    this.files = null;
   }
 
   #showDetails() {
-    this.fileName = this.#getUploadName(this.#fileInput.value.value);
-    this.value = this.#fileInput.value.value;
-    this.files = this.#fileInput.value.files;
+    const input = this.#fileInput.value;
+    const files = input.files;
+
+    if (!files?.length) {
+      this.#hideDetails();
+      return;
+    }
+
+    this.fileName = files[0].name;
+    this.files = files;
     this.isDetailHidden = false;
+
+    this.dispatchEvent(
+      new CustomEvent('file-change', {
+        detail: { files },
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 
   #hideDetails() {
     this.fileName = '';
-    this.value = '';
-    this.files = {};
+    this.files = null;
     this.isDetailHidden = true;
   }
 
@@ -80,16 +85,11 @@ export class CfpbFileUpload extends LitElement {
         class="a-btn a-btn--secondary"
         type="file"
         hidden
-        accept=${this.accept}
-        @input=${() => this.#checkStatus()}
-        @cancel=${() => this.#checkStatus()}
+        accept=${this.accept ?? ''}
+        @change=${() => this.#checkStatus()}
         ${ref(this.#fileInput)}
       />
-      <div
-        part="upload-details"
-        ?hidden=${this.isDetailHidden}
-        ${ref(this.#fileDetails)}
-      >
+      <div part="upload-details" ?hidden=${this.isDetailHidden}>
         <h4>File added</h4>
         <ul>
           <li>${this.fileName}</li>

--- a/packages/cfpb-design-system/src/elements/cfpb-file-upload/index.spec.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-file-upload/index.spec.js
@@ -1,0 +1,24 @@
+import { CfpbFileUpload } from './index.js';
+
+describe('<cfpb-file-upload>', () => {
+  let elm;
+
+  beforeEach(async () => {
+    CfpbFileUpload.init();
+    elm = document.createElement('cfpb-file-upload');
+    document.body.appendChild(elm);
+
+    await customElements.whenDefined('cfpb-file-upload');
+    await elm.updateComplete;
+  });
+
+  afterEach(() => {
+    document.body.removeChild(elm);
+  });
+
+  it('renders with hidden details initially', () => {
+    const details = elm.shadowRoot.querySelector('[part="upload-details"]');
+    expect(details.hidden).toBe(true);
+    expect(details.textContent).toContain('File added');
+  });
+});


### PR DESCRIPTION
## Removals

- cfpb-file-upload: 
  - Make `isDetailHidden`, `fileName`, and `files` properties internal state.
  - Remove `#getUploadName` and use Files API instead to get file name.
  - Remove erroneous `cancel` event. Change `input` to `change` event.
  - Emit event when file changes.
  - Add initial unit test.

## Testing

1.  `yarn jest` should pass.