### PR TITLE
Fix: Pinning server-decap to 3.11.0 so `yarn start` works again

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "release": "./scripts/release.sh",
     "serve-html": "http-server docs/_site",
     "serve-jekyll": "bundle exec jekyll serve --watch --profile --host=localhost --port=4000",
-    "serve-decap": "npx decap-server",
+    "serve-decap": "npx decap-server@3.11.0",
     "start": "yarn build-storybook --output-dir docs/_site/design-system/web-components && concurrently --kill-others \"yarn serve-decap\" \"yarn serve-jekyll\" \"yarn build-docs-watch\"",
     "test": "vitest run",
     "typecheck": "yarn analyze && tsc --noEmit",


### PR DESCRIPTION
`yarn start` was not working on main. Did some digging and found: https://github.com/decaporg/decap-cms/issues/7979

Pinning to last known good version while we wait on a fix. 

`yarn start` and everything should come up again and function normally.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots

| Before | After  |
| ------ | ------ |
|        |        |

## Notes and todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

Check the [current browser support cutoff list](https://cfpb.github.io/consumerfinance.gov/browser-support#current-browser-support-metrics) for browsers that are advisable
to prioritize for testing.

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
