### PR TITLE
Change show all details button to secondary variant

### DIFF
--- a/docs/_layouts/variation.html
+++ b/docs/_layouts/variation.html
@@ -9,7 +9,11 @@ layout: default
     {% include variation-content.html %} {% if page.variation_groups.size > 0 %}
 
     <div class="o-editor" id="toggle-details">
-      <cfpb-button iconright="lightbulb" title="Show all details">
+      <cfpb-button
+        variant="secondary"
+        iconright="lightbulb"
+        title="Show all details"
+      >
         Show all details
       </cfpb-button>
     </div>

--- a/docs/pages/sidebars-prefooters.md
+++ b/docs/pages/sidebars-prefooters.md
@@ -279,18 +279,18 @@ variation_groups:
               </div>
           </div>
         variation_is_deprecated: true
-guidelines: ""
+guidelines: ''
 eyebrow: Layout
 title: Main content and sidebars
 description: |+
   A set of HTML and CSS layout helpers.
 
-use_cases: ""
-behavior: ""
-accessibility: ""
+use_cases: ''
+behavior: ''
+accessibility: ''
 related_items: |-
   * [Blocks](https://cfpb.github.io/design-system/development/blocks)
   * [Grid](https://cfpb.github.io/design-system/foundation/grid)
 last_updated: 2020-01-28T15:55:47.394Z
-research: ""
+research: ''
 ---


### PR DESCRIPTION
Fixes https://github.com/cfpb/design-system/issues/2214

## Changes

- Change show all details button to secondary variant

## Testing

1. `yarn build && yarn start` and the "Show all details" button is secondary button styling.
