### PR TITLE
Revert "Update e2e so that we cache Playwright browser (#2786)"

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,25 +15,8 @@ jobs:
       - name: Shared setup
         uses:  ./.github/actions/shared-action-setup
 
-      - name: Resolve Playwright version
-        id: playwright-version
-        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
-
-      # Browser binaries live outside node_modules. Key on the exact
-      # Playwright version. A version bump must miss the cache, so don't restore
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 https://github.com/actions/cache/releases
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-chromium-shell
-
-      # --only-shell downloads just the chromium headless shell
-      # which is what all these headless tests need. If a run ever
-      # fails on a missing shared lib, add a step `npx playwright install-deps chromium`
-      - name: Install Playwright chromium
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --only-shell chromium 
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        run: npx playwright test --project=chromium
+        run: npx playwright test


### PR DESCRIPTION
This reverts commit 3e68dacc388d42e8f5c684c79fb1d52ea57ccc82.

Generally the above commit and subsequent [PR](https://github.com/cfpb/design-system/pull/2786) is the right idea.

Reverting because there are these issues with the commit:

CI passes when there are failing tests currently
Tests fail in CI but pass locally
I didn't save Chromium once it was d/l resulting in it never getting cached if the tests failed.


[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots

| Before | After  |
| ------ | ------ |
|        |        |

## Notes and todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

Check the [current browser support cutoff list](https://cfpb.github.io/consumerfinance.gov/browser-support#current-browser-support-metrics) for browsers that are advisable
to prioritize for testing.

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
