### PR TITLE
Fixing GH pages deploy after adding storybook for web components.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ plugins:
 # Base configuration
 permalink: /:title
 exclude: [package.json, webpack.config.js, yarn.lock]
-keep_files: [web-components]
+keep_files: [web-components, .git]
 highlighter: rouge
 timezone: America/New_York
 source: docs


### PR DESCRIPTION
The default Jekyll behavior was to keep .git and .svn files. As soon as you add keep_files: to the config it will only keep the files specified.

[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots

| Before | After  |
| ------ | ------ |
|        |        |

## Notes and todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

Check the [current browser support cutoff list](https://cfpb.github.io/consumerfinance.gov/browser-support#current-browser-support-metrics) for browsers that are advisable
to prioritize for testing.

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
