### PR TITLE
Fix issue where form-level alerts didn't have right color configuration

### DIFF
--- a/packages/cfpb-design-system/dist/index.js
+++ b/packages/cfpb-design-system/dist/index.js
@@ -1278,7 +1278,7 @@ var st = (e) => {
     >
       <cfpb-icon
         name="${this.icon.name}-round"
-        color="${this.icon.colorVar}"
+        style="--icon-color: var(--${this.icon.colorVar})"
       ></cfpb-icon>
       <div class="a-form-alert__text"><slot></slot></div>
     </div>`;

--- a/packages/cfpb-design-system/src/elements/cfpb-form-alert/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-form-alert/index.js
@@ -53,7 +53,7 @@ export class CfpbFormAlert extends LitElement {
     >
       <cfpb-icon
         name="${this.icon.name}-round"
-        color="${this.icon.colorVar}"
+        style="--icon-color: var(--${this.icon.colorVar})"
       ></cfpb-icon>
       <div class="a-form-alert__text"><slot></slot></div>
     </div>`;


### PR DESCRIPTION
The color of the icons in the form level alerts was black, because the coloring of the icons has moved from a `color` attribute, to using inline styles that set a custom property.

## Changes

- Fix issue where form-level alerts didn't have right color configuration

## Testing

1. `yarn build && yarn start` and the form level alert examples have color.

## Screenshots

| Before | After  |
| ------ | ------ |
|<img width="193" height="145" alt="Screenshot 2026-07-29 at 8 54 08 AM" src="https://github.com/user-attachments/assets/9fe2024d-ac8e-44e0-8111-cc46053a698e" />|<img width="202" height="138" alt="Screenshot 2026-07-29 at 8 54 02 AM" src="https://github.com/user-attachments/assets/edb9283c-b4a2-4d1d-bbfc-e4ce31d341c5" />|
