### PR TITLE
Fix padding on global eyebrow Banner (USA)

### DIFF
--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -77,6 +77,7 @@ details[open] summary::after {
 
 // Set padding for main content blocks.
 .m-global-eyebrow .m-global-eyebrow__container,
+.m-global-eyebrow .a-tagline,
 .site-header,
 .ds-footer {
   max-width: 1170px;


### PR DESCRIPTION
## Changes

- Fix padding on global eyebrow Banner (USA)

## Testing

1. Banner (USA) should have left padding for the tagline.