### PR TITLE
Bump to yarn 4.16.0

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,4 @@
-defaultSemverRangePrefix: ""
+defaultSemverRangePrefix: ''
 
 enableGlobalCache: false
 
@@ -8,7 +8,7 @@ enableTelemetry: false
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 0
+npmMinimalAgeGate: '3d'
 
 supportedArchitectures:
   cpu:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,4 @@
-defaultSemverRangePrefix: ''
+defaultSemverRangePrefix: ""
 
 enableGlobalCache: false
 
@@ -7,6 +7,8 @@ enableMirror: true
 enableTelemetry: false
 
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 0
 
 supportedArchitectures:
   cpu:

--- a/package.json
+++ b/package.json
@@ -124,5 +124,5 @@
     "qs": ">=6.14.2"
   },
   "type": "module",
-  "packageManager": "yarn@4.14.1"
+  "packageManager": "yarn@4.16.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 10
   cacheKey: 10c0
 
 "@asamuzakjp/css-color@npm:^5.1.11":


### PR DESCRIPTION
## Changes

- Bump to yarn 4.16.0
- Add `npmMinimalAgeGate: '3d'` to give a cooling off period for new installs.