### PR TITLE
Fix multiselect bug

### DIFF
--- a/packages/cfpb-design-system/dist/index.js
+++ b/packages/cfpb-design-system/dist/index.js
@@ -2798,7 +2798,7 @@ var on = Xe(an), sn = ".cf-icon-svg{vertical-align:middle;fill:currentColor;heig
 		t.optionList = this.list.childData ?? [], e.currentTarget.focusItemAt(e.detail.index);
 	}
 	async onTagClick(e, t, n) {
-		let r = this.tagGroup.tagList.filter((t) => t !== e.detail.target) ?? [];
+		let r = this.tagGroup.items.filter((t) => t !== e.detail.target) ?? [];
 		t.optionList = t.optionList.map((e) => ({
 			...e,
 			checked: r.some((t) => t.value === e.value)

--- a/packages/cfpb-design-system/src/elements/cfpb-select/multiple-select-event-proxy.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-select/multiple-select-event-proxy.js
@@ -32,7 +32,7 @@ export class MultipleSelectEventProxy {
 
   async onTagClick(evt, host, tagGroup) {
     const remaining =
-      this.tagGroup.tagList.filter((tag) => tag !== evt.detail.target) ?? [];
+      this.tagGroup.items.filter((tag) => tag !== evt.detail.target) ?? [];
 
     host.optionList = host.optionList.map((item) => ({
       ...item,

--- a/packages/cfpb-design-system/src/elements/cfpb-select/multiple-select-event-proxy.spec.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-select/multiple-select-event-proxy.spec.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MultipleSelectEventProxy } from './multiple-select-event-proxy.js';
+
+describe('MultipleSelectEventProxy', () => {
+  it('updates host.optionList when a tag is removed', async () => {
+    const tagA = { value: 'a' };
+    const tagB = { value: 'b' };
+
+    const host = {
+      optionList: [
+        { value: 'a', checked: true },
+        { value: 'b', checked: true },
+      ],
+      updateComplete: Promise.resolve(),
+    };
+
+    const focus = vi.fn();
+
+    const proxy = new MultipleSelectEventProxy(host);
+
+    proxy.tagGroup = {
+      items: [tagA, tagB],
+    };
+
+    await proxy.onTagClick(
+      {
+        detail: {
+          target: tagA,
+        },
+      },
+      host,
+      { focus },
+    );
+
+    expect(host.optionList).toEqual([
+      { value: 'a', checked: false },
+      { value: 'b', checked: true },
+    ]);
+
+    expect(focus).toHaveBeenCalled();
+  });
+
+  it('syncs optionList from list.childData on item click', () => {
+    const host = {
+      optionList: [],
+    };
+
+    const list = {
+      childData: [
+        { value: 'a', checked: true },
+        { value: 'b', checked: false },
+      ],
+    };
+
+    const proxy = new MultipleSelectEventProxy({ list });
+
+    proxy.list = {
+      childData: [
+        { value: 'a', checked: true },
+        { value: 'b', checked: false },
+      ],
+    };
+
+    const focusItemAt = vi.fn();
+
+    const evt = {
+      detail: {
+        index: 0,
+      },
+      currentTarget: {
+        focusItemAt,
+      },
+    };
+
+    proxy.onItemClick(evt, host);
+
+    expect(host.optionList).toEqual([
+      { value: 'a', checked: true },
+      { value: 'b', checked: false },
+    ]);
+
+    expect(focusItemAt).toHaveBeenCalledWith(0);
+  });
+});


### PR DESCRIPTION
There was a bug in the multiselect where you could click on the tags to remove them, but they'd re-appear when the drop-down list was opened. 

## Changes

- Fix bug in multiselect where incorrect internal list was selected.
- Add two unit tests.

## Testing

1. PR checks should pass.
