### PR TITLE
Migrate decap buttons to cfpb-button

### DIFF
--- a/docs/_includes/variation-content.html
+++ b/docs/_includes/variation-content.html
@@ -156,8 +156,8 @@
             {% assign variation_slug = variation_slug | strip | slugify | truncate: 40, '' %}
 
             <div class="a-toggle__code">
-                <button href="#{{ variation_slug }}-{{ forloop.index }}" class="a-btn a-btn--link" data-toggle-details="show">Show details</button>
-                <button href="#{{ variation_slug }}-{{ forloop.index }}" class="a-btn a-btn--link u-hidden" data-toggle-details="hide">Hide details</button>
+                <cfpb-button href="#{{ variation_slug }}-{{ forloop.index }}" style-as-link data-toggle-details="show">SHOW DETAILS</cfpb-button>
+                <cfpb-button href="#{{ variation_slug }}-{{ forloop.index }}" style-as-link class="u-hidden" data-toggle-details="hide">HIDE DETAILS</cfpb-button>
             </div>
 
             <div class="m-tabs u-hidden" id="{{ variation_slug }}-{{ forloop.index }}">

--- a/docs/_layouts/homepage.html
+++ b/docs/_layouts/homepage.html
@@ -5,15 +5,14 @@ layout: default
 <main class="content" id="main" role="main">
   <div class="wrapper">{% include generic-content.html %}</div>
   <div class="o-editor" id="edit-page">
-    <a
-      class="a-btn"
+    <cfpb-button
       href="
             {{- '/admin/#/collections/special-pages/entries/home' | relative_url
             -}}"
+      iconright="edit"
       title="Edit this page in Decap CMS"
     >
-      <span>Edit page</span>
-      {% include icons/edit.svg %}
-    </a>
+      Edit page
+    </cfpb-button>
   </div>
 </main>

--- a/docs/_layouts/variation.html
+++ b/docs/_layouts/variation.html
@@ -9,23 +9,21 @@ layout: default
     {% include variation-content.html %} {% if page.variation_groups.size > 0 %}
 
     <div class="o-editor" id="toggle-details">
-      <a class="a-btn" href="#" title="Show all details">
-        <span>Show all details</span>
-        {% include icons/lightbulb.svg %}
-      </a>
+      <cfpb-button iconright="lightbulb" title="Show all details">
+        Show all details
+      </cfpb-button>
     </div>
 
     {% endif %}
 
     <div class="o-editor" id="edit-page">
-      <a
-        class="a-btn"
+      <cfpb-button
         href="/design-system/updating-this-website?page={{ page.title | url_encode }}"
+        iconright="edit"
         title="Edit this page in Decap CMS"
       >
-        <span>Edit page</span>
-        {% include icons/edit.svg %}
-      </a>
+        Edit page
+      </cfpb-button>
     </div>
   </div>
 </main>

--- a/docs/assets/css/toggle-code-button.scss
+++ b/docs/assets/css/toggle-code-button.scss
@@ -4,8 +4,4 @@
   margin: 0 -1rem 0 auto;
   padding: 0 1rem 1rem;
   width: fit-content;
-
-  .a-btn {
-    text-transform: uppercase;
-  }
 }

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -94,8 +94,8 @@ if (tabsContainerDom.length > 0) {
     tabsInst.init();
   }
 }
