### PR TITLE
Sass map: Fix dir path in components and removed forward for `elements`

### DIFF
--- a/packages/cfpb-design-system/src/components/index.scss
+++ b/packages/cfpb-design-system/src/components/index.scss
@@ -1,61 +1,61 @@
 /* =======================================================================
    Design System
-   Legacy components
+   Legacy .
    ======================================================================= */
 
 // Buttons.
-@forward 'components/cfpb-buttons/button';
-@forward 'components/cfpb-buttons/button-group';
-@forward 'components/cfpb-buttons/button-link';
+@forward './cfpb-buttons/button';
+@forward './cfpb-buttons/button-group';
+@forward './cfpb-buttons/button-link';
 
 // Expandables.
-@forward 'components/cfpb-expandables/vars';
-@forward 'components/cfpb-expandables/expandable';
-@forward 'components/cfpb-expandables/expandable-group';
-@forward 'components/cfpb-expandables/summary';
-@forward 'components/cfpb-expandables/summary-minimal';
+@forward './cfpb-expandables/vars';
+@forward './cfpb-expandables/expandable';
+@forward './cfpb-expandables/expandable-group';
+@forward './cfpb-expandables/summary';
+@forward './cfpb-expandables/summary-minimal';
 
 // Forms.
-@forward 'components/cfpb-forms/form';
-@forward 'components/cfpb-forms/form-alert';
-@forward 'components/cfpb-forms/form-field';
-@forward 'components/cfpb-forms/label';
-@forward 'components/cfpb-forms/multiselect';
-@forward 'components/cfpb-forms/range';
-@forward 'components/cfpb-forms/search-input';
-@forward 'components/cfpb-forms/select';
-@forward 'components/cfpb-forms/tag';
-@forward 'components/cfpb-forms/text-input';
+@forward './cfpb-forms/form';
+@forward './cfpb-forms/form-alert';
+@forward './cfpb-forms/form-field';
+@forward './cfpb-forms/label';
+@forward './cfpb-forms/multiselect';
+@forward './cfpb-forms/range';
+@forward './cfpb-forms/search-input';
+@forward './cfpb-forms/select';
+@forward './cfpb-forms/tag';
+@forward './cfpb-forms/text-input';
 
 // Layout.
-@forward 'components/cfpb-layout/card-group';
-@forward 'components/cfpb-layout/card';
-@forward 'components/cfpb-layout/email-signup';
-@forward 'components/cfpb-layout/featured-content-module';
-@forward 'components/cfpb-layout/hero';
-@forward 'components/cfpb-layout/layout';
-@forward 'components/cfpb-layout/text-introduction';
-@forward 'components/cfpb-layout/well';
+@forward './cfpb-layout/card-group';
+@forward './cfpb-layout/card';
+@forward './cfpb-layout/email-signup';
+@forward './cfpb-layout/featured-content-module';
+@forward './cfpb-layout/hero';
+@forward './cfpb-layout/layout';
+@forward './cfpb-layout/text-introduction';
+@forward './cfpb-layout/well';
 
 // Notifications.
-@forward 'components/cfpb-notifications/vars';
-@forward 'components/cfpb-notifications/banner';
-@forward 'components/cfpb-notifications/notification';
+@forward './cfpb-notifications/vars';
+@forward './cfpb-notifications/banner';
+@forward './cfpb-notifications/notification';
 
 // Pagination.
-@forward 'components/cfpb-pagination/vars';
-@forward 'components/cfpb-pagination/pagination';
+@forward './cfpb-pagination/vars';
+@forward './cfpb-pagination/pagination';
 
 // Tables.
-@forward 'components/cfpb-tables/vars';
-@forward 'components/cfpb-tables/table';
+@forward './cfpb-tables/vars';
+@forward './cfpb-tables/table';
 
 // Typography.
-@forward 'components/cfpb-typography/vars';
-@forward 'components/cfpb-typography/date';
-@forward 'components/cfpb-typography/link';
-@forward 'components/cfpb-typography/list';
-@forward 'components/cfpb-typography/meta-header';
-@forward 'components/cfpb-typography/pull-quote';
-@forward 'components/cfpb-typography/slug-header';
-@forward 'components/cfpb-typography/tagline';
+@forward './cfpb-typography/vars';
+@forward './cfpb-typography/date';
+@forward './cfpb-typography/link';
+@forward './cfpb-typography/list';
+@forward './cfpb-typography/meta-header';
+@forward './cfpb-typography/pull-quote';
+@forward './cfpb-typography/slug-header';
+@forward './cfpb-typography/tagline';

--- a/packages/cfpb-design-system/src/index.scss
+++ b/packages/cfpb-design-system/src/index.scss
@@ -3,8 +3,7 @@
    Default package stylesheet
    ========================================================================== */
 
-@forward 'abstracts';
 @forward 'base';
+@forward 'abstracts';
 @forward 'components';
-@forward 'elements';
 @forward 'utilities';


### PR DESCRIPTION
After the reorg I found that the dir path for `components/index.scss` had not been updated to the new location. 

Additionally, I found that there was an unnecessary `@forward elements` in the `src/index.scss`. Removed that reference.

## Additions

-

## Removals

-

## Changes

- updated `components/index.scss` to use the correct path. EG  `@forward './cfpb-buttons/button';` instead of `@forward 'components/cfpb-buttons/button';`
- removed `src/index.scss` forward for elements since there is no scss in the root. EG deleted `@forward 'elements';`

## Testing

1.

## Screenshots

| Before | After  |
| ------ | ------ |
|        |        |

## Notes and todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

Check the [current browser support cutoff list](https://cfpb.github.io/consumerfinance.gov/browser-support#current-browser-support-metrics) for browsers that are advisable
to prioritize for testing.

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
