### PR TITLE
Fix Vite config warnings

### DIFF
--- a/vite.config.base.js
+++ b/vite.config.base.js
@@ -9,7 +9,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@cfpb/cfpb-design-system': path.resolve(
-        __dirname,
+        import.meta.dirname,
         'packages/cfpb-design-system/',
       ),
     },

--- a/vite.config.docs.js
+++ b/vite.config.docs.js
@@ -1,31 +1,33 @@
 import { defineConfig, mergeConfig } from 'vite';
-import baseConfig from './vite.config.base';
+import baseConfig from './vite.config.base.js';
 import path from 'path';
 
+const dirname = import.meta.dirname;
+
 const specificConfig = defineConfig({
-  root: path.resolve(__dirname, 'docs/assets'),
+  root: path.resolve(dirname, 'docs/assets'),
   base: '/dist/',
 
   build: {
     modulePreload: false,
     cssCodeSplit: false,
-    outDir: path.resolve(__dirname, 'docs/dist'),
+    outDir: path.resolve(dirname, 'docs/dist'),
     emptyOutDir: true,
 
     rolldownOptions: {
       input: {
-        main: path.resolve(__dirname, 'docs/assets/js/main.js'),
+        main: path.resolve(dirname, 'docs/assets/js/main.js'),
         'admin-decap-cms': path.resolve(
-          __dirname,
+          dirname,
           'docs/assets/js/admin/decap-cms.js',
         ),
         'admin-main-preview': path.resolve(
-          __dirname,
+          dirname,
           'docs/assets/js/admin/main-preview.js',
         ),
-        interstitial: path.resolve(__dirname, 'docs/assets/js/interstitial.js'),
-        search: path.resolve(__dirname, 'docs/assets/js/search.js'),
-        styles: path.resolve(__dirname, 'docs/assets/js/styles.js'),
+        interstitial: path.resolve(dirname, 'docs/assets/js/interstitial.js'),
+        search: path.resolve(dirname, 'docs/assets/js/search.js'),
+        styles: path.resolve(dirname, 'docs/assets/js/styles.js'),
       },
       output: {
         entryFileNames: '[name].js',

--- a/vite.config.packages.js
+++ b/vite.config.packages.js
@@ -1,5 +1,5 @@
 import { defineConfig, mergeConfig } from 'vite';
-import baseConfig from './vite.config.base';
+import baseConfig from './vite.config.base.js';
 import path from 'node:path';
 
 const specificConfig = defineConfig({


### PR DESCRIPTION
## Changes

- Add file extension to imports.
- Replace `__dirname` with `import.meta.dirname`

## Testing

1. PR checks should pass.