-const toggleAllBtn = document.querySelector('#toggle-details');
-const toggleBtns = document.querySelectorAll('.a-toggle__code button');
+const toggleAllBtn = document.querySelector('#toggle-details cfpb-button');
+const toggleBtns = document.querySelectorAll('.a-toggle__code cfpb-button');
 
 /**
  * @param {MouseEvent} event - The mouse event object from the click.

--- a/docs/assets/js/toggle-details.js
+++ b/docs/assets/js/toggle-details.js
@@ -45,11 +45,11 @@ function toggleDetails(button, document = window.document, state) {
  */
 function toggleAllDetails(toggleBtn) {
   if (isShowingAllDetails) {
-    toggleBtn.querySelector('.a-btn span').innerHTML = 'Show all details';
+    toggleBtn.textContent = 'Show all details';
     toggleBtn.setAttribute('title', 'Show all details');
     window.localStorage.setItem('toggleState', 'show');
   } else {
-    toggleBtn.querySelector('.a-btn span').innerHTML = 'Hide all details';
+    toggleBtn.textContent = 'Hide all details';
     toggleBtn.setAttribute('title', 'Hide all details');
     window.localStorage.setItem('toggleState', 'hide');
   }
@@ -57,7 +57,7 @@ function toggleAllDetails(toggleBtn) {
   const codeEls = document.querySelectorAll('.a-toggle__code');
   let buttonElm;
   for (let i = 0, len = codeEls.length; i < len; i++) {
-    buttonElm = codeEls[i].querySelector('button:not(.u-hidden)');
+    buttonElm = codeEls[i].querySelector('cfpb-button:not(.u-hidden)');
     toggleDetails(
       buttonElm,
       window.document,

--- a/docs/pages/heroes.md
+++ b/docs/pages/heroes.md
@@ -90,7 +90,7 @@ variation_groups:
           illustration](https://www.consumerfinance.gov/owning-a-home/) and
           [hero with bleeding
           illustration](https://www.consumerfinance.gov/consumer-tools/money-as-you-grow/).
-          Click on the "show details" link below for implementation details and
+          Click on the "SHOW DETAILS" link below for implementation details and
           production specs. '
         variation_name: Hero with illustration
         variation_specs: >-

--- a/docs/special-pages/updating-this-website.md
+++ b/docs/special-pages/updating-this-website.md
@@ -201,7 +201,7 @@ description: >-
       <h3>Ready to edit the <span data-interstitial-page-name></span> page?</h3>
 
       <p>
-        <a href="/design-system/admin" class="a-btn" data-interstitial-redirect-button>Continue to Decap CMS</a>
+        <cfpb-button href="/design-system/admin" data-interstitial-redirect-button>Continue to Decap CMS</cfpb-button>
       </p>
   </div>
 
@@ -225,7 +225,8 @@ description: >-
 
 
   <p>
-        <a href="/design-system/admin/#/collections/pages/new" class="a-btn" title="Create a new page for this website in Decap CMS">Create new page</a>
+        <cfpb-button href="/design-system/admin/#/collections/pages/new" title="Create a new page for this website in Decap CMS">
+        Create new page</cfpb-button>
   </p>
 
 
@@ -238,7 +239,7 @@ description: >-
 
 
   <p>
-        <a href="/design-system/admin/#/collections/navigation/entries/side-navigation" class="a-btn" title="Edit the side navigation">Edit the side navigation</a>
+        <cfpb-button href="/design-system/admin/#/collections/navigation/entries/side-navigation" title="Edit the side navigation">Edit the side navigation</cfpb-button>
   </p>
 
 

--- a/test/cypress/e2e/docs/decap-cms.cy.js
+++ b/test/cypress/e2e/docs/decap-cms.cy.js
@@ -61,16 +61,16 @@ describe('Decap CMS', () => {
       getIframeBody().find('.frame-content').should('include.text', '😄');
     });
 
-    it('should support switching between the various "show details" tabs', () => {
+    it('should support switching between the various "SHOW DETAILS" tabs', () => {
       cy.viewport(2000, 1200);
       // Wait for the editor to load
       cy.get('label').contains('Page title').should('be.visible');
       getIframeBody()
-        .find('button')
-        .contains('Show details')
+        .find('cfpb-button')
+        .contains('SHOW DETAILS')
         .should('be.visible');
       getIframeBody().find('.m-tabs').should('have.css', 'display', 'none');
-      getIframeBody().find('button').contains('Show details').click();
+      getIframeBody().find('cfpb-button').contains('SHOW DETAILS').click();
       getIframeBody().find('a').contains('Implementation').should('be.visible');
       getIframeBody().find('a').contains('Implementation').click();
       getIframeBody().find('.m-tabs').should('not.have.css', 'display', 'none');

--- a/test/cypress/e2e/docs/show-details.cy.js
+++ b/test/cypress/e2e/docs/show-details.cy.js
@@ -1,4 +1,4 @@
-describe('The "show details" toggling feature', () => {
+describe('The "SHOW DETAILS" toggling feature', () => {
   const components = [
     'alerts',
     'banner-notification',
@@ -53,21 +53,21 @@ describe('The "show details" toggling feature', () => {
 
       cy.log('should hide snippet tabs by default');
       // Show details button.
-      cy.get('button').contains('Show details').should('be.visible');
+      cy.get('cfpb-button').contains('SHOW DETAILS').should('be.visible');
 
       // Hide details button.
-      cy.get('button').contains('Hide details').should('not.be.visible');
+      cy.get('cfpb-button').contains('HIDE DETAILS').should('not.be.visible');
 
       // Detail tabs.
       cy.get('.m-tabs').should('not.be.visible');
 
       cy.log('should show code snippets when toggle button is clicked');
       // Show details button.
-      cy.get('button').contains('Show details').click();
-      cy.get('button').contains('Show details').should('not.be.visible');
+      cy.get('cfpb-button').contains('SHOW DETAILS').click();
+      cy.get('cfpb-button').contains('SHOW DETAILS').should('not.be.visible');
 
       // Hide details button.
-      cy.get('button').contains('Hide details').should('be.visible');
+      cy.get('cfpb-button').contains('HIDE DETAILS').should('be.visible');
 
       // Detail tabs.
       cy.get('.m-tabs').should('be.visible');
@@ -76,8 +76,8 @@ describe('The "show details" toggling feature', () => {
         'should re-hide code snippets when toggle button is clicked again',
       );
       // Hide details button.
-      cy.get('button').contains('Hide details').click();
-      cy.get('button').contains('Hide details').should('not.be.visible');
+      cy.get('cfpb-button').contains('HIDE DETAILS').click();
+      cy.get('cfpb-button').contains('HIDE DETAILS').should('not.be.visible');
 
       // Detail tabs.
       cy.get('.m-tabs').should('not.be.visible');


### PR DESCRIPTION
Use `<cfpb-button>` within decap interface.

## Changes

- Migrate decap buttons to cfpb-button

## Testing

1. `yarn build && yarn start`
2. Visit the local server and see that you can edit a page and toggle the code details panels.