### PR TITLE
Normalize import of Web Components types across stories

### DIFF
--- a/packages/cfpb-design-system/src/elements/cfpb-expandable/cfpb-expandable.stories.ts
+++ b/packages/cfpb-design-system/src/elements/cfpb-expandable/cfpb-expandable.stories.ts
@@ -3,7 +3,7 @@ import { html } from 'lit';
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
 import { fn, userEvent, expect } from 'storybook/test';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
-import type { CfpbExpandableProps } from '../../../../../storybook/custom-elements-types.d.ts';
+import type { CfpbExpandableProps } from '../../../../../storybook/custom-elements-types';
 import { CfpbExpandable } from './index.js';
 
 CfpbExpandable.init();

--- a/packages/cfpb-design-system/src/elements/cfpb-tag-filter/cfpb-tag-filter.stories.ts
+++ b/packages/cfpb-design-system/src/elements/cfpb-tag-filter/cfpb-tag-filter.stories.ts
@@ -2,7 +2,7 @@
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
 import { fn, userEvent, expect } from 'storybook/test';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
-import type { CfpbTagFilterProps } from '../../../../../storybook/custom-elements-types.d.ts';
+import type { CfpbTagFilterProps } from '../../../../../storybook/custom-elements-types';
 import { CfpbTagFilter } from './index.js';
 
 CfpbTagFilter.init();

--- a/packages/cfpb-design-system/src/elements/cfpb-tagline/cfpb-tagline.stories.ts
+++ b/packages/cfpb-design-system/src/elements/cfpb-tagline/cfpb-tagline.stories.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
-import type { CfpbTaglineProps } from '../../../../../storybook/custom-elements-types.d.ts';
+import type { CfpbTaglineProps } from '../../../../../storybook/custom-elements-types';
 import { CfpbTagline } from './index.js';
 
 CfpbTagline.init();


### PR DESCRIPTION
Fix Web Component types import to be the same across all component story files. 

Previously there was a mix of:
`import type { CfpbExpandableProps } from '../../../../../storybook/custom-elements-types.d.ts';`

and 

`import type { CfpbExpandableProps } from '../../../../../storybook/custom-elements-types';`

Now all stories will have this pattern for importing the component type:
`import type { ... } from '../../../../../storybook/custom-elements-types';`

`yarn storybook` to verify that it builds and runs with no regressions

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots

| Before | After  |
| ------ | ------ |
|        |        |

## Notes and todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

Check the [current browser support cutoff list](https://cfpb.github.io/consumerfinance.gov/browser-support#current-browser-support-metrics) for browsers that are advisable
to prioritize for testing.

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
