### PR TITLE
Get type check working in CI and locally by `yarn typecheck`

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,31 @@
+name: Typecheck
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Shared setup
+        uses:  ./.github/actions/shared-action-setup
+
+      # Regenerates the CEM, then type checks against it
+      # Catches stories that have drifted from a component's static properties
+      - name: Run typecheck
+        run: yarn typecheck
+
+      # The step above regenerates the CEM and types file in place, so a diff here means the
+      # commited CEM is stale. Run `yarn analyze` and commit the result.
+      - name: Check generated CEM is up to date
+        run: git diff --exit-code storybook/custom-elements.json storybook/custom-elements-types.d.ts

--- a/.storybook/themeCFPB.js
+++ b/.storybook/themeCFPB.js
@@ -9,7 +9,7 @@ export default create({
 
   brandTitle: 'CFPB Design System',
   brandImage: CfpbLogo,
-  brandURL: 'https://cfpb.github.io/design-system/web-components/',
+  brandUrl: 'https://cfpb.github.io/design-system/web-components/',
   brandTarget: '_blank',
 
   fontBase: token('--font-stack-branded'),

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "serve-decap": "npx decap-server",
     "start": "yarn build-storybook --output-dir docs/_site/design-system/web-components && concurrently --kill-others \"yarn serve-decap\" \"yarn serve-jekyll\" \"yarn build-docs-watch\"",
     "test": "vitest run",
+    "typecheck": "yarn analyze && tsc --noEmit",
     "cy": "./scripts/cypress.sh",
     "changelog": "./scripts/changelog.sh",
     "tokens": "style-dictionary build --config ./style-dictionary.config.js && yarn lint \"packages/cfpb-design-system/src/elements/**/*.css\"",

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -15,8 +15,8 @@ fi
 ## Run Prettier, See ignored paths in .prettierignore
 yarn exec prettier "./**/*.{js,jsx,ts,tsx,md,css,scss}" ${PRETTIER_FLAGS[@]}
 
-## Run JS linting. See ignored paths in eslint.config.js.
-yarn exec eslint "./{.,test,docs,packages}/**/*.js" ${ESLINT_FLAGS[@]}
+## Run JS/TS linting. See ignored paths in eslint.config.js.
+yarn exec eslint "./{.,test,docs,packages}/**/*.{js,ts,tsx}" ${ESLINT_FLAGS[@]}
 
 ## Run CSS linting. See ignored paths in .stylelintignore.
 yarn exec stylelint "{docs,packages}/**/*.{css,scss}" ${STYLELINT_FLAGS[@]}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "bundler",
+    // TS stories import JS components, so allow JS for module resolution only
     "allowJs": true,
     "checkJs": false,
     "strict": true,
@@ -10,5 +11,13 @@
     "skipLibCheck": true,
     "types": ["vite/client"]
   },
-  "include": [".storybook/**/*.js"]
+  "include": ["**/*.ts", "**.*.tsx"],
+  "exclude": [
+    "node_modules",
+    ".yarn",
+    "docs/_site",
+    "storybook-static",
+    "packages/*/dist",
+    "cypress"
+  ]
 }


### PR DESCRIPTION
Previous commit added TS files and types for the web components but didn't actually reach them. This corrects that.... so now all TS files are type checked. 

`tsc --noEmit` checks every `.ts/tsx` file in the repo (currently 4 storybook stories) against the components types generated by `yarn analyze` which should catch stories that have drifted from components `static properties`. 

Of note, plain JS files are never type checked. `checkJs` stays `false` so the `.js` files pulled into the program via imports serve only for inference. 

Overall the idea is that devs run `yarn typecheck` locally and that CI runs it's own type check on pushes and PRs to main which it follows up with a diff ... if that fails if that means the committed CEM is stale.  

Seperately, `yarn lint`'s eslint glob now includes `.ts/tsx` which gets us the rules that were already configured but unreachable previously. 

Also fixed typo in the theme for `brandUrl`

`yarn typecheck` and verify nothing fails
`yarn start` and verify that Storybook comes up on `http://localhost:4000/design-system/web-components/` with no regressions

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots

| Before | After  |
| ------ | ------ |
|        |        |

## Notes and todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

Check the [current browser support cutoff list](https://cfpb.github.io/consumerfinance.gov/browser-support#current-browser-support-metrics) for browsers that are advisable
to prioritize for testing.

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
