### PR TITLE
fix logo to maintain aspect and make code text white on black background

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -38,8 +38,7 @@
   .sidebar-header img {
     height: 40px;
     width: auto;
-    max-height: 40px;
-    max-width: none;
+    object-fit: contain;
   }
 
   /* Hides the three-dot context menu button in the sidebar */

--- a/.storybook/preview.scss
+++ b/.storybook/preview.scss
@@ -4,3 +4,9 @@
 :root {
   --font-stack-branded: 'Source Sans 3 Variable', arial, sans-serif;
 }
+
+#storybook-docs pre {
+  background-color: #2b2b2b;
+  color: white;
+  line-height: 22px;
+}


### PR DESCRIPTION
CFPB logo was distorted  and code examples could wind up with black text on a black bg. This fixes both of those issues. 

`yarn start` and verify that cfpb logo is maintaining the correct aspect ratio. Then use any "Show code" and see that there is white text on black bg for any text string (vs markup)

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots

| Before | After  |
| ------ | ------ |
|        |        |

## Notes and todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

Check the [current browser support cutoff list](https://cfpb.github.io/consumerfinance.gov/browser-support#current-browser-support-metrics) for browsers that are advisable
to prioritize for testing.

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
