### PR TITLE
Update cfpb-tagline story to use attr name in code example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,11 +103,11 @@ First, set some credentials:
 1. Check that you are logged in with `npm whoami`. If you aren't shown your username, run `npm login`.
 1. Launch a terminal and navigate to the cfpb-design-system repo on your system.
 1. Once in the repo, make sure you have a clean change list and do a `git push --dry-run origin main` this should trigger
-   GitHub authentication. *If you do not do this `yarn release` may stall out at the `git push` step while trying to run `yarn release`.*
+   GitHub authentication. _If you do not do this `yarn release` may stall out at the `git push` step while trying to run `yarn release`._
 1. When prompted in the terminal for GitHub username and password, use the GitHub username/email account that you created the PAT with. **When prompted
    for password supply your PAT!**
 1. The terminal should now show `git push --dry-run origin main` completed with a message `Everything up-to-date`.
-1. At this point you should be able to progress through the remaining steps 
+1. At this point you should be able to progress through the remaining steps
 
 **Note:** If you run into issues with your npm account not approving your MFA code, try resetting your npm password at npmjs.com.
 
@@ -115,7 +115,7 @@ Then, do a release:
 
 1. Ensure you're on the `main` branch with `git checkout main`
    and pull latest with `git pull`.
-1. Run `GITHUB_TOKEN=your_pat..... yarn release` in a terminal. <-replace the `your_pat....` with the one you generated. 
+1. Run `GITHUB_TOKEN=your_pat..... yarn release` in a terminal. <-replace the `your_pat....` with the one you generated.
 1. Follow the prompts to decide what version (major, minor, or patch)
    you will be releasing.
 

--- a/packages/cfpb-design-system/src/elements/cfpb-tagline/cfpb-tagline.stories.ts
+++ b/packages/cfpb-design-system/src/elements/cfpb-tagline/cfpb-tagline.stories.ts
@@ -33,5 +33,5 @@ type Story = StoryObj<TagLineStoryArgs>;
 export const Default: Story = {};
 
 export const Large: Story = {
-  args: { isLarge: true },
+  args: { islarge: true },
 };


### PR DESCRIPTION
The story for cfpb-tagline was not correctly showing the attribute name in the "large" tagline example. 

This fixes it to use the attr name in the Storybook example

`yarn storybook` and verify that in the large tagline code example you see:

```html
<cfpb-tagline islarge="true">
  An official website of the United States government.
</cfpb-tagline>
```

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots

| Before | After  |
| ------ | ------ |
|        |        |

## Notes and todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

Check the [current browser support cutoff list](https://cfpb.github.io/consumerfinance.gov/browser-support#current-browser-support-metrics) for browsers that are advisable
to prioritize for testing.

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
