### PR TITLE
Web Component story changes and fixes for cfpb-alert and  cfpb-expandable story

### DIFF
--- a/packages/cfpb-design-system/src/elements/cfpb-alert/cfpb-alert.stories.ts
+++ b/packages/cfpb-design-system/src/elements/cfpb-alert/cfpb-alert.stories.ts
@@ -21,9 +21,10 @@ const statusIcons = {
   loading: 'update',
 };
 
+// See cfpb-button.stories.ts for why properties is excluded
 const { args, argTypes, template } = getStorybookHelpers<CfpbAlertProps>(
   'cfpb-alert',
-  { excludeCategories: ['methods'] },
+  { excludeCategories: ['methods', 'properties'] },
 );
 
 type AlertStoryArgs = CfpbAlertProps & { 'default-slot'?: string };
@@ -36,7 +37,15 @@ const meta: Meta<AlertStoryArgs> = {
     ...args,
     status: 'info',
     message: 'Information alert',
-    'default-slot': 'You can also add an explanation to the alert.',
+    /**
+     * The explanation is wrapped in an element rather than slotted as text
+     * so the alert's `::slotted()` spacing applies to it. Text is not matched
+     * by `::slotted()`. A span is used instead of a `<p>` because slotted
+     * content stays in the light DOM. In the light DOM the global `<p> { margin: 0 0 15px }`
+     * in base.scss wins over slotted content. This matches the examples on the Docs page.
+     */
+    'default-slot':
+      '<span>You can also add an explanation to the alert.</span>',
   },
   argTypes: {
     ...argTypes,
@@ -64,7 +73,7 @@ export const MessageOnly: Story = {
 export const WithLinks: Story = {
   args: {
     'default-slot': `
-            <p>This is the explanation of the alert.</p>
+            <span>This is the explanation of the alert.</span>
             <cfpb-list gap="compact">
                 <cfpb-link link-variant="nav-right">
                     <a href="#">This is a link below the explanation</a>
@@ -81,7 +90,8 @@ export const Success: Story = {
   args: {
     status: 'success',
     message: '11 results',
-    'default-slot': 'This is an optional explanation of the success message.',
+    'default-slot':
+      '<span>This is an optional explanation of the success message.</span>',
   },
 };
 
@@ -89,7 +99,8 @@ export const Warning: Story = {
   args: {
     status: 'warning',
     message: 'No results found',
-    'default-slot': 'This is an optional explanation of the warning.',
+    'default-slot':
+      '<span>This is an optional explanation of the warning.</span>',
   },
 };
 
@@ -97,7 +108,8 @@ export const Error: Story = {
   args: {
     status: 'error',
     message: 'There was a problem with your submission',
-    'default-slot': 'This is an optional explanation of the error.',
+    'default-slot':
+      '<span>This is an optional explanation of the error.</span>',
   },
 };
 
@@ -105,7 +117,8 @@ export const Loading: Story = {
   args: {
     status: 'loading',
     message: 'Loading results',
-    'default-slot': 'This is an optional explanation of the loading state.',
+    'default-slot':
+      '<span>This is an optional explanation of the loading state.</span>',
   },
 };
 

--- a/packages/cfpb-design-system/src/elements/cfpb-button/cfpb-button.stories.ts
+++ b/packages/cfpb-design-system/src/elements/cfpb-button/cfpb-button.stories.ts
@@ -7,13 +7,21 @@ import { CfpbButton } from './index.js';
 CfpbButton.init();
 
 // Build the icon name list from the SVG filenames
+// TODO: Pull this out into a helper function
 const iconNames = Object.keys(
   import.meta.glob('../../components/cfpb-icons/icons/*.svg'),
 ).map((p) => p.split('/').pop()!.replace('.svg', ''));
 
+/**
+ * `properties` is excluded because wc-toolkit emits a control for both a prop
+ * and its attribute whenever the two are named differently (EG `styleAsLink and`
+ * `style-as-link`). Both describe one piece of state and `template()` binds both.
+ * In doing that it applys the prop _after_ the attr. So, leaving them in lets a property
+ * with a default overwrite whatever a story set through the attribute name
+ */
 const { args, argTypes, template } = getStorybookHelpers<CfpbButtonProps>(
   'cfpb-button',
-  { excludeCategories: ['methods'] },
+  { excludeCategories: ['methods', 'properties'] },
 );
 
 type ButtonStoryArgs = CfpbButtonProps & { 'default-slot'?: string };

--- a/packages/cfpb-design-system/src/elements/cfpb-expandable/cfpb-expandable.stories.ts
+++ b/packages/cfpb-design-system/src/elements/cfpb-expandable/cfpb-expandable.stories.ts
@@ -1,5 +1,4 @@
 /// <reference types="vite/client" />
-import { html } from 'lit';
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
 import { fn, userEvent, expect } from 'storybook/test';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
@@ -8,9 +7,16 @@ import { CfpbExpandable } from './index.js';
 
 CfpbExpandable.init();
 
-const { args, argTypes } = getStorybookHelpers<CfpbExpandableProps>(
+/**
+ * `properties` is excluded here. See `cfpb-button.stories.ts` for the reason.
+ * Specifically here `isExpanded` and `open` both describe once piece of state.
+ * `template()` binds both applying the prop _after_ the attribute. Leaving them in
+ * lets `isExpanded` default collapse the Expanded story. The prop still works on the
+ * element. See the behavior tests.....
+ */
+const { args, argTypes, template } = getStorybookHelpers<CfpbExpandableProps>(
   'cfpb-expandable',
-  { excludeCategories: ['methods'] },
+  { excludeCategories: ['methods', 'properties'] },
 );
 
 type ExpandableStoryArgs = CfpbExpandableProps & {
@@ -25,14 +31,10 @@ const meta: Meta<ExpandableStoryArgs> = {
   args: {
     ...args,
     'header-slot': 'Section header',
-    'content-slot': 'Expandable section content',
+    'content-slot': '<p>Expandable section content</p>',
   },
   argTypes,
-  render: ({ open, 'header-slot': header, 'content-slot': content }) =>
-    html`<cfpb-expandable ?open="${open}">
-      <span slot="header">${header}</span>
-      <p slot="content">${content}</p>
-    </cfpb-expandable>`,
+  render: (args) => template(args),
 };
 
 export default meta;
@@ -104,6 +106,26 @@ export const CollapseProgrammatically: Story = {
 
     await expect(expandable.isExpanded).toBe(false);
     await expect(button.getAttribute('aria-expanded')).toBe('false');
+  },
+};
+
+export const ExpandProgramamatically: Story = {
+  tags: ['!dev', '!autodocs'],
+  args: { open: false },
+  play: async ({ canvasElement }) => {
+    const expandable = canvasElement.querySelector(
+      'cfpb-expandable',
+    ) as CfpbExpandable;
+    const content = expandable.shadowRoot!.querySelector(
+      '.o-expandable__content',
+    )!;
+    expandable.isExpanded = true;
+    await expandable.updateComplete;
+
+    // The prop reflects to the attribute and drives the flyout open
+    await expect(expandable.hasAttribute('open')).toBe(true);
+    await expect(content.hasAttribute('hidden')).toBe(false);
+    await expect(content.classList.contains('u-max-height-default')).toBe(true);
   },
 };
 

--- a/packages/cfpb-design-system/src/elements/cfpb-tag-filter/cfpb-tag-filter.stories.ts
+++ b/packages/cfpb-design-system/src/elements/cfpb-tag-filter/cfpb-tag-filter.stories.ts
@@ -7,9 +7,10 @@ import { CfpbTagFilter } from './index.js';
 
 CfpbTagFilter.init();
 
+// See cfpb-button story for why `properties` is excluded
 const { args, argTypes, template } = getStorybookHelpers<CfpbTagFilterProps>(
   'cfpb-tag-filter',
-  { excludeCategories: ['methods'] },
+  { excludeCategories: ['methods', 'properties'] },
 );
 
 type TagFilterStoryArgs = CfpbTagFilterProps & { 'default-slot'?: string };

--- a/packages/cfpb-design-system/src/elements/cfpb-tagline/cfpb-tagline.stories.ts
+++ b/packages/cfpb-design-system/src/elements/cfpb-tagline/cfpb-tagline.stories.ts
@@ -6,9 +6,10 @@ import { CfpbTagline } from './index.js';
 
 CfpbTagline.init();
 
+// See cfpb-button story for why `properties` is excluded
 const { args, argTypes, template } = getStorybookHelpers<CfpbTaglineProps>(
   'cfpb-tagline',
-  { excludeCategories: ['methods'] },
+  { excludeCategories: ['methods', 'properties'] },
 );
 
 type TagLineStoryArgs = CfpbTaglineProps & { 'default-slot'?: string };
@@ -17,7 +18,10 @@ const meta: Meta<TagLineStoryArgs> = {
   title: 'Web Components/cfpb-tagline',
   component: 'cfpb-tagline',
   tags: ['autodocs'],
-  args,
+  args: {
+    ...args,
+    'default-slot': 'An official website of the United States government.',
+  },
   argTypes,
   render: (args) => template(args),
 };


### PR DESCRIPTION
Alerts content was not wrapped in <span> like the docs page examples. This lead to incorrect margin-bottom of 15px. Expandable Storybook UI controls for props were not working as expected so hiding them. (the cfpb-expandable component works fine though!). In general hiding all `properties` in our stories. 

This is because: `properties` is excluded because wc-toolkit emits a control for both a prop and its attribute whenever the two are named differently (EG `styleAsLink` and `style-as-link`). Both describe one piece of state and `template()` binds both. In doing that it applys the prop _after_ the attr and can mess up any setting the attr uses. The properties still work on the elements themselves, this is just an issue with `wc-toolkit storybook helpers`. 

Hiding in the SB UI seems acceptable here because these are Web Components and as such we should be prefering HTML attributes over props. 

`yarn storybook` and verify that in `cfpb-alert` story there is the correct spacing between the description and the link list. Verify that properties are hidden the Storybook UI.  Verify all tests pass or skip. 

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots

| Before | After  |
| ------ | ------ |
|        |        |

## Notes and todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

Check the [current browser support cutoff list](https://cfpb.github.io/consumerfinance.gov/browser-support#current-browser-support-metrics) for browsers that are advisable
to prioritize for testing.

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
