### PR TITLE
Move prettier config to prettier.config.js

### DIFF
--- a/docs/pages/sidebars-prefooters.md
+++ b/docs/pages/sidebars-prefooters.md
@@ -279,18 +279,18 @@ variation_groups:
               </div>
           </div>
         variation_is_deprecated: true
-guidelines: ''
+guidelines: ""
 eyebrow: Layout
 title: Main content and sidebars
 description: |+
   A set of HTML and CSS layout helpers.
 
-use_cases: ''
-behavior: ''
-accessibility: ''
+use_cases: ""
+behavior: ""
+accessibility: ""
 related_items: |-
   * [Blocks](https://cfpb.github.io/design-system/development/blocks)
   * [Grid](https://cfpb.github.io/design-system/foundation/grid)
 last_updated: 2020-01-28T15:55:47.394Z
-research: ''
+research: ""
 ---

--- a/docs/pages/sidebars-prefooters.md
+++ b/docs/pages/sidebars-prefooters.md
@@ -279,18 +279,18 @@ variation_groups:
               </div>
           </div>
         variation_is_deprecated: true
-guidelines: ""
+guidelines: ''
 eyebrow: Layout
 title: Main content and sidebars
 description: |+
   A set of HTML and CSS layout helpers.
 
-use_cases: ""
-behavior: ""
-accessibility: ""
+use_cases: ''
+behavior: ''
+accessibility: ''
 related_items: |-
   * [Blocks](https://cfpb.github.io/design-system/development/blocks)
   * [Grid](https://cfpb.github.io/design-system/foundation/grid)
 last_updated: 2020-01-28T15:55:47.394Z
-research: ""
+research: ''
 ---

--- a/package.json
+++ b/package.json
@@ -93,9 +93,6 @@
     "vite": "8.0.16",
     "vitest": "4.1.8"
   },
-  "prettier": {
-    "singleQuote": true
-  },
   "release-it": {
     "git": {
       "requireBranch": "main",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,9 @@
+/**
+ * @see https://prettier.io/docs/configuration
+ * @type {import("prettier").Config}
+ */
+const config = {
+  singleQuote: true,
+};
+
+export default config;


### PR DESCRIPTION
Makes the prettier config consistent with eslint, stylelint, etc., and fixes issue where single quote config was not being picked up locally.

## Changes

- Move prettier config to prettier.config.js

## Testing

1. PR checks should pass.
