### PR TITLE
Update cfpb-tagline story to use lowercase attr name and create CEM plugin to lowercase attr names

### DIFF
--- a/custom-elements-manifest.config.js
+++ b/custom-elements-manifest.config.js
@@ -18,6 +18,116 @@ function sortModulesPlugin() {
   };
 }
 
+/**
+ * True when `node` is a Lit `static properties` declaration, in either the
+ * `static properties = {}` or `static get properties() {}` forms.
+ * @param {object} node - The TS AST node to test.
+ * @param {object} ts - The TS module the analyzer is running with.
+ * @returns {boolean} - Whether the node declares Lit's reactive properties.
+ */
+function isStaticProperties(node, ts) {
+  return (
+    (ts.isPropertyDeclaration(node) || ts.isGetAccessor(node)) &&
+    node?.modifiers?.some((mod) => mod.kind === ts.SyntaxKind.StaticKeyword) &&
+    node.name?.getText() === 'properties'
+  );
+}
+
+/**
+ * Returns the object literal holding the individual property declarations.
+ * @param {object} node - A node that satisfies `isStaticProperties`.
+ * @param {object} ts - The TS module the analayzer is running with.
+ * @returns {object | undefined} - The object literal expression when present.
+ */
+function getPropertiesObject(node, ts) {
+  return ts.isGetAccessor(node)
+    ? node.body?.statements?.find(ts.isReturnStatement)?.expression
+    : node.initializer;
+}
+
+/**
+ * Plugin that removes the attributes that the analyzer invents for Lit's
+ * internal reactive state. Lit forces `attribute - false` whenever a property is
+ * declared `state: true` so those props would have no attribute in the DOM at all.
+ * The rub is that the analyzer's Lit plugin only skips a property when it sees a literal
+ * `attribute: false` it never checks `state`. The result is that internal state is
+ * published as public API, and Storybook renders attribute controls that silently do nothing
+ * because Lit is not observing the attribute they write to. Dropping the attr moves
+ * these props into Storybook's `properties` category, where these will actually work.
+ * @returns {import('custom-elements-manifest/analyzer').Plugin} - Returns the manifest without attributes for `state: true` properties
+ */
+function ignoreLitStatePropertiesPlugin() {
+  return {
+    name: 'ignore-list-state-properties',
+    analyzePhase({ ts, node, moduleDoc }) {
+      if (!isStaticProperties(node, ts)) return;
+
+      const stateNames = new Set();
+      for (const property of getPropertiesObject(node, ts)?.properties ?? []) {
+        if (property.kind !== ts.SyntaxKind.PropertyAssignment) continue;
+        const isState = (property.initializer?.properties ?? []).some(
+          (option) =>
+            option.name?.getText() === 'state' &&
+            option.initializer?.kind === ts.SyntaxKind.TrueKeyword,
+        );
+        if (isState) stateNames.add(property.name?.getText());
+      }
+      if (!stateNames.size) return;
+
+      //Scoped to this module so a state property in on file can never strip a
+      // same-named pub attr from another file
+      for (const declaration of moduleDoc.declarations ?? []) {
+        if (declaration.attributes) {
+          declaration.attributes = declaration.attributes.filter(
+            (attribute) => !stateNames.has(attribute.fieldName),
+          );
+        }
+        for (const member of declaration.members ?? []) {
+          if (!stateNames.has(member.name)) continue;
+          delete member.attribute;
+          delete member.reflects;
+        }
+      }
+    },
+  };
+}
+
+/**
+ * CEM analyzer plugin that lowercases attribute names the analyzer derived from a
+ * property name. When a `static properties` entry omits `attribute:` Lit derives the
+ * observed attribute with `name.toLowerCase()` EG `isLarge -> islarge` BUT the analyzer
+ * records the name verbatim. So, the manifest claims an attribute `isLarge` that never
+ * exists in the DOM. Consumers that trust the manifest then break because `getStorybookHelpers`
+ * renders `isLarge` and its arg-sync MutationObserver can't match the two. What that translates
+ * to is that a control will flip on and snaps back to the default. This plugin MUST run before
+ * `jsxTypesPlugin` in the array so generated types use the corrected name.
+ * @returns {import('custom-elements-manifest/analyzer').Plugin} - Returns the manifest with derived attribute names lowercased
+ */
+function lowercaseDerivedAttributesPlugin() {
+  return {
+    name: 'lowercase-derived-attributes',
+    packageLinkPhase({ customElementsManifest }) {
+      for (const module of customElementsManifest.modules) {
+        for (const declaration of module.declarations ?? []) {
+          for (const attribute of declaration.attributes ?? []) {
+            // An explicit `attribute:` makes the manifest differ from the field
+            // name. When they are identical the analyzer just copied the property name,
+            // which is the case Lit would have lowercased
+            if (attribute.name !== attribute.fieldName) continue;
+            const derived = attribute.name.toLowerCase();
+            if (derived === attribute.name) continue;
+            attribute.name = derived;
+            const member = declaration.members?.find(
+              (x) => x.kind === 'field' && x.name === attribute.fieldName,
+            );
+            if (member) member.attribute = derived;
+          }
+        }
+      }
+    },
+  };
+}
+
 export default {
   globs: ['packages/cfpb-design-system/src/elements/**/*.js'],
   exclude: ['**/*.spec.js', '**/utilities/**'],
@@ -25,6 +135,8 @@ export default {
   litelement: true,
   plugins: [
     sortModulesPlugin(),
+    ignoreLitStatePropertiesPlugin(),
+    lowercaseDerivedAttributesPlugin(),
     jsxTypesPlugin({
       outdir: 'storybook',
       fileName: 'custom-elements-types.d.ts',

--- a/packages/cfpb-design-system/src/elements/cfpb-tagline/cfpb-tagline.stories.ts
+++ b/packages/cfpb-design-system/src/elements/cfpb-tagline/cfpb-tagline.stories.ts
@@ -29,5 +29,5 @@ type Story = StoryObj<TagLineStoryArgs>;
 export const Default: Story = {};
 
 export const Large: Story = {
-  args: { isLarge: true },
+  args: { islarge: true },
 };

--- a/storybook/custom-elements-types.d.ts
+++ b/storybook/custom-elements-types.d.ts
@@ -477,6 +477,8 @@ export type CfpbFormSearchProps = {
   /**  */
   ariaLabelButton?: CfpbFormSearch['ariaLabelButton'];
   /**  */
+  searchlist?: CfpbFormSearch['searchList'];
+  /**  */
   searchList?: CfpbFormSearch['searchList'];
 };
 
@@ -505,6 +507,8 @@ export type CfpbFormSearchSolidJsProps = {
   'attr:aria-label-button'?: CfpbFormSearch['ariaLabelButton'];
   /**  */
   'prop:ariaLabelButton'?: CfpbFormSearch['ariaLabelButton'];
+  /**  */
+  'attr:searchlist'?: CfpbFormSearch['searchList'];
   /**  */
   'prop:searchList'?: CfpbFormSearch['searchList'];
 
@@ -625,10 +629,6 @@ export type CfpbLabelSolidJsProps = {
 
 export type CfpbLinkProps = {
   /**  */
-  linkText?: CfpbLink['linkText'];
-  /**  */
-  linkAttributes?: CfpbLink['linkAttributes'];
-  /**  */
   'link-variant'?: CfpbLink['linkVariant'];
   /**  */
   linkVariant?: CfpbLink['linkVariant'];
@@ -648,13 +648,13 @@ export type CfpbLinkProps = {
   noTopBorder?: CfpbLink['noTopBorder'];
   /**  */
   inline?: CfpbLink['inline'];
+  /**  */
+  linkText?: CfpbLink['linkText'];
+  /**  */
+  linkAttributes?: CfpbLink['linkAttributes'];
 };
 
 export type CfpbLinkSolidJsProps = {
-  /**  */
-  'prop:linkText'?: CfpbLink['linkText'];
-  /**  */
-  'prop:linkAttributes'?: CfpbLink['linkAttributes'];
   /**  */
   'attr:link-variant'?: CfpbLink['linkVariant'];
   /**  */
@@ -675,6 +675,10 @@ export type CfpbLinkSolidJsProps = {
   'prop:noTopBorder'?: CfpbLink['noTopBorder'];
   /**  */
   'prop:inline'?: CfpbLink['inline'];
+  /**  */
+  'prop:linkText'?: CfpbLink['linkText'];
+  /**  */
+  'prop:linkAttributes'?: CfpbLink['linkAttributes'];
 
   /** Set the innerHTML of the element */
   innerHTML?: string;
@@ -887,7 +891,11 @@ export type CfpbSelectProps = {
   /**  */
   isExpanded?: CfpbSelect['isExpanded'];
   /**  */
+  selectedtexts?: CfpbSelect['selectedTexts'];
+  /**  */
   selectedTexts?: CfpbSelect['selectedTexts'];
+  /**  */
+  optionlist?: CfpbSelect['optionList'];
   /**  */
   optionList?: CfpbSelect['optionList'];
   /**  */
@@ -929,7 +937,11 @@ export type CfpbSelectSolidJsProps = {
   /**  */
   'prop:isExpanded'?: CfpbSelect['isExpanded'];
   /**  */
+  'attr:selectedtexts'?: CfpbSelect['selectedTexts'];
+  /**  */
   'prop:selectedTexts'?: CfpbSelect['selectedTexts'];
+  /**  */
+  'attr:optionlist'?: CfpbSelect['optionList'];
   /**  */
   'prop:optionList'?: CfpbSelect['optionList'];
   /**  */
@@ -971,12 +983,16 @@ export type CfpbTagTopicProps = {
   /**  */
   href?: CfpbTagTopic['href'];
   /**  */
+  siblingofjumplink?: CfpbTagTopic['siblingOfJumpLink'];
+  /**  */
   siblingOfJumpLink?: CfpbTagTopic['siblingOfJumpLink'];
 };
 
 export type CfpbTagTopicSolidJsProps = {
   /**  */
   'prop:href'?: CfpbTagTopic['href'];
+  /**  */
+  'bool:siblingofjumplink'?: CfpbTagTopic['siblingOfJumpLink'];
   /**  */
   'prop:siblingOfJumpLink'?: CfpbTagTopic['siblingOfJumpLink'];
 
@@ -988,10 +1004,14 @@ export type CfpbTagTopicSolidJsProps = {
 
 export type CfpbTaglineProps = {
   /**  */
+  islarge?: CfpbTagline['isLarge'];
+  /**  */
   isLarge?: CfpbTagline['isLarge'];
 };
 
 export type CfpbTaglineSolidJsProps = {
+  /**  */
+  'bool:islarge'?: CfpbTagline['isLarge'];
   /**  */
   'prop:isLarge'?: CfpbTagline['isLarge'];
 
@@ -1131,9 +1151,9 @@ export type CustomElements = {
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
    * - `accept`: undefined
-   * - `isDetailHidden`: undefined
-   * - `fileName`: undefined
-   * - `files`: undefined
+   * - `isDetailHidden`: undefined (property only)
+   * - `fileName`: undefined (property only)
+   * - `files`: undefined (property only)
    *
    * ## Events
    *
@@ -1290,7 +1310,7 @@ export type CustomElements = {
    * - `placeholder`: undefined
    * - `aria-label-input`/`ariaLabelInput`: undefined
    * - `aria-label-button`/`ariaLabelButton`: undefined
-   * - `searchList`: undefined
+   * - `searchlist`/`searchList`: undefined
    * - `isSearchDisabled`: undefined (property only) (readonly)
    * - `isOverMaxLength`: undefined (property only) (readonly)
    *
@@ -1394,14 +1414,14 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `linkText`: undefined
-   * - `linkAttributes`: undefined
    * - `link-variant`/`linkVariant`: undefined
    * - `size`: undefined
    * - `color-theme`/`colorTheme`: undefined
    * - `no-underline`/`noUnderline`: undefined
    * - `no-top-border`/`noTopBorder`: undefined
    * - `inline`: undefined
+   * - `linkText`: undefined (property only)
+   * - `linkAttributes`: undefined (property only)
    *
    * ## Slots
    *
@@ -1608,8 +1628,8 @@ export type CustomElements = {
    * - `aria-label-input`/`ariaLabelInput`: undefined
    * - `aria-label-list`/`ariaLabelList`: undefined
    * - `open`/`isExpanded`: undefined
-   * - `selectedTexts`: undefined
-   * - `optionList`: undefined
+   * - `selectedtexts`/`selectedTexts`: undefined
+   * - `optionlist`/`optionList`: undefined
    * - `options`: undefined (property only)
    *
    * ## Events
@@ -1673,7 +1693,7 @@ export type CustomElements = {
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
    * - `href`: undefined
-   * - `siblingOfJumpLink`: undefined
+   * - `siblingofjumplink`/`siblingOfJumpLink`: undefined
    *
    * ## Slots
    *
@@ -1699,7 +1719,7 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `isLarge`: undefined
+   * - `islarge`/`isLarge`: undefined
    *
    * ## Slots
    *
@@ -1861,9 +1881,9 @@ export type CustomElementsSolidJs = {
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
    * - `accept`: undefined
-   * - `isDetailHidden`: undefined
-   * - `fileName`: undefined
-   * - `files`: undefined
+   * - `isDetailHidden`: undefined (property only)
+   * - `fileName`: undefined (property only)
+   * - `files`: undefined (property only)
    *
    * ## Events
    *
@@ -2035,7 +2055,7 @@ export type CustomElementsSolidJs = {
    * - `placeholder`: undefined
    * - `aria-label-input`/`ariaLabelInput`: undefined
    * - `aria-label-button`/`ariaLabelButton`: undefined
-   * - `searchList`: undefined
+   * - `searchlist`/`searchList`: undefined
    * - `isSearchDisabled`: undefined (property only) (readonly)
    * - `isOverMaxLength`: undefined (property only) (readonly)
    *
@@ -2149,14 +2169,14 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `linkText`: undefined
-   * - `linkAttributes`: undefined
    * - `link-variant`/`linkVariant`: undefined
    * - `size`: undefined
    * - `color-theme`/`colorTheme`: undefined
    * - `no-underline`/`noUnderline`: undefined
    * - `no-top-border`/`noTopBorder`: undefined
    * - `inline`: undefined
+   * - `linkText`: undefined (property only)
+   * - `linkAttributes`: undefined (property only)
    *
    * ## Slots
    *
@@ -2379,8 +2399,8 @@ export type CustomElementsSolidJs = {
    * - `aria-label-input`/`ariaLabelInput`: undefined
    * - `aria-label-list`/`ariaLabelList`: undefined
    * - `open`/`isExpanded`: undefined
-   * - `selectedTexts`: undefined
-   * - `optionList`: undefined
+   * - `selectedtexts`/`selectedTexts`: undefined
+   * - `optionlist`/`optionList`: undefined
    * - `options`: undefined (property only)
    *
    * ## Events
@@ -2452,7 +2472,7 @@ export type CustomElementsSolidJs = {
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
    * - `href`: undefined
-   * - `siblingOfJumpLink`: undefined
+   * - `siblingofjumplink`/`siblingOfJumpLink`: undefined
    *
    * ## Slots
    *
@@ -2481,7 +2501,7 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `isLarge`: undefined
+   * - `islarge`/`isLarge`: undefined
    *
    * ## Slots
    *

--- a/storybook/custom-elements.json
+++ b/storybook/custom-elements.json
@@ -733,8 +733,7 @@
               "type": {
                 "text": "boolean"
               },
-              "default": "true",
-              "attribute": "isDetailHidden"
+              "default": "true"
             },
             {
               "kind": "field",
@@ -743,8 +742,7 @@
               "type": {
                 "text": "string"
               },
-              "default": "''",
-              "attribute": "fileName"
+              "default": "''"
             },
             {
               "kind": "field",
@@ -753,8 +751,7 @@
               "type": {
                 "text": "null"
               },
-              "default": "null",
-              "attribute": "files"
+              "default": "null"
             },
             {
               "kind": "field",
@@ -782,30 +779,6 @@
                 "text": "string"
               },
               "fieldName": "accept"
-            },
-            {
-              "name": "isDetailHidden",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "true",
-              "fieldName": "isDetailHidden"
-            },
-            {
-              "name": "fileName",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "fieldName": "fileName"
-            },
-            {
-              "name": "files",
-              "type": {
-                "text": "null"
-              },
-              "default": "null",
-              "fieldName": "files"
             }
           ],
           "superclass": {
@@ -1641,7 +1614,7 @@
                 "text": "array"
               },
               "default": "[]",
-              "attribute": "searchList"
+              "attribute": "searchlist"
             },
             {
               "kind": "field",
@@ -1798,7 +1771,7 @@
               "fieldName": "ariaLabelButton"
             },
             {
-              "name": "searchList",
+              "name": "searchlist",
               "type": {
                 "text": "array"
               },
@@ -2339,7 +2312,6 @@
                 "text": "string"
               },
               "default": "''",
-              "attribute": "linkText",
               "inheritedFrom": {
                 "name": "MixinLink",
                 "module": "packages/cfpb-design-system/src/elements/cfpb-link/mixin-link/index.js"
@@ -2353,7 +2325,6 @@
                 "text": "object"
               },
               "default": "{}",
-              "attribute": "linkAttributes",
               "inheritedFrom": {
                 "name": "MixinLink",
                 "module": "packages/cfpb-design-system/src/elements/cfpb-link/mixin-link/index.js"
@@ -2457,30 +2428,6 @@
           "tagName": "cfpb-link.",
           "customElement": true,
           "attributes": [
-            {
-              "name": "linkText",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "fieldName": "linkText",
-              "inheritedFrom": {
-                "name": "MixinLink",
-                "module": "packages/cfpb-design-system/src/elements/cfpb-link/mixin-link/index.js"
-              }
-            },
-            {
-              "name": "linkAttributes",
-              "type": {
-                "text": "object"
-              },
-              "default": "{}",
-              "fieldName": "linkAttributes",
-              "inheritedFrom": {
-                "name": "MixinLink",
-                "module": "packages/cfpb-design-system/src/elements/cfpb-link/mixin-link/index.js"
-              }
-            },
             {
               "name": "link-variant",
               "type": {
@@ -2647,8 +2594,7 @@
               "type": {
                 "text": "string"
               },
-              "default": "''",
-              "attribute": "linkText"
+              "default": "''"
             },
             {
               "kind": "field",
@@ -2657,8 +2603,7 @@
               "type": {
                 "text": "object"
               },
-              "default": "{}",
-              "attribute": "linkAttributes"
+              "default": "{}"
             },
             {
               "kind": "field",
@@ -2722,22 +2667,6 @@
             }
           ],
           "attributes": [
-            {
-              "name": "linkText",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "fieldName": "linkText"
-            },
-            {
-              "name": "linkAttributes",
-              "type": {
-                "text": "object"
-              },
-              "default": "{}",
-              "fieldName": "linkAttributes"
-            },
             {
               "name": "link-variant",
               "type": {
@@ -4160,7 +4089,7 @@
                 "text": "array"
               },
               "default": "[]",
-              "attribute": "selectedTexts"
+              "attribute": "selectedtexts"
             },
             {
               "kind": "field",
@@ -4170,7 +4099,7 @@
                 "text": "array"
               },
               "default": "[]",
-              "attribute": "optionList"
+              "attribute": "optionlist"
             },
             {
               "kind": "field",
@@ -4368,7 +4297,7 @@
               "fieldName": "isExpanded"
             },
             {
-              "name": "selectedTexts",
+              "name": "selectedtexts",
               "type": {
                 "text": "array"
               },
@@ -4376,7 +4305,7 @@
               "fieldName": "selectedTexts"
             },
             {
-              "name": "optionList",
+              "name": "optionlist",
               "type": {
                 "text": "array"
               },
@@ -4755,7 +4684,7 @@
                 "text": "boolean"
               },
               "default": "false",
-              "attribute": "siblingOfJumpLink"
+              "attribute": "siblingofjumplink"
             }
           ],
           "attributes": [
@@ -4768,7 +4697,7 @@
               "fieldName": "href"
             },
             {
-              "name": "siblingOfJumpLink",
+              "name": "siblingofjumplink",
               "type": {
                 "text": "boolean"
               },
@@ -4827,13 +4756,13 @@
                 "text": "boolean"
               },
               "default": "false",
-              "attribute": "isLarge",
+              "attribute": "islarge",
               "reflects": true
             }
           ],
           "attributes": [
             {
-              "name": "isLarge",
+              "name": "islarge",
               "type": {
                 "text": "boolean"
               },


### PR DESCRIPTION
I created a CEM analyzer plugin that lowercases attribute names the analyzer derived from a property name. 

The bug in Storybook was when a `static properties` entry omits `attribute:` Lit derives the observed attribute with `name.toLowerCase()` EG `isLarge -> islarge` BUT the analyzer records the name verbatim. So, the manifest claims an attribute `isLarge` that never exists in the DOM which made it so when you set the bool `isLarge = true` Storybook could not resolve the name and the control would stay set to `true` but the component would blink large and then snap back to the small version immediately.

`yarn storybook` and navigate to the cfpb-tagline component and verify there no longer is an `isLarge` (notice the capital L) and instead it is `islarge` attribute name (which is proper HTML). Toggle the `islarge` from false -> true and verify that it sticks and does not revert.

Also review existing stories and verify there are no regressions.  

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots

| Before | After  |
| ------ | ------ |
|        |        |

## Notes and todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

Check the [current browser support cutoff list](https://cfpb.github.io/consumerfinance.gov/browser-support#current-browser-support-metrics) for browsers that are advisable
to prioritize for testing.

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
