### PR TITLE
Refactor JSDoc comments and helpers for testing and Stories

### DIFF
--- a/.storybook/plugins/story-helpers.ts
+++ b/.storybook/plugins/story-helpers.ts
@@ -1,0 +1,53 @@
+/// <reference types="vite/client" />
+import { html } from 'lit';
+
+/**
+ * Helpers that are shared across `*.stories.ts` files
+ *
+ * Things that go here should be Storybook-only. Component behavior helpers
+ * belong in `test/plugins/element-helpers.js`.
+ *
+ */
+
+/**
+ * Every icon name the DS ships is taken from the SVG filenames, so a new icon
+ * shows up in the controls withouth anyone editing a story.
+ *
+ * `import.meta.glob` is resolved by Vite and is realtive to this file, so the path
+ * is from `.storybook/`.
+ */
+export const iconNames: string[] = Object.keys(
+  import.meta.glob(
+    '../../packages/cfpb-design-system/src/components/cfpb-icons/icons/*.svg',
+  ),
+)
+  .map((path) => path.split('/').pop()!.replace('.svg', ''))
+  .sort();
+
+/**
+ * A Storybook select control listing every icon name.
+ *
+ * The empty string is first and is the default, so a component that takes an
+ * optional icon starts out without one.
+ * @returns {object} An argType control definition for an icon name property
+ */
+export function iconControl() {
+  return {
+    control: 'select' as const,
+    options: ['', ...iconNames],
+  };
+}
+
+/**
+ * Make sure that components that show menus don't get cut off by the Story canvas.
+ *
+ * Storybook sizes the canvas iframe based on the story's content, and the open
+ * menu extends past the bottom of the iframe and appears cut off. Specifically,
+ * `cfpb-select` and `cfpb-form-search`.
+ * @param {string} [minHeight] - CSS length for the reserved space.
+ * @returns {(story: () => unknown) => unknown} A Storybook decorator.
+ */
+export function reserveOverlayRoom(minHeight = '20rem') {
+  return (story: () => unknown) =>
+    html`<div style="min-height: ${minHeight}">${story()}</div>`;
+}

--- a/packages/cfpb-design-system/src/elements/cfpb-alert/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-alert/index.js
@@ -7,6 +7,8 @@ import { CfpbList } from '../cfpb-list';
 /**
  * @element cfpb-alert
  * @slot - The main content for the tagline.
+ * @property {string} status - The alert status: error, success, warning, info, loading.
+ * @property {string} message - The message heading on an alert.
  */
 export class CfpbAlert extends LitElement {
   static styles = css`
@@ -14,8 +16,6 @@ export class CfpbAlert extends LitElement {
   `;
 
   /**
-   * @property {string} status - The alert status: error, success, warning, info, loading.
-   * @property {string} message - The message heading on an alert.
    * @returns {object} The map of properties.
    */
   static properties = {

--- a/packages/cfpb-design-system/src/elements/cfpb-alert/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-alert/index.js
@@ -15,9 +15,6 @@ export class CfpbAlert extends LitElement {
     ${unsafeCSS(styles)}
   `;
 
-  /**
-   * @returns {object} The map of properties.
-   */
   static properties = {
     status: { type: String },
     message: { type: String },

--- a/packages/cfpb-design-system/src/elements/cfpb-alert/index.spec.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-alert/index.spec.js
@@ -1,4 +1,7 @@
+import { mount, cleanup } from '../../../../../test/plugins/element-helpers.js';
 import { CfpbAlert } from './index.js';
+
+CfpbAlert.init();
 
 // The icon each status renders, per the component's icon getter
 const statusIcons = {
@@ -9,25 +12,17 @@ const statusIcons = {
   loading: 'update',
 };
 
-describe('<cfpb-alert', () => {
+describe('<cfpb-alert>', () => {
   let elm;
 
   beforeEach(async () => {
-    CfpbAlert.init();
-    elm = document.createElement('cfpb-alert');
-    elm.setAttribute('status', 'info');
-    elm.setAttribute('message', 'Information alert');
-    elm.innerHTML =
-      '<span>You can also add an explanation to the alert.</span>';
-    document.body.appendChild(elm);
-
-    await customElements.whenDefined('cfpb-alert');
-    await elm.updateComplete;
+    elm = await mount('cfpb-alert', {
+      attributes: { status: 'info', message: 'Information alert' },
+      html: '<span>You can also add an explanation to the alert.</span>',
+    });
   });
 
-  afterEach(() => {
-    document.body.removeChild(elm);
-  });
+  afterEach(cleanup);
 
   it('renders the message', () => {
     const message = elm.shadowRoot.querySelector('.message');

--- a/packages/cfpb-design-system/src/elements/cfpb-button/cfpb-button.stories.ts
+++ b/packages/cfpb-design-system/src/elements/cfpb-button/cfpb-button.stories.ts
@@ -3,14 +3,9 @@ import type { Meta, StoryObj } from '@storybook/web-components-vite';
 import { getStorybookHelpers } from '@wc-toolkit/storybook-helpers';
 import type { CfpbButtonProps } from '../../../../../storybook/custom-elements-types';
 import { CfpbButton } from './index.js';
+import { iconControl } from '../../../../../.storybook/plugins/story-helpers';
 
 CfpbButton.init();
-
-// Build the icon name list from the SVG filenames
-// TODO: Pull this out into a helper function
-const iconNames = Object.keys(
-  import.meta.glob('../../components/cfpb-icons/icons/*.svg'),
-).map((p) => p.split('/').pop()!.replace('.svg', ''));
 
 /**
  * `properties` is excluded because wc-toolkit emits a control for both a prop
@@ -41,14 +36,8 @@ const meta: Meta<ButtonStoryArgs> = {
       control: 'select',
       options: ['primary', 'secondary', 'warning'],
     },
-    'icon-left': {
-      control: 'select',
-      options: ['', ...iconNames],
-    },
-    'icon-right': {
-      control: 'select',
-      options: ['', ...iconNames],
-    },
+    'icon-left': iconControl(),
+    'icon-right': iconControl(),
   },
   render: (args) => template(args),
 };

--- a/packages/cfpb-design-system/src/elements/cfpb-button/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-button/index.js
@@ -21,8 +21,8 @@ const VALID_TYPES = ['button', 'submit', 'reset'];
  * @property {string} variant - The button variant: primary, secondary, or warning.
  * @property {string} iconLeft - The name of the icon on the left.
  * @property {string} iconRight - The name of the icon on the right.
- * @property {string} isIconLeftSpin - Whether the left icon spins or not.
- * @property {string} isIconRightSpin - Whether the right icon spins or not.
+ * @property {boolean} isIconLeftSpin - Whether the left icon spins or not.
+ * @property {boolean} isIconRightSpin - Whether the right icon spins or not.
  * @property {boolean} fullOnMobile - Whether to be width 100% on mobile.
  * @property {boolean} flushLeft - Whether button is not rounded on left.
  * @property {boolean} flushRight - Whether button is not rounded on right.

--- a/packages/cfpb-design-system/src/elements/cfpb-button/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-button/index.js
@@ -15,28 +15,24 @@ const VALID_TYPES = ['button', 'submit', 'reset'];
  *
  * @element cfpb-button
  * @slot - The main content for the button.
+ * @property {string} type - The button type: button, submit, or reset.
+ * @property {string} href - The URL to link to (makes the button a link).
+ * @property {boolean} disabled - Whether the button is disabled or not.
+ * @property {string} variant - The button variant: primary, secondary, or warning.
+ * @property {string} iconLeft - The name of the icon on the left.
+ * @property {string} iconRight - The name of the icon on the right.
+ * @property {string} isIconLeftSpin - Whether the left icon spins or not.
+ * @property {string} isIconRightSpin - Whether the right icon spins or not.
+ * @property {boolean} fullOnMobile - Whether to be width 100% on mobile.
+ * @property {boolean} flushLeft - Whether button is not rounded on left.
+ * @property {boolean} flushRight - Whether button is not rounded on right.
+ * @property {boolean} styleAsLink - Style the button as a link.
  */
 export class CfpbButton extends LitElement {
   static styles = css`
     ${unsafeCSS(styles)}
   `;
 
-  /**
-   * @property {string} type - The button type: button, submit, or reset.
-   * @property {string} href - The URL to link to (makes the button a link).
-   * @property {boolean} disabled - Whether the button is disabled or not.
-   * @property {string} variant
-   *   The button variant: primary, secondary, or warning.
-   * @property {string} iconLeft - The name of the icon on the left.
-   * @property {string} iconRight - The name of the icon on the right.
-   * @property {string} isIconLeftSpin - Whether the left icon spins or not.
-   * @property {string} isIconRightSpin - Whether the right icon spins or not.
-   * @property {boolean} fullOnMobile - Whether to be width 100% on mobile.
-   * @property {boolean} flushLeft - Whether button is not rounded on left.
-   * @property {boolean} flushRight - Whether button is not rounded on right.
-   * @property {boolean} styleAsLink - Style the button as a link.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     type: { type: String },
     href: { type: String },

--- a/packages/cfpb-design-system/src/elements/cfpb-button/index.spec.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-button/index.spec.js
@@ -1,38 +1,21 @@
 import { expect } from 'vitest';
+import { mount, cleanup } from '../../../../../test/plugins/element-helpers.js';
 import { CfpbButton } from './index.js';
 
-/**
- * Mount a cfpb-button with the given attributes and wait for the first render.
- * @param {object} attributes - Attribute name/value pairs to set on the element.
- * @returns {Promise<HTMLElement>} The mounted element.
- */
-async function mount(attributes = {}) {
-  CfpbButton.init();
+CfpbButton.init();
 
-  const elm = document.createElement('cfpb-button');
-  for (const [name, value] of Object.entries(attributes)) {
-    elm.setAttribute(name, value);
-  }
-  elm.textContent = 'Button label';
-  document.body.appendChild(elm);
-
-  await customElements.whenDefined('cfpb-button');
-  await elm.updateComplete;
-
-  return elm;
-}
+// Every mount in this file slots the same label; only attributes vary.
+const mountButton = (attributes) =>
+  mount('cfpb-button', { attributes, text: 'Button label' });
 
 describe('<cfpb-button>', () => {
   let elm;
 
-  afterEach(() => {
-    if (elm?.parentNode) document.body.removeChild(elm);
-    elm = undefined;
-  });
+  afterEach(cleanup);
 
   describe('button form', () => {
     it('renders a button of type "button" by default', async () => {
-      elm = await mount();
+      elm = await mountButton();
       const button = elm.shadowRoot.querySelector('button');
 
       expect(button).not.toBeNull();
@@ -41,28 +24,28 @@ describe('<cfpb-button>', () => {
     });
 
     it.each(['submit', 'reset'])('honors the "%s" type', async (type) => {
-      elm = await mount({ type });
+      elm = await mountButton({ type });
       const button = elm.shadowRoot.querySelector('button');
 
       expect(button.getAttribute('type')).toBe(type);
     });
 
     it('falls back to type "button" for an invalid type', async () => {
-      elm = await mount({ type: 'not-a-type' });
+      elm = await mountButton({ type: 'not-a-type' });
       const button = elm.shadowRoot.querySelector('button');
 
       expect(button.getAttribute('type')).toBe('button');
     });
 
     it('disables the button whenthe disabled attribute is set', async () => {
-      elm = await mount({ disabled: '' });
+      elm = await mountButton({ disabled: '' });
       const button = elm.shadowRoot.querySelector('button');
 
       expect(button.disabled).toBe(true);
     });
 
     it('passes the disabled state down to the icon text', async () => {
-      elm = await mount({ disabled: '' });
+      elm = await mountButton({ disabled: '' });
       const iconText = elm.shadowRoot.querySelector('cfpb-icon-text');
 
       expect(iconText.hasAttribute('disabled')).toBe(true);
@@ -74,21 +57,21 @@ describe('<cfpb-button>', () => {
       ['secondary', 'a-btn--secondary'],
       ['warning', 'a-btn--warning'],
     ])('adds the %s modifier class', async (variant, className) => {
-      elm = await mount({ variant });
+      elm = await mountButton({ variant });
       const button = elm.shadowRoot.querySelector('button');
 
       expect(button.classList.contains(className)).toBe(true);
     });
 
     it('adds no modifier class for the primary variant', async () => {
-      elm = await mount({ variant: 'primary' });
+      elm = await mountButton({ variant: 'primary' });
       const button = elm.shadowRoot.querySelector('button');
 
       expect([...button.classList]).toEqual(['a-btn']);
     });
 
     it('falls back to primary for an invalid variant', async () => {
-      elm = await mount({ variant: 'not-a-variant' });
+      elm = await mountButton({ variant: 'not-a-variant' });
       const button = elm.shadowRoot.querySelector('button');
 
       // Primary renders no modifier, so the fallback is an `a-btn` only class list
@@ -98,7 +81,7 @@ describe('<cfpb-button>', () => {
 
   describe('link form', () => {
     it('renders an anchor with role="button" when href is set', async () => {
-      elm = await mount({ href: '#' });
+      elm = await mountButton({ href: '#' });
       const anchor = elm.shadowRoot.querySelector('a');
 
       expect(anchor).not.toBeNull();
@@ -110,14 +93,14 @@ describe('<cfpb-button>', () => {
     });
 
     it('adds the link modifier class when styled as link', async () => {
-      elm = await mount({ href: '#', 'style-as-link': '' });
+      elm = await mountButton({ href: '#', 'style-as-link': '' });
       const anchor = elm.shadowRoot.querySelector('a');
 
       expect(anchor.classList.contains('a-btn--link')).toBe(true);
     });
 
     it('removes a disabled link from the tab order', async () => {
-      elm = await mount({ href: '#', disabled: '' });
+      elm = await mountButton({ href: '#', disabled: '' });
       const anchor = elm.shadowRoot.querySelector('a');
 
       expect(anchor.getAttribute('aria-disabled')).toBe('true');
@@ -125,7 +108,7 @@ describe('<cfpb-button>', () => {
     });
 
     it('does no point a disabled link at its href target', async () => {
-      elm = await mount({ href: '#', disabled: '' });
+      elm = await mountButton({ href: '#', disabled: '' });
       const anchor = elm.shadowRoot.querySelector('a');
 
       expect(anchor.getAttribute('href')).not.toBe('#');

--- a/packages/cfpb-design-system/src/elements/cfpb-checkbox-icon/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-checkbox-icon/index.js
@@ -8,6 +8,10 @@ const VALID_VALIDATION = ['error', 'warning', 'success'];
 
 /**
  * @element cfpb-checkbox-icon
+ * @property {boolean} borderless - Whether the checkbox has a border or not.
+ * @property {boolean} checked - Whether the checkbox is checked or not.
+ * @property {boolean} disabled - Whether the checkbox is disabled or not.
+ * @property {string} validation - Validation style: error, warning, success.
  */
 export class CfpbCheckboxIcon extends LitElement {
   static styles = css`
@@ -17,13 +21,6 @@ export class CfpbCheckboxIcon extends LitElement {
   #hover;
   #focus;
 
-  /**
-   * @property {boolean} borderless - Whether the checkbox has a border or not.
-   * @property {boolean} checked - Whether the checkbox is checked or not.
-   * @property {boolean} disabled - Whether the checkbox is disabled or not.
-   * @property {string} validation - Validation style: error, warning, success.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     borderless: { type: Boolean, reflect: true },
     checked: { type: Boolean, reflect: true },

--- a/packages/cfpb-design-system/src/elements/cfpb-expandable/cfpb-expandable.stories.ts
+++ b/packages/cfpb-design-system/src/elements/cfpb-expandable/cfpb-expandable.stories.ts
@@ -41,102 +41,75 @@ export default meta;
 
 type Story = StoryObj<ExpandableStoryArgs>;
 
+/**
+ * The component has two visual states so it has two stories.
+ * All four of its events are driven by the same click that moves between
+ * these states so each story asserts the begin/end pair for its own
+ * direction rather than splitting into a story per event.
+ *
+ * Programatic expand/collapse is covered in index.spec.js
+ * See STORYBOOK.md for the split.
+ */
+
+/**
+ * Drive the CSS transition to completion.
+ *
+ * BaseTransition registers on 'webkitTransitionEnd' in Chromium (the first
+ * match in its prefix map) so the synthetic event has to use that name
+ * rather than the standard 'transitioned'
+ * @param {Element} content - The expandable's content element/
+ */
+function finishTransition(content: Element) {
+  content.dispatchEvent(
+    new TransitionEvent('webkitTransitionEnd', {
+      propertyName: 'max-height',
+    }),
+  );
+}
+
 export const Default: Story = {
   args: { open: false },
-};
-
-export const ExpandBegin: Story = {
-  tags: ['!dev', '!autodocs'],
   play: async ({ canvasElement }) => {
     const expandable = canvasElement.querySelector(
       'cfpb-expandable',
     ) as CfpbExpandable;
-    const spy = fn();
-    expandable.addEventListener('expandbegin', spy);
+    const onExpandBegin = fn();
+    const onExpandEnd = fn();
+    expandable.addEventListener('expandbegin', onExpandBegin);
+    expandable.addEventListener('expandend', onExpandEnd);
 
     const button = expandable.shadowRoot!.querySelector('button')!;
-    await userEvent.click(button);
+    const content = expandable.shadowRoot!.querySelector(
+      '.o-expandable__content',
+    )!;
 
-    await expect(spy).toHaveBeenCalledOnce();
+    await userEvent.click(button);
+    await expect(onExpandBegin).toHaveBeenCalledOnce();
+
+    finishTransition(content);
+    await expect(onExpandEnd).toHaveBeenCalledOnce();
   },
 };
 
 export const Expanded: Story = {
   args: { open: true },
-};
-
-export const CollapseOnClick: Story = {
-  tags: ['!dev', '!autodocs'],
-  args: { open: true },
   play: async ({ canvasElement }) => {
     const expandable = canvasElement.querySelector(
       'cfpb-expandable',
     ) as CfpbExpandable;
-    const spy = fn();
-    expandable.addEventListener('collapseend', spy);
+    const onCollapseBegin = fn();
+    const onCollapseEnd = fn();
+    expandable.addEventListener('collapsebegin', onCollapseBegin);
+    expandable.addEventListener('collapseend', onCollapseEnd);
 
     const button = expandable.shadowRoot!.querySelector('button')!;
     const content = expandable.shadowRoot!.querySelector(
       '.o-expandable__content',
     )!;
     await userEvent.click(button);
+    await expect(onCollapseBegin).toHaveBeenCalledOnce();
 
-    // BaseTransition registers on 'webketTransitionEnd' in Chromium (first match
-    // in its prefix map), so the synthetic event must use that name (not transitioned)
-    content.dispatchEvent(
-      new TransitionEvent('webkitTransitionEnd', {
-        propertyName: 'max-height',
-      }),
-    );
-
-    await expect(spy).toHaveBeenCalledOnce();
-  },
-};
-
-/**
- * Programatic expand/collapse is covered in index.spec.js
- * The event tests below stay here because they are driven
- * by user interaction.
- */
-
-export const ExpandEnd: Story = {
-  tags: ['!dev', '!autodocs'],
-  play: async ({ canvasElement }) => {
-    const expandable = canvasElement.querySelector(
-      'cfpb-expandable',
-    ) as CfpbExpandable;
-    const spy = fn();
-    expandable.addEventListener('expandend', spy);
-
-    const button = expandable.shadowRoot!.querySelector('button')!;
-    const content = expandable.shadowRoot!.querySelector(
-      '.o-expandable__content',
-    )!;
-    await userEvent.click(button);
-
-    content.dispatchEvent(
-      new TransitionEvent('webkitTransitionEnd', {
-        propertyName: 'max-height',
-      }),
-    );
-
-    await expect(spy).toHaveBeenCalledOnce();
-  },
-};
-
-export const CollapseBegin: Story = {
-  tags: ['!dev', '!autodocs'],
-  args: { open: true },
-  play: async ({ canvasElement }) => {
-    const expandable = canvasElement.querySelector(
-      'cfpb-expandable',
-    ) as CfpbExpandable;
-    const spy = fn();
-    expandable.addEventListener('collapsebegin', spy);
-
-    const button = expandable.shadowRoot!.querySelector('button')!;
-    await userEvent.click(button);
-
-    await expect(spy).toHaveBeenCalledOnce();
+    finishTransition(content);
+    await expect(onCollapseEnd).toHaveBeenCalledOnce();
   },
 };

--- a/packages/cfpb-design-system/src/elements/cfpb-expandable/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-expandable/index.js
@@ -14,6 +14,7 @@ import { FlyoutMenu } from '../../utilities/behavior/flyout-menu';
  * @fires expandend - The expandable finshed expanding.
  * @fires collapsebegin - The expandables started collapsing.
  * @fires collapseend - The expandables finished collapsing.
+ * @property {boolean} isExpanded - Whether the expandable is expanded or not.
  */
 export class CfpbExpandable extends LitElement {
   static styles = css`
@@ -23,10 +24,6 @@ export class CfpbExpandable extends LitElement {
   #flyoutMenu;
   #transition;
 
-  /**
-   * @property {boolean} isExpanded - Whether the expandable is expanded or not.
-   * @returns {object} The map of properties.
-   */
   static get properties() {
     return {
       isExpanded: { type: Boolean, attribute: 'open', reflect: true },

--- a/packages/cfpb-design-system/src/elements/cfpb-file-upload/index.spec.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-file-upload/index.spec.js
@@ -1,20 +1,16 @@
+import { mount, cleanup } from '../../../../../test/plugins/element-helpers.js';
 import { CfpbFileUpload } from './index.js';
+
+CfpbFileUpload.init();
 
 describe('<cfpb-file-upload>', () => {
   let elm;
 
   beforeEach(async () => {
-    CfpbFileUpload.init();
-    elm = document.createElement('cfpb-file-upload');
-    document.body.appendChild(elm);
-
-    await customElements.whenDefined('cfpb-file-upload');
-    await elm.updateComplete;
+    elm = await mount('cfpb-file-upload');
   });
 
-  afterEach(() => {
-    document.body.removeChild(elm);
-  });
+  afterEach(cleanup);
 
   it('renders with hidden details initially', () => {
     const details = elm.shadowRoot.querySelector('[part="upload-details"]');

--- a/packages/cfpb-design-system/src/elements/cfpb-form-alert/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-form-alert/index.js
@@ -6,16 +6,13 @@ import { CfpbIcon } from '../cfpb-icon';
 /**
  * @element cfpb-form-alert
  * @slot - The text for the form alert.
+ * @property {string} validation - Validation style: error, warning, success.
  */
 export class CfpbFormAlert extends LitElement {
   static styles = css`
     ${unsafeCSS(styles)}
   `;
 
-  /**
-   * @property {string} validation - Validation style: error, warning, success.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     validation: { type: String },
   };

--- a/packages/cfpb-design-system/src/elements/cfpb-form-choice/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-form-choice/index.js
@@ -14,6 +14,13 @@ const VALID_TYPES = ['checkbox', 'radio'];
 /**
  * @element cfpb-form-choice
  * @slot - The label for the form input.
+ * @property {boolean} checked - Whether the choice is checked or not.
+ * @property {boolean} disabled - Whether the choice is disabled or not.
+ * @property {boolean} large - Whether the choice has a large target area.
+ * @property {string} validation - Validation style: error, warning, success.
+ * @property {string} type - Choice type: checkbox or radio.
+ * @property {string} name - The name within a form.
+ * @property {string} value - The value to submit within a form.
  */
 export class CfpbFormChoice extends LitElement {
   static styles = css`
@@ -22,16 +29,6 @@ export class CfpbFormChoice extends LitElement {
 
   #checkboxIcon = createRef();
 
-  /**
-   * @property {boolean} checked - Whether the choice is checked or not.
-   * @property {boolean} disabled - Whether the choice is disabled or not.
-   * @property {boolean} large - Whether the choice has a large target area.
-   * @property {string} validation - Validation style: error, warning, success.
-   * @property {string} type - Choice type: checkbox or radio.
-   * @property {string} name - The name within a form.
-   * @property {string} value - The value to submit within a form.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     checked: { type: Boolean, reflect: true },
     disabled: { type: Boolean },

--- a/packages/cfpb-design-system/src/elements/cfpb-form-search-input/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-form-search-input/index.js
@@ -6,25 +6,22 @@ import { CfpbIcon } from '../cfpb-icon';
 
 /**
  * @element cfpb-form-search-input
+ * @property {boolean} disabled - Whether the input is disabled or not.
+ * @property {string} validation - Validation style: error, warning, success.
+ * @property {string} label - The aria-label for the input.
+ * @property {string} name - The name within a form.
+ * @property {string} value - The value within the input.
+ * @property {number} maxlength - The maximum characters allowed in the input.
+ * @property {string} placeholder - The placeholder value.
+ * @property {string} ariaLabelInput - aria-label for input.
+ * @property {string} ariaLabelButton - aria-label for button.
+ * @property {boolean} borderless - Whether the input has a border or not.
  */
 export class CfpbFormSearchInput extends LitElement {
   static styles = css`
     ${unsafeCSS(styles)}
   `;
 
-  /**
-   * @property {boolean} disabled - Whether the input is disabled or not.
-   * @property {string} validation - Validation style: error, warning, success.
-   * @property {string} label - The aria-label for the input.
-   * @property {string} name - The name within a form.
-   * @property {string} value - The value within the input.
-   * @property {number} maxlength - The maximum characters allowed in the input.
-   * @property {string} placeholder - The placeholder value.
-   * @property {string} ariaLabelInput - aria-label for input.
-   * @property {string} ariaLabelButton - aria-label for button.
-   * @property {boolean} borderless - Whether the input has a border or not.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     disabled: { type: Boolean, reflect: true },
     validation: { type: String, reflect: true },

--- a/packages/cfpb-design-system/src/elements/cfpb-form-search/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-form-search/index.js
@@ -10,6 +10,15 @@ import { CfpbFormAlert } from '../cfpb-form-alert';
 /**
  * @element cfpb-form-search
  * @slot - Slot for list of autocomplete items.
+ * @property {boolean} disabled - Whether the choice is disabled or not.
+ * @property {string} validation - Validation style: error, warning, success.
+ * @property {string} label - The aria-label for the input.
+ * @property {string} name - The name within a form.
+ * @property {string} value - The value within the input.
+ * @property {string} placeholder - The placeholder value.
+ * @property {string} maxlength - The maximum characters allowed in the input.
+ * @property {string} ariaLabelInput - aria-label for input.
+ * @property {string} ariaLabelButton - aria-label for button.
  */
 export class CfpbFormSearch extends LitElement {
   static styles = css`
@@ -18,18 +27,6 @@ export class CfpbFormSearch extends LitElement {
 
   static formAssociated = true;
 
-  /**
-   * @property {boolean} disabled - Whether the choice is disabled or not.
-   * @property {string} validation - Validation style: error, warning, success.
-   * @property {string} label - The aria-label for the input.
-   * @property {string} name - The name within a form.
-   * @property {string} value - The value within the input.
-   * @property {string} placeholder - The placeholder value.
-   * @property {string} maxlength - The maximum characters allowed in the input.
-   * @property {string} ariaLabelInput - aria-label for input.
-   * @property {string} ariaLabelButton - aria-label for button.
-   * @returns {object} The map of properties.
-   */
   static get properties() {
     return {
       disabled: { type: Boolean },

--- a/packages/cfpb-design-system/src/elements/cfpb-icon-text/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-icon-text/index.js
@@ -8,24 +8,21 @@ import { CfpbIcon } from '../cfpb-icon';
  * which may or may not have a divider.
  * @element cfpb-icon-text
  * @slot - The main content for the text and icon.
+ * @property {boolean} disabled - Apply disabled styles or not.
+ * @property {string} iconLeft - The name of the icon on the left.
+ * @property {string} iconRight - The name of the icon on the right.
+ * @property {string} isIconLeftSpin - Whether the left icon spins or not.
+ * @property {string} isIconRightSpin - Whether the right icon spins or not.
+ * @property {boolean} hasDiv - If true, render a divider.
+ * @property {boolean} underline -
+ *   "all" for all screen sizes, "tablet-up", for tablet and above, "none", for only on hover on tablet and above.
+ * @property {boolean} mobileUnderline - If true render an underline at mobile.
  */
 export class CfpbIconText extends LitElement {
   static styles = css`
     ${unsafeCSS(styles)}
   `;
 
-  /**
-   * @property {boolean} disabled - Apply disabled styles or not.
-   * @property {string} iconLeft - The name of the icon on the left.
-   * @property {string} iconRight - The name of the icon on the right.
-   * @property {string} isIconLeftSpin - Whether the left icon spins or not.
-   * @property {string} isIconRightSpin - Whether the right icon spins or not.
-   * @property {boolean} hasDiv - If true, render a divider.
-   * @property {boolean} underline -
-   *   "all" for all screen sizes, "tablet-up", for tablet and above, "none", for only on hover on tablet and above.
-   * @property {boolean} mobileUnderline - If true render an underline at mobile.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     disabled: { type: Boolean, reflect: true },
     iconLeft: { type: String, attribute: 'icon-left' },

--- a/packages/cfpb-design-system/src/elements/cfpb-icon/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-icon/index.js
@@ -4,16 +4,13 @@ import styles from './styles.component.css?inline';
 
 /**
  * @element cfpb-icon
+ * @property {boolean} name - The name of the icon.
  */
 export class CfpbIcon extends LitElement {
   static styles = css`
     ${unsafeCSS(styles)}
   `;
 
-  /**
-   * @property {boolean} name - The name of the icon.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     name: { type: String },
     spin: { type: Boolean, attribute: true },

--- a/packages/cfpb-design-system/src/elements/cfpb-label/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-label/index.js
@@ -8,17 +8,14 @@ import { ifDefined } from 'lit/directives/if-defined.js';
  * @element cfpb-label.
  * @slot label - The content for the label text.
  * @slot helper - The content for the label helper text.
+ * @property {boolean} block - Whether this has block or inline helper text.
+ * @property {string} for - Associate the label with an ID elsewhere.
  */
 export class CfpbLabel extends LitElement {
   static styles = css`
     ${unsafeCSS(styles)}
   `;
 
-  /**
-   * @property {boolean} block - Whether this has block or inline helper text.
-   * @property {string} for - Associate the label with an ID elsewhere.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     block: { type: Boolean, reflect: true },
     for: { type: String },

--- a/packages/cfpb-design-system/src/elements/cfpb-list/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-list/index.js
@@ -22,6 +22,8 @@ const SUPPORTED_TAG_LIST = new Set([
  * @fires item-added - An item was added to the group.
  * @fires item-click - An item was clicked.
  * @fires item-removed - An item was removed to the group.
+ * @property {string} childData - Structure data to create child components.
+ * @property {string} colorTheme - The color theme of the link. Takes 'dark'.
  */
 export class CfpbList extends LitElement {
   static styles = css`
@@ -30,11 +32,6 @@ export class CfpbList extends LitElement {
 
   #items = [];
 
-  /**
-   * @property {string} childData - Structure data to create child components.
-   * @property {string} colorTheme - The color theme of the link. Takes 'dark'.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     childData: { type: String, attribute: 'childdata' },
     colorTheme: { type: String, reflect: true, attribute: 'color-theme' },

--- a/packages/cfpb-design-system/src/elements/cfpb-listbox-item/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-listbox-item/index.js
@@ -7,6 +7,10 @@ import { CfpbCheckboxIcon } from '../cfpb-checkbox-icon';
 /**
  * @element cfpb-listbox-item.
  * @slot - The text for the list item.
+ * @property {string} type - Choice type: plain, check, checkbox.
+ * @property {boolean} checked - Whether the list item is checked or not.
+ * @property {boolean} disabled - Whether the list item is selectable or not.
+ * @property {boolean} hidden - Whether the list item is hidden or not.
  */
 export class CfpbListboxItem extends LitElement {
   static styles = css`
@@ -17,13 +21,6 @@ export class CfpbListboxItem extends LitElement {
   #value;
   #inList = false;
 
-  /**
-   * @property {string} type - Choice type: plain, check, checkbox.
-   * @property {boolean} checked - Whether the list item is checked or not.
-   * @property {boolean} disabled - Whether the list item is selectable or not.
-   * @property {boolean} hidden - Whether the list item is hidden or not.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     type: { type: String, reflect: true },
     checked: { type: Boolean, reflect: true },

--- a/packages/cfpb-design-system/src/elements/cfpb-listbox/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-listbox/index.js
@@ -8,6 +8,10 @@ import { parseChildData } from '../utilities/parse-child-data';
 /**
  * @element cfpb-listbox.
  * @slot - Slot for the list of items in the list box.
+ * @property {Array} childData - Structure data to create child components.
+ * @property {boolean} multiple - Whether the select supports multiple or not.
+ * @property {string} type - List item type: plain, check, or checkbox.
+ * @property {string} ariaLabel - The aria-label for the list container.
  */
 export class CfpbListbox extends LitElement {
   static styles = css`
@@ -26,13 +30,6 @@ export class CfpbListbox extends LitElement {
   // WeakMap to store per-item click listeners.
   #clickListeners = new WeakMap();
 
-  /**
-   * @property {Array} childData - Structure data to create child components.
-   * @property {boolean} multiple - Whether the select supports multiple or not.
-   * @property {string} type - List item type: plain, check, or checkbox.
-   * @property {string} ariaLabel - The aria-label for the list container.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     childData: { type: Array, attribute: 'childdata' },
     multiple: { type: Boolean, reflect: true },

--- a/packages/cfpb-design-system/src/elements/cfpb-pagination/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-pagination/index.js
@@ -8,6 +8,8 @@ import { I18nService, MediaQueryService } from '../utilities/';
  *
  * @element cfpb-pagination
  * @slot - Slot for passing in i18n (internationalization) service strings via a <template>.
+ * @property {number} currentPage - The currently selected page.
+ * @property {number} maxPage - The maximum page count.
  */
 export class CfpbPagination extends LitElement {
   #mediaService;
@@ -18,11 +20,6 @@ export class CfpbPagination extends LitElement {
     ${unsafeCSS(styles)}
   `;
 
-  /**
-   * @property {number} currentPage - The currently selected page.
-   * @property {number} maxPage - The maximum page count.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     currentPage: { type: Number, attribute: 'value', reflect: true },
     maxPage: { type: Number, attribute: 'max', reflect: true },

--- a/packages/cfpb-design-system/src/elements/cfpb-select/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-select/index.js
@@ -17,6 +17,9 @@ import { MultipleSelectEventProxy } from './multiple-select-event-proxy.js';
  *
  * @element cfpb-select
  * @slot - The main content for the select.
+ * @property {boolean} multiple - Whether the select supports multiple or not.
+ * @property {boolean} isExpanded - Whether the select is expanded or not.
+ * @property {Array} selectedTexts - Text of selected options.
  */
 export class CfpbSelect extends LitElement {
   static styles = css`
@@ -37,12 +40,6 @@ export class CfpbSelect extends LitElement {
   #boundOnOutsideFocus;
   #noResults = false;
 
-  /**
-   * @property {boolean} multiple - Whether the select supports multiple or not.
-   * @property {boolean} isExpanded - Whether the select is expanded or not.
-   * @property {Array} selectedTexts - Text of selected options.
-   * @returns {object} The map of properties.
-   */
   static get properties() {
     return {
       multiple: { type: Boolean, reflect: true },

--- a/packages/cfpb-design-system/src/elements/cfpb-tag-filter/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-tag-filter/index.js
@@ -8,16 +8,13 @@ import { errorIcon as icon } from '../../components/cfpb-icons/icons-lib';
  *
  * @element cfpb-tag-filter
  * @slot - The content for the filter tag.
+ * @property {string} for - Associate the label with an ID elsewhere.
  */
 export class CfpbTagFilter extends LitElement {
   static styles = css`
     ${unsafeCSS(styles)}
   `;
 
-  /**
-   * @property {string} for - Associate the label with an ID elsewhere.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     for: { type: String },
     value: { type: String },

--- a/packages/cfpb-design-system/src/elements/cfpb-tag-topic/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-tag-topic/index.js
@@ -6,18 +6,14 @@ import styles from './styles.component.scss?inline';
  *
  * @element cfpb-tag-topic.
  * @slot - The content for the topic tag.
+ * @property {string} href - href attribute, if this is a topic link.
+ * @property {boolean} siblingOfJumpLink - Whether the preceding sibling is a jump link or not.
  */
 export class CfpbTagTopic extends LitElement {
   static styles = css`
     ${unsafeCSS(styles)}
   `;
 
-  /**
-   * @property {string} href - href attribute, if this is a topic link.
-   * @property {boolean} siblingOfJumpLink
-   *   Whether the preceding sibling is a jump link or not.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     href: { type: String, reflect: true },
     siblingOfJumpLink: { type: Boolean },

--- a/packages/cfpb-design-system/src/elements/cfpb-tagline/index.js
+++ b/packages/cfpb-design-system/src/elements/cfpb-tagline/index.js
@@ -6,16 +6,13 @@ import styles from './styles.component.scss?inline';
 /**
  * @element cfpb-tagline
  * @slot - The main content for the tagline.
+ * @property {boolean} isLarge - Whether to use the larger tagline appearance.
  */
 export class CfpbTagline extends LitElement {
   static styles = css`
     ${unsafeCSS(styles)}
   `;
 
-  /**
-   * @property {boolean} isLarge - Whether to use the larger tagline appearance.
-   * @returns {object} The map of properties.
-   */
   static properties = {
     isLarge: { type: Boolean, reflect: true },
   };

--- a/storybook/custom-elements-types.d.ts
+++ b/storybook/custom-elements-types.d.ts
@@ -99,16 +99,16 @@ type BaseProps<T extends HTMLElement> = {
 type BaseEvents = {};
 
 export type CfpbAlertProps = {
-  /**  */
+  /** The alert status: error, success, warning, info, loading. */
   status?: CfpbAlert['status'] | undefined;
-  /**  */
+  /** The message heading on an alert. */
   message?: CfpbAlert['message'] | undefined;
 };
 
 export type CfpbAlertSolidJsProps = {
-  /**  */
+  /** The alert status: error, success, warning, info, loading. */
   'prop:status'?: CfpbAlert['status'] | undefined;
-  /**  */
+  /** The message heading on an alert. */
   'prop:message'?: CfpbAlert['message'] | undefined;
 
   /** Set the innerHTML of the element */
@@ -118,88 +118,88 @@ export type CfpbAlertSolidJsProps = {
 };
 
 export type CfpbButtonProps = {
-  /**  */
+  /** The button type: button, submit, or reset. */
   type?: CfpbButton['type'] | undefined;
-  /**  */
+  /** The URL to link to (makes the button a link). */
   href?: CfpbButton['href'] | undefined;
-  /**  */
+  /** Whether the button is disabled or not. */
   disabled?: CfpbButton['disabled'] | undefined;
-  /**  */
+  /** The button variant: primary, secondary, or warning. */
   variant?: CfpbButton['variant'] | undefined;
-  /**  */
+  /** The name of the icon on the left. */
   'icon-left'?: CfpbButton['iconLeft'] | undefined;
-  /**  */
+  /** The name of the icon on the left. */
   iconLeft?: CfpbButton['iconLeft'] | undefined;
-  /**  */
+  /** The name of the icon on the right. */
   'icon-right'?: CfpbButton['iconRight'] | undefined;
-  /**  */
+  /** The name of the icon on the right. */
   iconRight?: CfpbButton['iconRight'] | undefined;
-  /**  */
+  /** Whether the left icon spins or not. */
   'icon-left-spin'?: CfpbButton['isIconLeftSpin'] | undefined;
-  /**  */
+  /** Whether the left icon spins or not. */
   isIconLeftSpin?: CfpbButton['isIconLeftSpin'] | undefined;
-  /**  */
+  /** Whether the right icon spins or not. */
   'icon-right-spin'?: CfpbButton['isIconRightSpin'] | undefined;
-  /**  */
+  /** Whether the right icon spins or not. */
   isIconRightSpin?: CfpbButton['isIconRightSpin'] | undefined;
-  /**  */
+  /** Whether to be width 100% on mobile. */
   'full-on-mobile'?: CfpbButton['fullOnMobile'] | undefined;
-  /**  */
+  /** Whether to be width 100% on mobile. */
   fullOnMobile?: CfpbButton['fullOnMobile'] | undefined;
-  /**  */
+  /** Whether button is not rounded on left. */
   'flush-left'?: CfpbButton['flushLeft'] | undefined;
-  /**  */
+  /** Whether button is not rounded on left. */
   flushLeft?: CfpbButton['flushLeft'] | undefined;
-  /**  */
+  /** Whether button is not rounded on right. */
   'flush-right'?: CfpbButton['flushRight'] | undefined;
-  /**  */
+  /** Whether button is not rounded on right. */
   flushRight?: CfpbButton['flushRight'] | undefined;
-  /**  */
+  /** Style the button as a link. */
   'style-as-link'?: CfpbButton['styleAsLink'] | undefined;
-  /**  */
+  /** Style the button as a link. */
   styleAsLink?: CfpbButton['styleAsLink'] | undefined;
 };
 
 export type CfpbButtonSolidJsProps = {
-  /**  */
+  /** The button type: button, submit, or reset. */
   'prop:type'?: CfpbButton['type'] | undefined;
-  /**  */
+  /** The URL to link to (makes the button a link). */
   'prop:href'?: CfpbButton['href'] | undefined;
-  /**  */
+  /** Whether the button is disabled or not. */
   'prop:disabled'?: CfpbButton['disabled'] | undefined;
-  /**  */
+  /** The button variant: primary, secondary, or warning. */
   'prop:variant'?: CfpbButton['variant'] | undefined;
-  /**  */
+  /** The name of the icon on the left. */
   'attr:icon-left'?: CfpbButton['iconLeft'] | undefined;
-  /**  */
+  /** The name of the icon on the left. */
   'prop:iconLeft'?: CfpbButton['iconLeft'] | undefined;
-  /**  */
+  /** The name of the icon on the right. */
   'attr:icon-right'?: CfpbButton['iconRight'] | undefined;
-  /**  */
+  /** The name of the icon on the right. */
   'prop:iconRight'?: CfpbButton['iconRight'] | undefined;
-  /**  */
+  /** Whether the left icon spins or not. */
   'bool:icon-left-spin'?: CfpbButton['isIconLeftSpin'] | undefined;
-  /**  */
+  /** Whether the left icon spins or not. */
   'prop:isIconLeftSpin'?: CfpbButton['isIconLeftSpin'] | undefined;
-  /**  */
+  /** Whether the right icon spins or not. */
   'bool:icon-right-spin'?: CfpbButton['isIconRightSpin'] | undefined;
-  /**  */
+  /** Whether the right icon spins or not. */
   'prop:isIconRightSpin'?: CfpbButton['isIconRightSpin'] | undefined;
-  /**  */
+  /** Whether to be width 100% on mobile. */
   'bool:full-on-mobile'?: CfpbButton['fullOnMobile'] | undefined;
-  /**  */
+  /** Whether to be width 100% on mobile. */
   'prop:fullOnMobile'?: CfpbButton['fullOnMobile'] | undefined;
-  /**  */
+  /** Whether button is not rounded on left. */
   'bool:flush-left'?: CfpbButton['flushLeft'] | undefined;
-  /**  */
+  /** Whether button is not rounded on left. */
   'prop:flushLeft'?: CfpbButton['flushLeft'] | undefined;
-  /**  */
+  /** Whether button is not rounded on right. */
   'bool:flush-right'?: CfpbButton['flushRight'] | undefined;
-  /**  */
+  /** Whether button is not rounded on right. */
   'prop:flushRight'?: CfpbButton['flushRight'] | undefined;
-  /**  */
+  /** Style the button as a link. */
   'bool:style-as-link'?: CfpbButton['styleAsLink'] | undefined;
-  /**  */
+  /** Style the button as a link. */
   'prop:styleAsLink'?: CfpbButton['styleAsLink'] | undefined;
 
   /** Set the innerHTML of the element */
@@ -209,24 +209,24 @@ export type CfpbButtonSolidJsProps = {
 };
 
 export type CfpbCheckboxIconProps = {
-  /**  */
+  /** Whether the checkbox has a border or not. */
   borderless?: CfpbCheckboxIcon['borderless'] | undefined;
-  /**  */
+  /** Whether the checkbox is checked or not. */
   checked?: CfpbCheckboxIcon['checked'] | undefined;
-  /**  */
+  /** Whether the checkbox is disabled or not. */
   disabled?: CfpbCheckboxIcon['disabled'] | undefined;
-  /**  */
+  /** Validation style: error, warning, success. */
   validation?: CfpbCheckboxIcon['validation'] | undefined;
 };
 
 export type CfpbCheckboxIconSolidJsProps = {
-  /**  */
+  /** Whether the checkbox has a border or not. */
   'prop:borderless'?: CfpbCheckboxIcon['borderless'] | undefined;
-  /**  */
+  /** Whether the checkbox is checked or not. */
   'prop:checked'?: CfpbCheckboxIcon['checked'] | undefined;
-  /**  */
+  /** Whether the checkbox is disabled or not. */
   'prop:disabled'?: CfpbCheckboxIcon['disabled'] | undefined;
-  /**  */
+  /** Validation style: error, warning, success. */
   'prop:validation'?: CfpbCheckboxIcon['validation'] | undefined;
 
   /** Set the innerHTML of the element */
@@ -236,9 +236,9 @@ export type CfpbCheckboxIconSolidJsProps = {
 };
 
 export type CfpbExpandableProps = {
-  /**  */
+  /** Whether the expandable is expanded or not. */
   open?: CfpbExpandable['isExpanded'] | undefined;
-  /**  */
+  /** Whether the expandable is expanded or not. */
   isExpanded?: CfpbExpandable['isExpanded'] | undefined;
 
   /** The expandable started expanding. */
@@ -252,9 +252,9 @@ export type CfpbExpandableProps = {
 };
 
 export type CfpbExpandableSolidJsProps = {
-  /**  */
+  /** Whether the expandable is expanded or not. */
   'bool:open'?: CfpbExpandable['isExpanded'] | undefined;
-  /**  */
+  /** Whether the expandable is expanded or not. */
   'prop:isExpanded'?: CfpbExpandable['isExpanded'] | undefined;
   /** The expandable started expanding. */
   'on:expandbegin'?: ((e: CustomEvent) => void) | undefined;
@@ -313,12 +313,12 @@ export type CfpbFlagUsaSolidJsProps = {
 };
 
 export type CfpbFormAlertProps = {
-  /**  */
+  /** Validation style: error, warning, success. */
   validation?: CfpbFormAlert['validation'] | undefined;
 };
 
 export type CfpbFormAlertSolidJsProps = {
-  /**  */
+  /** Validation style: error, warning, success. */
   'prop:validation'?: CfpbFormAlert['validation'] | undefined;
 
   /** Set the innerHTML of the element */
@@ -328,19 +328,19 @@ export type CfpbFormAlertSolidJsProps = {
 };
 
 export type CfpbFormChoiceProps = {
-  /**  */
+  /** Whether the choice is checked or not. */
   checked?: CfpbFormChoice['checked'] | undefined;
-  /**  */
+  /** Whether the choice is disabled or not. */
   disabled?: CfpbFormChoice['disabled'] | undefined;
-  /**  */
+  /** Whether the choice has a large target area. */
   large?: CfpbFormChoice['large'] | undefined;
-  /**  */
+  /** Validation style: error, warning, success. */
   validation?: CfpbFormChoice['validation'] | undefined;
-  /**  */
+  /** Choice type: checkbox or radio. */
   type?: CfpbFormChoice['type'] | undefined;
-  /**  */
+  /** The name within a form. */
   name?: CfpbFormChoice['name'] | undefined;
-  /**  */
+  /** The value to submit within a form. */
   value?: CfpbFormChoice['value'] | undefined;
 
   /**  */
@@ -350,19 +350,19 @@ export type CfpbFormChoiceProps = {
 };
 
 export type CfpbFormChoiceSolidJsProps = {
-  /**  */
+  /** Whether the choice is checked or not. */
   'prop:checked'?: CfpbFormChoice['checked'] | undefined;
-  /**  */
+  /** Whether the choice is disabled or not. */
   'prop:disabled'?: CfpbFormChoice['disabled'] | undefined;
-  /**  */
+  /** Whether the choice has a large target area. */
   'prop:large'?: CfpbFormChoice['large'] | undefined;
-  /**  */
+  /** Validation style: error, warning, success. */
   'prop:validation'?: CfpbFormChoice['validation'] | undefined;
-  /**  */
+  /** Choice type: checkbox or radio. */
   'prop:type'?: CfpbFormChoice['type'] | undefined;
-  /**  */
+  /** The name within a form. */
   'prop:name'?: CfpbFormChoice['name'] | undefined;
-  /**  */
+  /** The value to submit within a form. */
   'prop:value'?: CfpbFormChoice['value'] | undefined;
   /**  */
   'on:change'?: ((e: Event) => void) | undefined;
@@ -376,31 +376,31 @@ export type CfpbFormChoiceSolidJsProps = {
 };
 
 export type CfpbFormSearchInputProps = {
-  /**  */
+  /** Whether the input is disabled or not. */
   disabled?: CfpbFormSearchInput['disabled'] | undefined;
-  /**  */
+  /** Validation style: error, warning, success. */
   validation?: CfpbFormSearchInput['validation'] | undefined;
-  /**  */
+  /** The aria-label for the input. */
   label?: CfpbFormSearchInput['label'] | undefined;
-  /**  */
+  /** The name within a form. */
   name?: CfpbFormSearchInput['name'] | undefined;
   /**  */
   title?: CfpbFormSearchInput['title'] | undefined;
-  /**  */
+  /** The value within the input. */
   value?: CfpbFormSearchInput['value'] | undefined;
-  /**  */
+  /** The maximum characters allowed in the input. */
   maxlength?: CfpbFormSearchInput['maxlength'] | undefined;
-  /**  */
+  /** The placeholder value. */
   placeholder?: CfpbFormSearchInput['placeholder'] | undefined;
-  /**  */
+  /** aria-label for input. */
   'aria-label-input'?: CfpbFormSearchInput['ariaLabelInput'] | undefined;
-  /**  */
+  /** aria-label for input. */
   ariaLabelInput?: CfpbFormSearchInput['ariaLabelInput'] | undefined;
-  /**  */
+  /** aria-label for button. */
   'aria-label-button'?: CfpbFormSearchInput['ariaLabelButton'] | undefined;
-  /**  */
+  /** aria-label for button. */
   ariaLabelButton?: CfpbFormSearchInput['ariaLabelButton'] | undefined;
-  /**  */
+  /** Whether the input has a border or not. */
   borderless?: CfpbFormSearchInput['borderless'] | undefined;
 
   /**  */
@@ -412,31 +412,31 @@ export type CfpbFormSearchInputProps = {
 };
 
 export type CfpbFormSearchInputSolidJsProps = {
-  /**  */
+  /** Whether the input is disabled or not. */
   'prop:disabled'?: CfpbFormSearchInput['disabled'] | undefined;
-  /**  */
+  /** Validation style: error, warning, success. */
   'prop:validation'?: CfpbFormSearchInput['validation'] | undefined;
-  /**  */
+  /** The aria-label for the input. */
   'prop:label'?: CfpbFormSearchInput['label'] | undefined;
-  /**  */
+  /** The name within a form. */
   'prop:name'?: CfpbFormSearchInput['name'] | undefined;
   /**  */
   'prop:title'?: CfpbFormSearchInput['title'] | undefined;
-  /**  */
+  /** The value within the input. */
   'prop:value'?: CfpbFormSearchInput['value'] | undefined;
-  /**  */
+  /** The maximum characters allowed in the input. */
   'prop:maxlength'?: CfpbFormSearchInput['maxlength'] | undefined;
-  /**  */
+  /** The placeholder value. */
   'prop:placeholder'?: CfpbFormSearchInput['placeholder'] | undefined;
-  /**  */
+  /** aria-label for input. */
   'attr:aria-label-input'?: CfpbFormSearchInput['ariaLabelInput'] | undefined;
-  /**  */
+  /** aria-label for input. */
   'prop:ariaLabelInput'?: CfpbFormSearchInput['ariaLabelInput'] | undefined;
-  /**  */
+  /** aria-label for button. */
   'attr:aria-label-button'?: CfpbFormSearchInput['ariaLabelButton'] | undefined;
-  /**  */
+  /** aria-label for button. */
   'prop:ariaLabelButton'?: CfpbFormSearchInput['ariaLabelButton'] | undefined;
-  /**  */
+  /** Whether the input has a border or not. */
   'prop:borderless'?: CfpbFormSearchInput['borderless'] | undefined;
   /**  */
   'on:enter-down'?: ((e: CustomEvent) => void) | undefined;
@@ -452,29 +452,29 @@ export type CfpbFormSearchInputSolidJsProps = {
 };
 
 export type CfpbFormSearchProps = {
-  /**  */
+  /** Whether the choice is disabled or not. */
   disabled?: CfpbFormSearch['disabled'] | undefined;
-  /**  */
+  /** Validation style: error, warning, success. */
   validation?: CfpbFormSearch['validation'] | undefined;
-  /**  */
+  /** The aria-label for the input. */
   label?: CfpbFormSearch['label'] | undefined;
-  /**  */
+  /** The name within a form. */
   name?: CfpbFormSearch['name'] | undefined;
   /**  */
   title?: CfpbFormSearch['title'] | undefined;
-  /**  */
+  /** The value within the input. */
   value?: CfpbFormSearch['value'] | undefined;
-  /**  */
+  /** The maximum characters allowed in the input. */
   maxlength?: CfpbFormSearch['maxlength'] | undefined;
-  /**  */
+  /** The placeholder value. */
   placeholder?: CfpbFormSearch['placeholder'] | undefined;
-  /**  */
+  /** aria-label for input. */
   'aria-label-input'?: CfpbFormSearch['ariaLabelInput'] | undefined;
-  /**  */
+  /** aria-label for input. */
   ariaLabelInput?: CfpbFormSearch['ariaLabelInput'] | undefined;
-  /**  */
+  /** aria-label for button. */
   'aria-label-button'?: CfpbFormSearch['ariaLabelButton'] | undefined;
-  /**  */
+  /** aria-label for button. */
   ariaLabelButton?: CfpbFormSearch['ariaLabelButton'] | undefined;
   /**  */
   searchlist?: CfpbFormSearch['searchList'] | undefined;
@@ -483,29 +483,29 @@ export type CfpbFormSearchProps = {
 };
 
 export type CfpbFormSearchSolidJsProps = {
-  /**  */
+  /** Whether the choice is disabled or not. */
   'prop:disabled'?: CfpbFormSearch['disabled'] | undefined;
-  /**  */
+  /** Validation style: error, warning, success. */
   'prop:validation'?: CfpbFormSearch['validation'] | undefined;
-  /**  */
+  /** The aria-label for the input. */
   'prop:label'?: CfpbFormSearch['label'] | undefined;
-  /**  */
+  /** The name within a form. */
   'prop:name'?: CfpbFormSearch['name'] | undefined;
   /**  */
   'prop:title'?: CfpbFormSearch['title'] | undefined;
-  /**  */
+  /** The value within the input. */
   'prop:value'?: CfpbFormSearch['value'] | undefined;
-  /**  */
+  /** The maximum characters allowed in the input. */
   'prop:maxlength'?: CfpbFormSearch['maxlength'] | undefined;
-  /**  */
+  /** The placeholder value. */
   'prop:placeholder'?: CfpbFormSearch['placeholder'] | undefined;
-  /**  */
+  /** aria-label for input. */
   'attr:aria-label-input'?: CfpbFormSearch['ariaLabelInput'] | undefined;
-  /**  */
+  /** aria-label for input. */
   'prop:ariaLabelInput'?: CfpbFormSearch['ariaLabelInput'] | undefined;
-  /**  */
+  /** aria-label for button. */
   'attr:aria-label-button'?: CfpbFormSearch['ariaLabelButton'] | undefined;
-  /**  */
+  /** aria-label for button. */
   'prop:ariaLabelButton'?: CfpbFormSearch['ariaLabelButton'] | undefined;
   /**  */
   'attr:searchlist'?: CfpbFormSearch['searchList'] | undefined;
@@ -519,29 +519,29 @@ export type CfpbFormSearchSolidJsProps = {
 };
 
 export type CfpbIconTextProps = {
-  /**  */
+  /** Apply disabled styles or not. */
   disabled?: CfpbIconText['disabled'] | undefined;
-  /**  */
+  /** The name of the icon on the left. */
   'icon-left'?: CfpbIconText['iconLeft'] | undefined;
-  /**  */
+  /** The name of the icon on the left. */
   iconLeft?: CfpbIconText['iconLeft'] | undefined;
-  /**  */
+  /** The name of the icon on the right. */
   'icon-right'?: CfpbIconText['iconRight'] | undefined;
-  /**  */
+  /** The name of the icon on the right. */
   iconRight?: CfpbIconText['iconRight'] | undefined;
-  /**  */
+  /** Whether the left icon spins or not. */
   'icon-left-spin'?: CfpbIconText['isIconLeftSpin'] | undefined;
-  /**  */
+  /** Whether the left icon spins or not. */
   isIconLeftSpin?: CfpbIconText['isIconLeftSpin'] | undefined;
-  /**  */
+  /** Whether the right icon spins or not. */
   'icon-right-spin'?: CfpbIconText['isIconRightSpin'] | undefined;
-  /**  */
+  /** Whether the right icon spins or not. */
   isIconRightSpin?: CfpbIconText['isIconRightSpin'] | undefined;
-  /**  */
+  /** If true, render a divider. */
   'has-div'?: CfpbIconText['hasDiv'] | undefined;
-  /**  */
+  /** If true, render a divider. */
   hasDiv?: CfpbIconText['hasDiv'] | undefined;
-  /**  */
+  /** "all" for all screen sizes, "tablet-up", for tablet and above, "none", for only on hover on tablet and above. */
   underline?: CfpbIconText['underline'] | undefined;
   /**  */
   'mobile-icon-align-end'?: CfpbIconText['mobileIconAlignEnd'] | undefined;
@@ -549,32 +549,34 @@ export type CfpbIconTextProps = {
   mobileIconAlignEnd?: CfpbIconText['mobileIconAlignEnd'] | undefined;
   /**  */
   inline?: CfpbIconText['inline'] | undefined;
+  /** If true render an underline at mobile. */
+  mobileUnderline?: CfpbIconText['mobileUnderline'] | undefined;
 };
 
 export type CfpbIconTextSolidJsProps = {
-  /**  */
+  /** Apply disabled styles or not. */
   'prop:disabled'?: CfpbIconText['disabled'] | undefined;
-  /**  */
+  /** The name of the icon on the left. */
   'attr:icon-left'?: CfpbIconText['iconLeft'] | undefined;
-  /**  */
+  /** The name of the icon on the left. */
   'prop:iconLeft'?: CfpbIconText['iconLeft'] | undefined;
-  /**  */
+  /** The name of the icon on the right. */
   'attr:icon-right'?: CfpbIconText['iconRight'] | undefined;
-  /**  */
+  /** The name of the icon on the right. */
   'prop:iconRight'?: CfpbIconText['iconRight'] | undefined;
-  /**  */
-  'bool:icon-left-spin'?: CfpbIconText['isIconLeftSpin'] | undefined;
-  /**  */
+  /** Whether the left icon spins or not. */
+  'attr:icon-left-spin'?: CfpbIconText['isIconLeftSpin'] | undefined;
+  /** Whether the left icon spins or not. */
   'prop:isIconLeftSpin'?: CfpbIconText['isIconLeftSpin'] | undefined;
-  /**  */
-  'bool:icon-right-spin'?: CfpbIconText['isIconRightSpin'] | undefined;
-  /**  */
+  /** Whether the right icon spins or not. */
+  'attr:icon-right-spin'?: CfpbIconText['isIconRightSpin'] | undefined;
+  /** Whether the right icon spins or not. */
   'prop:isIconRightSpin'?: CfpbIconText['isIconRightSpin'] | undefined;
-  /**  */
+  /** If true, render a divider. */
   'bool:has-div'?: CfpbIconText['hasDiv'] | undefined;
-  /**  */
+  /** If true, render a divider. */
   'prop:hasDiv'?: CfpbIconText['hasDiv'] | undefined;
-  /**  */
+  /** "all" for all screen sizes, "tablet-up", for tablet and above, "none", for only on hover on tablet and above. */
   'prop:underline'?: CfpbIconText['underline'] | undefined;
   /**  */
   'bool:mobile-icon-align-end'?: CfpbIconText['mobileIconAlignEnd'] | undefined;
@@ -582,6 +584,8 @@ export type CfpbIconTextSolidJsProps = {
   'prop:mobileIconAlignEnd'?: CfpbIconText['mobileIconAlignEnd'] | undefined;
   /**  */
   'prop:inline'?: CfpbIconText['inline'] | undefined;
+  /** If true render an underline at mobile. */
+  'prop:mobileUnderline'?: CfpbIconText['mobileUnderline'] | undefined;
 
   /** Set the innerHTML of the element */
   innerHTML?: string | undefined;
@@ -590,14 +594,14 @@ export type CfpbIconTextSolidJsProps = {
 };
 
 export type CfpbIconProps = {
-  /**  */
+  /** The name of the icon. */
   name?: CfpbIcon['name'] | undefined;
   /**  */
   spin?: CfpbIcon['spin'] | undefined;
 };
 
 export type CfpbIconSolidJsProps = {
-  /**  */
+  /** The name of the icon. */
   'prop:name'?: CfpbIcon['name'] | undefined;
   /**  */
   'prop:spin'?: CfpbIcon['spin'] | undefined;
@@ -609,16 +613,16 @@ export type CfpbIconSolidJsProps = {
 };
 
 export type CfpbLabelProps = {
-  /**  */
+  /** Whether this has block or inline helper text. */
   block?: CfpbLabel['block'] | undefined;
-  /**  */
+  /** Associate the label with an ID elsewhere. */
   for?: CfpbLabel['for'] | undefined;
 };
 
 export type CfpbLabelSolidJsProps = {
-  /**  */
+  /** Whether this has block or inline helper text. */
   'prop:block'?: CfpbLabel['block'] | undefined;
-  /**  */
+  /** Associate the label with an ID elsewhere. */
   'prop:for'?: CfpbLabel['for'] | undefined;
 
   /** Set the innerHTML of the element */
@@ -696,13 +700,13 @@ export type CfpbListItemSolidJsProps = {
 };
 
 export type CfpbListProps = {
-  /**  */
+  /** Structure data to create child components. */
   childdata?: CfpbList['childData'] | undefined;
-  /**  */
+  /** Structure data to create child components. */
   childData?: CfpbList['childData'] | undefined;
-  /**  */
+  /** The color theme of the link. Takes 'dark'. */
   'color-theme'?: CfpbList['colorTheme'] | undefined;
-  /**  */
+  /** The color theme of the link. Takes 'dark'. */
   colorTheme?: CfpbList['colorTheme'] | undefined;
 
   /** An item was clicked. */
@@ -714,13 +718,13 @@ export type CfpbListProps = {
 };
 
 export type CfpbListSolidJsProps = {
-  /**  */
+  /** Structure data to create child components. */
   'attr:childdata'?: CfpbList['childData'] | undefined;
-  /**  */
+  /** Structure data to create child components. */
   'prop:childData'?: CfpbList['childData'] | undefined;
-  /**  */
+  /** The color theme of the link. Takes 'dark'. */
   'attr:color-theme'?: CfpbList['colorTheme'] | undefined;
-  /**  */
+  /** The color theme of the link. Takes 'dark'. */
   'prop:colorTheme'?: CfpbList['colorTheme'] | undefined;
   /** An item was clicked. */
   'on:item-click'?: ((e: CustomEvent) => void) | undefined;
@@ -736,13 +740,13 @@ export type CfpbListSolidJsProps = {
 };
 
 export type CfpbListboxItemProps = {
-  /**  */
+  /** Choice type: plain, check, checkbox. */
   type?: CfpbListboxItem['type'] | undefined;
-  /**  */
+  /** Whether the list item is checked or not. */
   checked?: CfpbListboxItem['checked'] | undefined;
-  /**  */
+  /** Whether the list item is selectable or not. */
   disabled?: CfpbListboxItem['disabled'] | undefined;
-  /**  */
+  /** Whether the list item is hidden or not. */
   hidden?: CfpbListboxItem['hidden'] | undefined;
   /**  */
   href?: CfpbListboxItem['href'] | undefined;
@@ -754,13 +758,13 @@ export type CfpbListboxItemProps = {
 };
 
 export type CfpbListboxItemSolidJsProps = {
-  /**  */
+  /** Choice type: plain, check, checkbox. */
   'prop:type'?: CfpbListboxItem['type'] | undefined;
-  /**  */
+  /** Whether the list item is checked or not. */
   'prop:checked'?: CfpbListboxItem['checked'] | undefined;
-  /**  */
+  /** Whether the list item is selectable or not. */
   'prop:disabled'?: CfpbListboxItem['disabled'] | undefined;
-  /**  */
+  /** Whether the list item is hidden or not. */
   'prop:hidden'?: CfpbListboxItem['hidden'] | undefined;
   /**  */
   'prop:href'?: CfpbListboxItem['href'] | undefined;
@@ -776,17 +780,17 @@ export type CfpbListboxItemSolidJsProps = {
 };
 
 export type CfpbListboxProps = {
-  /**  */
+  /** Structure data to create child components. */
   childdata?: CfpbListbox['childData'] | undefined;
-  /**  */
+  /** Structure data to create child components. */
   childData?: CfpbListbox['childData'] | undefined;
-  /**  */
+  /** Whether the select supports multiple or not. */
   multiple?: CfpbListbox['multiple'] | undefined;
-  /**  */
+  /** List item type: plain, check, or checkbox. */
   type?: CfpbListbox['type'] | undefined;
-  /**  */
+  /** The aria-label for the list container. */
   'aria-label'?: CfpbListbox['ariaLabel'] | undefined;
-  /**  */
+  /** The aria-label for the list container. */
   ariaLabel?: CfpbListbox['ariaLabel'] | undefined;
 
   /**  */
@@ -798,17 +802,17 @@ export type CfpbListboxProps = {
 };
 
 export type CfpbListboxSolidJsProps = {
-  /**  */
+  /** Structure data to create child components. */
   'attr:childdata'?: CfpbListbox['childData'] | undefined;
-  /**  */
+  /** Structure data to create child components. */
   'prop:childData'?: CfpbListbox['childData'] | undefined;
-  /**  */
+  /** Whether the select supports multiple or not. */
   'prop:multiple'?: CfpbListbox['multiple'] | undefined;
-  /**  */
+  /** List item type: plain, check, or checkbox. */
   'prop:type'?: CfpbListbox['type'] | undefined;
-  /**  */
+  /** The aria-label for the list container. */
   'attr:aria-label'?: CfpbListbox['ariaLabel'] | undefined;
-  /**  */
+  /** The aria-label for the list container. */
   'prop:ariaLabel'?: CfpbListbox['ariaLabel'] | undefined;
   /**  */
   'on:items-ready'?: ((e: CustomEvent) => void) | undefined;
@@ -824,13 +828,13 @@ export type CfpbListboxSolidJsProps = {
 };
 
 export type CfpbPaginationProps = {
-  /**  */
+  /** The currently selected page. */
   value?: CfpbPagination['currentPage'] | undefined;
-  /**  */
+  /** The currently selected page. */
   currentPage?: CfpbPagination['currentPage'] | undefined;
-  /**  */
+  /** The maximum page count. */
   max?: CfpbPagination['maxPage'] | undefined;
-  /**  */
+  /** The maximum page count. */
   maxPage?: CfpbPagination['maxPage'] | undefined;
   /**  */
   lang?: CfpbPagination['lang'] | undefined;
@@ -840,13 +844,13 @@ export type CfpbPaginationProps = {
 };
 
 export type CfpbPaginationSolidJsProps = {
-  /**  */
+  /** The currently selected page. */
   'attr:value'?: CfpbPagination['currentPage'] | undefined;
-  /**  */
+  /** The currently selected page. */
   'prop:currentPage'?: CfpbPagination['currentPage'] | undefined;
-  /**  */
+  /** The maximum page count. */
   'attr:max'?: CfpbPagination['maxPage'] | undefined;
-  /**  */
+  /** The maximum page count. */
   'prop:maxPage'?: CfpbPagination['maxPage'] | undefined;
   /**  */
   'prop:lang'?: CfpbPagination['lang'] | undefined;
@@ -860,7 +864,7 @@ export type CfpbPaginationSolidJsProps = {
 };
 
 export type CfpbSelectProps = {
-  /**  */
+  /** Whether the select supports multiple or not. */
   multiple?: CfpbSelect['multiple'] | undefined;
   /**  */
   disabled?: CfpbSelect['disabled'] | undefined;
@@ -886,13 +890,13 @@ export type CfpbSelectProps = {
   'aria-label-list'?: CfpbSelect['ariaLabelList'] | undefined;
   /**  */
   ariaLabelList?: CfpbSelect['ariaLabelList'] | undefined;
-  /**  */
+  /** Whether the select is expanded or not. */
   open?: CfpbSelect['isExpanded'] | undefined;
-  /**  */
+  /** Whether the select is expanded or not. */
   isExpanded?: CfpbSelect['isExpanded'] | undefined;
-  /**  */
+  /** Text of selected options. */
   selectedtexts?: CfpbSelect['selectedTexts'] | undefined;
-  /**  */
+  /** Text of selected options. */
   selectedTexts?: CfpbSelect['selectedTexts'] | undefined;
   /**  */
   optionlist?: CfpbSelect['optionList'] | undefined;
@@ -906,7 +910,7 @@ export type CfpbSelectProps = {
 };
 
 export type CfpbSelectSolidJsProps = {
-  /**  */
+  /** Whether the select supports multiple or not. */
   'prop:multiple'?: CfpbSelect['multiple'] | undefined;
   /**  */
   'prop:disabled'?: CfpbSelect['disabled'] | undefined;
@@ -932,13 +936,13 @@ export type CfpbSelectSolidJsProps = {
   'attr:aria-label-list'?: CfpbSelect['ariaLabelList'] | undefined;
   /**  */
   'prop:ariaLabelList'?: CfpbSelect['ariaLabelList'] | undefined;
-  /**  */
+  /** Whether the select is expanded or not. */
   'bool:open'?: CfpbSelect['isExpanded'] | undefined;
-  /**  */
+  /** Whether the select is expanded or not. */
   'prop:isExpanded'?: CfpbSelect['isExpanded'] | undefined;
-  /**  */
+  /** Text of selected options. */
   'attr:selectedtexts'?: CfpbSelect['selectedTexts'] | undefined;
-  /**  */
+  /** Text of selected options. */
   'prop:selectedTexts'?: CfpbSelect['selectedTexts'] | undefined;
   /**  */
   'attr:optionlist'?: CfpbSelect['optionList'] | undefined;
@@ -956,7 +960,7 @@ export type CfpbSelectSolidJsProps = {
 };
 
 export type CfpbTagFilterProps = {
-  /**  */
+  /** Associate the label with an ID elsewhere. */
   for?: CfpbTagFilter['for'] | undefined;
   /**  */
   value?: CfpbTagFilter['value'] | undefined;
@@ -966,7 +970,7 @@ export type CfpbTagFilterProps = {
 };
 
 export type CfpbTagFilterSolidJsProps = {
-  /**  */
+  /** Associate the label with an ID elsewhere. */
   'prop:for'?: CfpbTagFilter['for'] | undefined;
   /**  */
   'prop:value'?: CfpbTagFilter['value'] | undefined;
@@ -980,20 +984,20 @@ export type CfpbTagFilterSolidJsProps = {
 };
 
 export type CfpbTagTopicProps = {
-  /**  */
+  /** href attribute, if this is a topic link. */
   href?: CfpbTagTopic['href'] | undefined;
-  /**  */
+  /** Whether the preceding sibling is a jump link or not. */
   siblingofjumplink?: CfpbTagTopic['siblingOfJumpLink'] | undefined;
-  /**  */
+  /** Whether the preceding sibling is a jump link or not. */
   siblingOfJumpLink?: CfpbTagTopic['siblingOfJumpLink'] | undefined;
 };
 
 export type CfpbTagTopicSolidJsProps = {
-  /**  */
+  /** href attribute, if this is a topic link. */
   'prop:href'?: CfpbTagTopic['href'] | undefined;
-  /**  */
+  /** Whether the preceding sibling is a jump link or not. */
   'bool:siblingofjumplink'?: CfpbTagTopic['siblingOfJumpLink'] | undefined;
-  /**  */
+  /** Whether the preceding sibling is a jump link or not. */
   'prop:siblingOfJumpLink'?: CfpbTagTopic['siblingOfJumpLink'] | undefined;
 
   /** Set the innerHTML of the element */
@@ -1003,16 +1007,16 @@ export type CfpbTagTopicSolidJsProps = {
 };
 
 export type CfpbTaglineProps = {
-  /**  */
+  /** Whether to use the larger tagline appearance. */
   islarge?: CfpbTagline['isLarge'] | undefined;
-  /**  */
+  /** Whether to use the larger tagline appearance. */
   isLarge?: CfpbTagline['isLarge'] | undefined;
 };
 
 export type CfpbTaglineSolidJsProps = {
-  /**  */
+  /** Whether to use the larger tagline appearance. */
   'bool:islarge'?: CfpbTagline['isLarge'] | undefined;
-  /**  */
+  /** Whether to use the larger tagline appearance. */
   'prop:isLarge'?: CfpbTagline['isLarge'] | undefined;
 
   /** Set the innerHTML of the element */
@@ -1029,8 +1033,8 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `status`: undefined
-   * - `message`: undefined
+   * - `status`: The alert status: error, success, warning, info, loading.
+   * - `message`: The message heading on an alert.
    * - `icon`: undefined (property only) (readonly)
    *
    * ## Slots
@@ -1054,18 +1058,18 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `type`: undefined
-   * - `href`: undefined
-   * - `disabled`: undefined
-   * - `variant`: undefined
-   * - `icon-left`/`iconLeft`: undefined
-   * - `icon-right`/`iconRight`: undefined
-   * - `icon-left-spin`/`isIconLeftSpin`: undefined
-   * - `icon-right-spin`/`isIconRightSpin`: undefined
-   * - `full-on-mobile`/`fullOnMobile`: undefined
-   * - `flush-left`/`flushLeft`: undefined
-   * - `flush-right`/`flushRight`: undefined
-   * - `style-as-link`/`styleAsLink`: undefined
+   * - `type`: The button type: button, submit, or reset.
+   * - `href`: The URL to link to (makes the button a link).
+   * - `disabled`: Whether the button is disabled or not.
+   * - `variant`: The button variant: primary, secondary, or warning.
+   * - `icon-left`/`iconLeft`: The name of the icon on the left.
+   * - `icon-right`/`iconRight`: The name of the icon on the right.
+   * - `icon-left-spin`/`isIconLeftSpin`: Whether the left icon spins or not.
+   * - `icon-right-spin`/`isIconRightSpin`: Whether the right icon spins or not.
+   * - `full-on-mobile`/`fullOnMobile`: Whether to be width 100% on mobile.
+   * - `flush-left`/`flushLeft`: Whether button is not rounded on left.
+   * - `flush-right`/`flushRight`: Whether button is not rounded on right.
+   * - `style-as-link`/`styleAsLink`: Style the button as a link.
    * - `dividerColorVar`: undefined (property only) (readonly)
    *
    * ## Slots
@@ -1089,10 +1093,10 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `borderless`: undefined
-   * - `checked`: undefined
-   * - `disabled`: undefined
-   * - `validation`: undefined
+   * - `borderless`: Whether the checkbox has a border or not.
+   * - `checked`: Whether the checkbox is checked or not.
+   * - `disabled`: Whether the checkbox is disabled or not.
+   * - `validation`: Validation style: error, warning, success.
    *
    * ## Methods
    *
@@ -1115,7 +1119,7 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `open`/`isExpanded`: undefined
+   * - `open`/`isExpanded`: Whether the expandable is expanded or not.
    *
    * ## Events
    *
@@ -1197,7 +1201,7 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `validation`: undefined
+   * - `validation`: Validation style: error, warning, success.
    * - `icon`: undefined (property only) (readonly)
    *
    * ## Slots
@@ -1223,13 +1227,13 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `checked`: undefined
-   * - `disabled`: undefined
-   * - `large`: undefined
-   * - `validation`: undefined
-   * - `type`: undefined
-   * - `name`: undefined
-   * - `value`: undefined
+   * - `checked`: Whether the choice is checked or not.
+   * - `disabled`: Whether the choice is disabled or not.
+   * - `large`: Whether the choice has a large target area.
+   * - `validation`: Validation style: error, warning, success.
+   * - `type`: Choice type: checkbox or radio.
+   * - `name`: The name within a form.
+   * - `value`: The value to submit within a form.
    *
    * ## Events
    *
@@ -1262,17 +1266,17 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `disabled`: undefined
-   * - `validation`: undefined
-   * - `label`: undefined
-   * - `name`: undefined
+   * - `disabled`: Whether the input is disabled or not.
+   * - `validation`: Validation style: error, warning, success.
+   * - `label`: The aria-label for the input.
+   * - `name`: The name within a form.
    * - `title`: undefined
-   * - `value`: undefined
-   * - `maxlength`: undefined
-   * - `placeholder`: undefined
-   * - `aria-label-input`/`ariaLabelInput`: undefined
-   * - `aria-label-button`/`ariaLabelButton`: undefined
-   * - `borderless`: undefined
+   * - `value`: The value within the input.
+   * - `maxlength`: The maximum characters allowed in the input.
+   * - `placeholder`: The placeholder value.
+   * - `aria-label-input`/`ariaLabelInput`: aria-label for input.
+   * - `aria-label-button`/`ariaLabelButton`: aria-label for button.
+   * - `borderless`: Whether the input has a border or not.
    *
    * ## Events
    *
@@ -1300,16 +1304,16 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `disabled`: undefined
-   * - `validation`: undefined
-   * - `label`: undefined
-   * - `name`: undefined
+   * - `disabled`: Whether the choice is disabled or not.
+   * - `validation`: Validation style: error, warning, success.
+   * - `label`: The aria-label for the input.
+   * - `name`: The name within a form.
    * - `title`: undefined
-   * - `value`: undefined
-   * - `maxlength`: undefined
-   * - `placeholder`: undefined
-   * - `aria-label-input`/`ariaLabelInput`: undefined
-   * - `aria-label-button`/`ariaLabelButton`: undefined
+   * - `value`: The value within the input.
+   * - `maxlength`: The maximum characters allowed in the input.
+   * - `placeholder`: The placeholder value.
+   * - `aria-label-input`/`ariaLabelInput`: aria-label for input.
+   * - `aria-label-button`/`ariaLabelButton`: aria-label for button.
    * - `searchlist`/`searchList`: undefined
    * - `isSearchDisabled`: undefined (property only) (readonly)
    * - `isOverMaxLength`: undefined (property only) (readonly)
@@ -1338,15 +1342,16 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `disabled`: undefined
-   * - `icon-left`/`iconLeft`: undefined
-   * - `icon-right`/`iconRight`: undefined
-   * - `icon-left-spin`/`isIconLeftSpin`: undefined
-   * - `icon-right-spin`/`isIconRightSpin`: undefined
-   * - `has-div`/`hasDiv`: undefined
-   * - `underline`: undefined
+   * - `disabled`: Apply disabled styles or not.
+   * - `icon-left`/`iconLeft`: The name of the icon on the left.
+   * - `icon-right`/`iconRight`: The name of the icon on the right.
+   * - `icon-left-spin`/`isIconLeftSpin`: Whether the left icon spins or not.
+   * - `icon-right-spin`/`isIconRightSpin`: Whether the right icon spins or not.
+   * - `has-div`/`hasDiv`: If true, render a divider.
+   * - `underline`: "all" for all screen sizes, "tablet-up", for tablet and above, "none", for only on hover on tablet and above.
    * - `mobile-icon-align-end`/`mobileIconAlignEnd`: undefined
    * - `inline`: undefined
+   * - `mobileUnderline`: If true render an underline at mobile. (property only)
    *
    * ## Slots
    *
@@ -1371,7 +1376,7 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `name`: undefined
+   * - `name`: The name of the icon.
    * - `spin`: undefined
    *
    * ## Methods
@@ -1389,8 +1394,8 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `block`: undefined
-   * - `for`: undefined
+   * - `block`: Whether this has block or inline helper text.
+   * - `for`: Associate the label with an ID elsewhere.
    *
    * ## Slots
    *
@@ -1464,8 +1469,8 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `childdata`/`childData`: undefined
-   * - `color-theme`/`colorTheme`: undefined
+   * - `childdata`/`childData`: Structure data to create child components.
+   * - `color-theme`/`colorTheme`: The color theme of the link. Takes 'dark'.
    * - `items`: undefined (property only) (readonly)
    *
    * ## Events
@@ -1500,10 +1505,10 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `type`: undefined
-   * - `checked`: undefined
-   * - `disabled`: undefined
-   * - `hidden`: undefined
+   * - `type`: Choice type: plain, check, checkbox.
+   * - `checked`: Whether the list item is checked or not.
+   * - `disabled`: Whether the list item is selectable or not.
+   * - `hidden`: Whether the list item is hidden or not.
    * - `href`: undefined
    * - `value`: undefined (property only)
    *
@@ -1536,10 +1541,10 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `childdata`/`childData`: undefined
-   * - `multiple`: undefined
-   * - `type`: undefined
-   * - `aria-label`/`ariaLabel`: undefined
+   * - `childdata`/`childData`: Structure data to create child components.
+   * - `multiple`: Whether the select supports multiple or not.
+   * - `type`: List item type: plain, check, or checkbox.
+   * - `aria-label`/`ariaLabel`: The aria-label for the list container.
    * - `items`: undefined (property only) (readonly)
    * - `checkedItems`: undefined (property only) (readonly)
    * - `visibleItems`: undefined (property only) (readonly)
@@ -1581,8 +1586,8 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `value`/`currentPage`: undefined
-   * - `max`/`maxPage`: undefined
+   * - `value`/`currentPage`: The currently selected page.
+   * - `max`/`maxPage`: The maximum page count.
    * - `lang`: undefined
    * - `isAtMin`: undefined (property only) (readonly)
    * - `isAtMax`: undefined (property only) (readonly)
@@ -1616,7 +1621,7 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `multiple`: undefined
+   * - `multiple`: Whether the select supports multiple or not.
    * - `disabled`: undefined
    * - `validation`: undefined
    * - `label`: undefined
@@ -1627,8 +1632,8 @@ export type CustomElements = {
    * - `placeholder`: undefined
    * - `aria-label-input`/`ariaLabelInput`: undefined
    * - `aria-label-list`/`ariaLabelList`: undefined
-   * - `open`/`isExpanded`: undefined
-   * - `selectedtexts`/`selectedTexts`: undefined
+   * - `open`/`isExpanded`: Whether the select is expanded or not.
+   * - `selectedtexts`/`selectedTexts`: Text of selected options.
    * - `optionlist`/`optionList`: undefined
    * - `options`: undefined (property only)
    *
@@ -1659,7 +1664,7 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `for`: undefined
+   * - `for`: Associate the label with an ID elsewhere.
    * - `value`: undefined
    *
    * ## Events
@@ -1692,8 +1697,8 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `href`: undefined
-   * - `siblingofjumplink`/`siblingOfJumpLink`: undefined
+   * - `href`: href attribute, if this is a topic link.
+   * - `siblingofjumplink`/`siblingOfJumpLink`: Whether the preceding sibling is a jump link or not.
    *
    * ## Slots
    *
@@ -1719,7 +1724,7 @@ export type CustomElements = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `islarge`/`isLarge`: undefined
+   * - `islarge`/`isLarge`: Whether to use the larger tagline appearance.
    *
    * ## Slots
    *
@@ -1746,8 +1751,8 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `status`: undefined
-   * - `message`: undefined
+   * - `status`: The alert status: error, success, warning, info, loading.
+   * - `message`: The message heading on an alert.
    * - `icon`: undefined (property only) (readonly)
    *
    * ## Slots
@@ -1773,18 +1778,18 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `type`: undefined
-   * - `href`: undefined
-   * - `disabled`: undefined
-   * - `variant`: undefined
-   * - `icon-left`/`iconLeft`: undefined
-   * - `icon-right`/`iconRight`: undefined
-   * - `icon-left-spin`/`isIconLeftSpin`: undefined
-   * - `icon-right-spin`/`isIconRightSpin`: undefined
-   * - `full-on-mobile`/`fullOnMobile`: undefined
-   * - `flush-left`/`flushLeft`: undefined
-   * - `flush-right`/`flushRight`: undefined
-   * - `style-as-link`/`styleAsLink`: undefined
+   * - `type`: The button type: button, submit, or reset.
+   * - `href`: The URL to link to (makes the button a link).
+   * - `disabled`: Whether the button is disabled or not.
+   * - `variant`: The button variant: primary, secondary, or warning.
+   * - `icon-left`/`iconLeft`: The name of the icon on the left.
+   * - `icon-right`/`iconRight`: The name of the icon on the right.
+   * - `icon-left-spin`/`isIconLeftSpin`: Whether the left icon spins or not.
+   * - `icon-right-spin`/`isIconRightSpin`: Whether the right icon spins or not.
+   * - `full-on-mobile`/`fullOnMobile`: Whether to be width 100% on mobile.
+   * - `flush-left`/`flushLeft`: Whether button is not rounded on left.
+   * - `flush-right`/`flushRight`: Whether button is not rounded on right.
+   * - `style-as-link`/`styleAsLink`: Style the button as a link.
    * - `dividerColorVar`: undefined (property only) (readonly)
    *
    * ## Slots
@@ -1813,10 +1818,10 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `borderless`: undefined
-   * - `checked`: undefined
-   * - `disabled`: undefined
-   * - `validation`: undefined
+   * - `borderless`: Whether the checkbox has a border or not.
+   * - `checked`: Whether the checkbox is checked or not.
+   * - `disabled`: Whether the checkbox is disabled or not.
+   * - `validation`: Validation style: error, warning, success.
    *
    * ## Methods
    *
@@ -1842,7 +1847,7 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `open`/`isExpanded`: undefined
+   * - `open`/`isExpanded`: Whether the expandable is expanded or not.
    *
    * ## Events
    *
@@ -1933,7 +1938,7 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `validation`: undefined
+   * - `validation`: Validation style: error, warning, success.
    * - `icon`: undefined (property only) (readonly)
    *
    * ## Slots
@@ -1962,13 +1967,13 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `checked`: undefined
-   * - `disabled`: undefined
-   * - `large`: undefined
-   * - `validation`: undefined
-   * - `type`: undefined
-   * - `name`: undefined
-   * - `value`: undefined
+   * - `checked`: Whether the choice is checked or not.
+   * - `disabled`: Whether the choice is disabled or not.
+   * - `large`: Whether the choice has a large target area.
+   * - `validation`: Validation style: error, warning, success.
+   * - `type`: Choice type: checkbox or radio.
+   * - `name`: The name within a form.
+   * - `value`: The value to submit within a form.
    *
    * ## Events
    *
@@ -2004,17 +2009,17 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `disabled`: undefined
-   * - `validation`: undefined
-   * - `label`: undefined
-   * - `name`: undefined
+   * - `disabled`: Whether the input is disabled or not.
+   * - `validation`: Validation style: error, warning, success.
+   * - `label`: The aria-label for the input.
+   * - `name`: The name within a form.
    * - `title`: undefined
-   * - `value`: undefined
-   * - `maxlength`: undefined
-   * - `placeholder`: undefined
-   * - `aria-label-input`/`ariaLabelInput`: undefined
-   * - `aria-label-button`/`ariaLabelButton`: undefined
-   * - `borderless`: undefined
+   * - `value`: The value within the input.
+   * - `maxlength`: The maximum characters allowed in the input.
+   * - `placeholder`: The placeholder value.
+   * - `aria-label-input`/`ariaLabelInput`: aria-label for input.
+   * - `aria-label-button`/`ariaLabelButton`: aria-label for button.
+   * - `borderless`: Whether the input has a border or not.
    *
    * ## Events
    *
@@ -2045,16 +2050,16 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `disabled`: undefined
-   * - `validation`: undefined
-   * - `label`: undefined
-   * - `name`: undefined
+   * - `disabled`: Whether the choice is disabled or not.
+   * - `validation`: Validation style: error, warning, success.
+   * - `label`: The aria-label for the input.
+   * - `name`: The name within a form.
    * - `title`: undefined
-   * - `value`: undefined
-   * - `maxlength`: undefined
-   * - `placeholder`: undefined
-   * - `aria-label-input`/`ariaLabelInput`: undefined
-   * - `aria-label-button`/`ariaLabelButton`: undefined
+   * - `value`: The value within the input.
+   * - `maxlength`: The maximum characters allowed in the input.
+   * - `placeholder`: The placeholder value.
+   * - `aria-label-input`/`ariaLabelInput`: aria-label for input.
+   * - `aria-label-button`/`ariaLabelButton`: aria-label for button.
    * - `searchlist`/`searchList`: undefined
    * - `isSearchDisabled`: undefined (property only) (readonly)
    * - `isOverMaxLength`: undefined (property only) (readonly)
@@ -2086,15 +2091,16 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `disabled`: undefined
-   * - `icon-left`/`iconLeft`: undefined
-   * - `icon-right`/`iconRight`: undefined
-   * - `icon-left-spin`/`isIconLeftSpin`: undefined
-   * - `icon-right-spin`/`isIconRightSpin`: undefined
-   * - `has-div`/`hasDiv`: undefined
-   * - `underline`: undefined
+   * - `disabled`: Apply disabled styles or not.
+   * - `icon-left`/`iconLeft`: The name of the icon on the left.
+   * - `icon-right`/`iconRight`: The name of the icon on the right.
+   * - `icon-left-spin`/`isIconLeftSpin`: Whether the left icon spins or not.
+   * - `icon-right-spin`/`isIconRightSpin`: Whether the right icon spins or not.
+   * - `has-div`/`hasDiv`: If true, render a divider.
+   * - `underline`: "all" for all screen sizes, "tablet-up", for tablet and above, "none", for only on hover on tablet and above.
    * - `mobile-icon-align-end`/`mobileIconAlignEnd`: undefined
    * - `inline`: undefined
+   * - `mobileUnderline`: If true render an underline at mobile. (property only)
    *
    * ## Slots
    *
@@ -2122,7 +2128,7 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `name`: undefined
+   * - `name`: The name of the icon.
    * - `spin`: undefined
    *
    * ## Methods
@@ -2142,8 +2148,8 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `block`: undefined
-   * - `for`: undefined
+   * - `block`: Whether this has block or inline helper text.
+   * - `for`: Associate the label with an ID elsewhere.
    *
    * ## Slots
    *
@@ -2224,8 +2230,8 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `childdata`/`childData`: undefined
-   * - `color-theme`/`colorTheme`: undefined
+   * - `childdata`/`childData`: Structure data to create child components.
+   * - `color-theme`/`colorTheme`: The color theme of the link. Takes 'dark'.
    * - `items`: undefined (property only) (readonly)
    *
    * ## Events
@@ -2262,10 +2268,10 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `type`: undefined
-   * - `checked`: undefined
-   * - `disabled`: undefined
-   * - `hidden`: undefined
+   * - `type`: Choice type: plain, check, checkbox.
+   * - `checked`: Whether the list item is checked or not.
+   * - `disabled`: Whether the list item is selectable or not.
+   * - `hidden`: Whether the list item is hidden or not.
    * - `href`: undefined
    * - `value`: undefined (property only)
    *
@@ -2301,10 +2307,10 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `childdata`/`childData`: undefined
-   * - `multiple`: undefined
-   * - `type`: undefined
-   * - `aria-label`/`ariaLabel`: undefined
+   * - `childdata`/`childData`: Structure data to create child components.
+   * - `multiple`: Whether the select supports multiple or not.
+   * - `type`: List item type: plain, check, or checkbox.
+   * - `aria-label`/`ariaLabel`: The aria-label for the list container.
    * - `items`: undefined (property only) (readonly)
    * - `checkedItems`: undefined (property only) (readonly)
    * - `visibleItems`: undefined (property only) (readonly)
@@ -2349,8 +2355,8 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `value`/`currentPage`: undefined
-   * - `max`/`maxPage`: undefined
+   * - `value`/`currentPage`: The currently selected page.
+   * - `max`/`maxPage`: The maximum page count.
    * - `lang`: undefined
    * - `isAtMin`: undefined (property only) (readonly)
    * - `isAtMax`: undefined (property only) (readonly)
@@ -2387,7 +2393,7 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `multiple`: undefined
+   * - `multiple`: Whether the select supports multiple or not.
    * - `disabled`: undefined
    * - `validation`: undefined
    * - `label`: undefined
@@ -2398,8 +2404,8 @@ export type CustomElementsSolidJs = {
    * - `placeholder`: undefined
    * - `aria-label-input`/`ariaLabelInput`: undefined
    * - `aria-label-list`/`ariaLabelList`: undefined
-   * - `open`/`isExpanded`: undefined
-   * - `selectedtexts`/`selectedTexts`: undefined
+   * - `open`/`isExpanded`: Whether the select is expanded or not.
+   * - `selectedtexts`/`selectedTexts`: Text of selected options.
    * - `optionlist`/`optionList`: undefined
    * - `options`: undefined (property only)
    *
@@ -2435,7 +2441,7 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `for`: undefined
+   * - `for`: Associate the label with an ID elsewhere.
    * - `value`: undefined
    *
    * ## Events
@@ -2471,8 +2477,8 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `href`: undefined
-   * - `siblingofjumplink`/`siblingOfJumpLink`: undefined
+   * - `href`: href attribute, if this is a topic link.
+   * - `siblingofjumplink`/`siblingOfJumpLink`: Whether the preceding sibling is a jump link or not.
    *
    * ## Slots
    *
@@ -2501,7 +2507,7 @@ export type CustomElementsSolidJs = {
    *
    * Component attributes and properties that can be applied to the element or by using JavaScript.
    *
-   * - `islarge`/`isLarge`: undefined
+   * - `islarge`/`isLarge`: Whether to use the larger tagline appearance.
    *
    * ## Slots
    *

--- a/storybook/custom-elements.json
+++ b/storybook/custom-elements.json
@@ -38,6 +38,7 @@
                 "text": "string"
               },
               "default": "'info'",
+              "description": "The alert status: error, success, warning, info, loading.",
               "attribute": "status"
             },
             {
@@ -48,6 +49,7 @@
                 "text": "string"
               },
               "default": "'Alert'",
+              "description": "The message heading on an alert.",
               "attribute": "message"
             }
           ],
@@ -58,6 +60,7 @@
                 "text": "string"
               },
               "default": "'info'",
+              "description": "The alert status: error, success, warning, info, loading.",
               "fieldName": "status"
             },
             {
@@ -66,6 +69,7 @@
                 "text": "string"
               },
               "default": "'Alert'",
+              "description": "The message heading on an alert.",
               "fieldName": "message"
             }
           ],
@@ -171,6 +175,7 @@
                 "text": "string"
               },
               "default": "'button'",
+              "description": "The button type: button, submit, or reset.",
               "attribute": "type"
             },
             {
@@ -181,6 +186,7 @@
                 "text": "string"
               },
               "default": "'primary'",
+              "description": "The button variant: primary, secondary, or warning.",
               "attribute": "variant"
             },
             {
@@ -191,6 +197,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the button is disabled or not.",
               "attribute": "disabled",
               "reflects": true
             },
@@ -202,6 +209,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether to be width 100% on mobile.",
               "attribute": "full-on-mobile",
               "reflects": true
             },
@@ -213,6 +221,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Style the button as a link.",
               "attribute": "style-as-link",
               "reflects": true
             },
@@ -224,6 +233,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the left icon spins or not.",
               "attribute": "icon-left-spin"
             },
             {
@@ -234,6 +244,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the right icon spins or not.",
               "attribute": "icon-right-spin"
             },
             {
@@ -243,6 +254,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The URL to link to (makes the button a link).",
               "attribute": "href"
             },
             {
@@ -252,6 +264,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The name of the icon on the left.",
               "attribute": "icon-left"
             },
             {
@@ -261,6 +274,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The name of the icon on the right.",
               "attribute": "icon-right"
             },
             {
@@ -270,6 +284,7 @@
               "type": {
                 "text": "boolean"
               },
+              "description": "Whether button is not rounded on left.",
               "attribute": "flush-left",
               "reflects": true
             },
@@ -280,6 +295,7 @@
               "type": {
                 "text": "boolean"
               },
+              "description": "Whether button is not rounded on right.",
               "attribute": "flush-right",
               "reflects": true
             }
@@ -291,6 +307,7 @@
                 "text": "string"
               },
               "default": "'button'",
+              "description": "The button type: button, submit, or reset.",
               "fieldName": "type"
             },
             {
@@ -298,6 +315,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The URL to link to (makes the button a link).",
               "fieldName": "href"
             },
             {
@@ -306,6 +324,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the button is disabled or not.",
               "fieldName": "disabled"
             },
             {
@@ -314,6 +333,7 @@
                 "text": "string"
               },
               "default": "'primary'",
+              "description": "The button variant: primary, secondary, or warning.",
               "fieldName": "variant"
             },
             {
@@ -321,6 +341,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The name of the icon on the left.",
               "fieldName": "iconLeft"
             },
             {
@@ -328,6 +349,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The name of the icon on the right.",
               "fieldName": "iconRight"
             },
             {
@@ -336,6 +358,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the left icon spins or not.",
               "fieldName": "isIconLeftSpin"
             },
             {
@@ -344,6 +367,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the right icon spins or not.",
               "fieldName": "isIconRightSpin"
             },
             {
@@ -352,6 +376,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether to be width 100% on mobile.",
               "fieldName": "fullOnMobile"
             },
             {
@@ -359,6 +384,7 @@
               "type": {
                 "text": "boolean"
               },
+              "description": "Whether button is not rounded on left.",
               "fieldName": "flushLeft"
             },
             {
@@ -366,6 +392,7 @@
               "type": {
                 "text": "boolean"
               },
+              "description": "Whether button is not rounded on right.",
               "fieldName": "flushRight"
             },
             {
@@ -374,6 +401,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Style the button as a link.",
               "fieldName": "styleAsLink"
             }
           ],
@@ -485,6 +513,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the checkbox has a border or not.",
               "attribute": "borderless",
               "reflects": true
             },
@@ -496,6 +525,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the checkbox is checked or not.",
               "attribute": "checked",
               "reflects": true
             },
@@ -507,6 +537,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the checkbox is disabled or not.",
               "attribute": "disabled",
               "reflects": true
             },
@@ -518,6 +549,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "Validation style: error, warning, success.",
               "attribute": "validation",
               "reflects": true
             }
@@ -529,6 +561,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the checkbox has a border or not.",
               "fieldName": "borderless"
             },
             {
@@ -537,6 +570,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the checkbox is checked or not.",
               "fieldName": "checked"
             },
             {
@@ -545,6 +579,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the checkbox is disabled or not.",
               "fieldName": "disabled"
             },
             {
@@ -553,6 +588,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "Validation style: error, warning, success.",
               "fieldName": "validation"
             }
           ],
@@ -621,6 +657,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the expandable is expanded or not.",
               "attribute": "open",
               "reflects": true
             }
@@ -662,6 +699,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the expandable is expanded or not.",
               "fieldName": "isExpanded"
             }
           ],
@@ -877,6 +915,7 @@
                 "text": "string"
               },
               "default": "'error'",
+              "description": "Validation style: error, warning, success.",
               "attribute": "validation"
             }
           ],
@@ -887,6 +926,7 @@
                 "text": "string"
               },
               "default": "'error'",
+              "description": "Validation style: error, warning, success.",
               "fieldName": "validation"
             }
           ],
@@ -1023,6 +1063,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the choice is checked or not.",
               "attribute": "checked",
               "reflects": true
             },
@@ -1034,6 +1075,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the choice is disabled or not.",
               "attribute": "disabled"
             },
             {
@@ -1044,6 +1086,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the choice has a large target area.",
               "attribute": "large"
             },
             {
@@ -1054,6 +1097,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "Validation style: error, warning, success.",
               "attribute": "validation"
             },
             {
@@ -1064,6 +1108,7 @@
                 "text": "string"
               },
               "default": "'checkbox'",
+              "description": "Choice type: checkbox or radio.",
               "attribute": "type"
             },
             {
@@ -1074,6 +1119,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "The name within a form.",
               "attribute": "name"
             },
             {
@@ -1084,6 +1130,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "The value to submit within a form.",
               "attribute": "value"
             }
           ],
@@ -1108,6 +1155,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the choice is checked or not.",
               "fieldName": "checked"
             },
             {
@@ -1116,6 +1164,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the choice is disabled or not.",
               "fieldName": "disabled"
             },
             {
@@ -1124,6 +1173,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the choice has a large target area.",
               "fieldName": "large"
             },
             {
@@ -1132,6 +1182,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "Validation style: error, warning, success.",
               "fieldName": "validation"
             },
             {
@@ -1140,6 +1191,7 @@
                 "text": "string"
               },
               "default": "'checkbox'",
+              "description": "Choice type: checkbox or radio.",
               "fieldName": "type"
             },
             {
@@ -1148,6 +1200,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "The name within a form.",
               "fieldName": "name"
             },
             {
@@ -1156,6 +1209,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "The value to submit within a form.",
               "fieldName": "value"
             }
           ],
@@ -1251,6 +1305,7 @@
                 "text": "string"
               },
               "default": "'Search'",
+              "description": "The aria-label for the input.",
               "attribute": "label"
             },
             {
@@ -1261,6 +1316,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "The name within a form.",
               "attribute": "name"
             },
             {
@@ -1281,6 +1337,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "The value within the input.",
               "attribute": "value"
             },
             {
@@ -1291,6 +1348,7 @@
                 "text": "number"
               },
               "default": "75",
+              "description": "The maximum characters allowed in the input.",
               "attribute": "maxlength",
               "reflects": true
             },
@@ -1302,6 +1360,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "The placeholder value.",
               "attribute": "placeholder"
             },
             {
@@ -1312,6 +1371,7 @@
                 "text": "string"
               },
               "default": "'Search input'",
+              "description": "aria-label for input.",
               "attribute": "aria-label-input"
             },
             {
@@ -1322,6 +1382,7 @@
                 "text": "string"
               },
               "default": "'Clear search'",
+              "description": "aria-label for button.",
               "attribute": "aria-label-button"
             },
             {
@@ -1332,6 +1393,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the input is disabled or not.",
               "attribute": "disabled",
               "reflects": true
             },
@@ -1343,6 +1405,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the input has a border or not.",
               "attribute": "borderless",
               "reflects": true
             },
@@ -1353,6 +1416,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "Validation style: error, warning, success.",
               "attribute": "validation",
               "reflects": true
             }
@@ -1384,6 +1448,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the input is disabled or not.",
               "fieldName": "disabled"
             },
             {
@@ -1391,6 +1456,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "Validation style: error, warning, success.",
               "fieldName": "validation"
             },
             {
@@ -1399,6 +1465,7 @@
                 "text": "string"
               },
               "default": "'Search'",
+              "description": "The aria-label for the input.",
               "fieldName": "label"
             },
             {
@@ -1407,6 +1474,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "The name within a form.",
               "fieldName": "name"
             },
             {
@@ -1423,6 +1491,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "The value within the input.",
               "fieldName": "value"
             },
             {
@@ -1431,6 +1500,7 @@
                 "text": "number"
               },
               "default": "75",
+              "description": "The maximum characters allowed in the input.",
               "fieldName": "maxlength"
             },
             {
@@ -1439,6 +1509,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "The placeholder value.",
               "fieldName": "placeholder"
             },
             {
@@ -1447,6 +1518,7 @@
                 "text": "string"
               },
               "default": "'Search input'",
+              "description": "aria-label for input.",
               "fieldName": "ariaLabelInput"
             },
             {
@@ -1455,6 +1527,7 @@
                 "text": "string"
               },
               "default": "'Clear search'",
+              "description": "aria-label for button.",
               "fieldName": "ariaLabelButton"
             },
             {
@@ -1463,6 +1536,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the input has a border or not.",
               "fieldName": "borderless"
             }
           ],
@@ -1606,6 +1680,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "The value within the input.",
               "attribute": "value"
             },
             {
@@ -1625,6 +1700,7 @@
               "type": {
                 "text": "boolean"
               },
+              "description": "Whether the choice is disabled or not.",
               "attribute": "disabled"
             },
             {
@@ -1634,6 +1710,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "Validation style: error, warning, success.",
               "attribute": "validation"
             },
             {
@@ -1643,6 +1720,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The aria-label for the input.",
               "attribute": "label"
             },
             {
@@ -1652,25 +1730,8 @@
               "type": {
                 "text": "string"
               },
+              "description": "The name within a form.",
               "attribute": "name"
-            },
-            {
-              "kind": "field",
-              "name": "title",
-              "privacy": "public",
-              "type": {
-                "text": "boolean"
-              },
-              "attribute": "title"
-            },
-            {
-              "kind": "field",
-              "name": "maxlength",
-              "privacy": "public",
-              "type": {
-                "text": "number"
-              },
-              "attribute": "maxlength"
             },
             {
               "kind": "field",
@@ -1679,7 +1740,18 @@
               "type": {
                 "text": "string"
               },
+              "description": "The placeholder value.",
               "attribute": "placeholder"
+            },
+            {
+              "kind": "field",
+              "name": "maxlength",
+              "privacy": "public",
+              "type": {
+                "text": "string"
+              },
+              "description": "The maximum characters allowed in the input.",
+              "attribute": "maxlength"
             },
             {
               "kind": "field",
@@ -1688,6 +1760,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "aria-label for input.",
               "attribute": "aria-label-input"
             },
             {
@@ -1697,7 +1770,17 @@
               "type": {
                 "text": "string"
               },
+              "description": "aria-label for button.",
               "attribute": "aria-label-button"
+            },
+            {
+              "kind": "field",
+              "name": "title",
+              "privacy": "public",
+              "type": {
+                "text": "boolean"
+              },
+              "attribute": "title"
             }
           ],
           "attributes": [
@@ -1706,6 +1789,7 @@
               "type": {
                 "text": "boolean"
               },
+              "description": "Whether the choice is disabled or not.",
               "fieldName": "disabled"
             },
             {
@@ -1713,6 +1797,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "Validation style: error, warning, success.",
               "fieldName": "validation"
             },
             {
@@ -1720,6 +1805,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The aria-label for the input.",
               "fieldName": "label"
             },
             {
@@ -1727,6 +1813,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The name within a form.",
               "fieldName": "name"
             },
             {
@@ -1742,13 +1829,15 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "The value within the input.",
               "fieldName": "value"
             },
             {
               "name": "maxlength",
               "type": {
-                "text": "number"
+                "text": "string"
               },
+              "description": "The maximum characters allowed in the input.",
               "fieldName": "maxlength"
             },
             {
@@ -1756,6 +1845,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The placeholder value.",
               "fieldName": "placeholder"
             },
             {
@@ -1763,6 +1853,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "aria-label for input.",
               "fieldName": "ariaLabelInput"
             },
             {
@@ -1770,6 +1861,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "aria-label for button.",
               "fieldName": "ariaLabelButton"
             },
             {
@@ -1832,6 +1924,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Apply disabled styles or not.",
               "attribute": "disabled",
               "reflects": true
             },
@@ -1840,9 +1933,10 @@
               "name": "isIconLeftSpin",
               "privacy": "public",
               "type": {
-                "text": "boolean"
+                "text": "string"
               },
               "default": "false",
+              "description": "Whether the left icon spins or not.",
               "attribute": "icon-left-spin"
             },
             {
@@ -1850,9 +1944,10 @@
               "name": "isIconRightSpin",
               "privacy": "public",
               "type": {
-                "text": "boolean"
+                "text": "string"
               },
               "default": "false",
+              "description": "Whether the right icon spins or not.",
               "attribute": "icon-right-spin"
             },
             {
@@ -1862,6 +1957,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The name of the icon on the left.",
               "attribute": "icon-left"
             },
             {
@@ -1871,6 +1967,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The name of the icon on the right.",
               "attribute": "icon-right"
             },
             {
@@ -1880,6 +1977,7 @@
               "type": {
                 "text": "boolean"
               },
+              "description": "If true, render a divider.",
               "attribute": "has-div",
               "reflects": true
             },
@@ -1888,10 +1986,19 @@
               "name": "underline",
               "privacy": "public",
               "type": {
-                "text": "string"
+                "text": "boolean"
               },
+              "description": "\"all\" for all screen sizes, \"tablet-up\", for tablet and above, \"none\", for only on hover on tablet and above.",
               "attribute": "underline",
               "reflects": true
+            },
+            {
+              "type": {
+                "text": "boolean"
+              },
+              "description": "If true render an underline at mobile.",
+              "name": "mobileUnderline",
+              "kind": "field"
             },
             {
               "kind": "field",
@@ -1921,6 +2028,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Apply disabled styles or not.",
               "fieldName": "disabled"
             },
             {
@@ -1928,6 +2036,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The name of the icon on the left.",
               "fieldName": "iconLeft"
             },
             {
@@ -1935,22 +2044,25 @@
               "type": {
                 "text": "string"
               },
+              "description": "The name of the icon on the right.",
               "fieldName": "iconRight"
             },
             {
               "name": "icon-left-spin",
               "type": {
-                "text": "boolean"
+                "text": "string"
               },
               "default": "false",
+              "description": "Whether the left icon spins or not.",
               "fieldName": "isIconLeftSpin"
             },
             {
               "name": "icon-right-spin",
               "type": {
-                "text": "boolean"
+                "text": "string"
               },
               "default": "false",
+              "description": "Whether the right icon spins or not.",
               "fieldName": "isIconRightSpin"
             },
             {
@@ -1958,13 +2070,15 @@
               "type": {
                 "text": "boolean"
               },
+              "description": "If true, render a divider.",
               "fieldName": "hasDiv"
             },
             {
               "name": "underline",
               "type": {
-                "text": "string"
+                "text": "boolean"
               },
+              "description": "\"all\" for all screen sizes, \"tablet-up\", for tablet and above, \"none\", for only on hover on tablet and above.",
               "fieldName": "underline"
             },
             {
@@ -2024,8 +2138,9 @@
               "name": "name",
               "privacy": "public",
               "type": {
-                "text": "string"
+                "text": "boolean"
               },
+              "description": "The name of the icon.",
               "attribute": "name"
             },
             {
@@ -2042,8 +2157,9 @@
             {
               "name": "name",
               "type": {
-                "text": "string"
+                "text": "boolean"
               },
+              "description": "The name of the icon.",
               "fieldName": "name"
             },
             {
@@ -2115,6 +2231,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether this has block or inline helper text.",
               "attribute": "block",
               "reflects": true
             },
@@ -2126,6 +2243,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "Associate the label with an ID elsewhere.",
               "attribute": "for"
             }
           ],
@@ -2136,6 +2254,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether this has block or inline helper text.",
               "fieldName": "block"
             },
             {
@@ -2144,6 +2263,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "Associate the label with an ID elsewhere.",
               "fieldName": "for"
             }
           ],
@@ -3075,6 +3195,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "Structure data to create child components.",
               "attribute": "childdata"
             },
             {
@@ -3084,6 +3205,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The color theme of the link. Takes 'dark'.",
               "attribute": "color-theme",
               "reflects": true
             }
@@ -3118,6 +3240,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "Structure data to create child components.",
               "fieldName": "childData"
             },
             {
@@ -3125,6 +3248,7 @@
               "type": {
                 "text": "string"
               },
+              "description": "The color theme of the link. Takes 'dark'.",
               "fieldName": "colorTheme"
             }
           ],
@@ -3252,6 +3376,7 @@
                 "text": "string"
               },
               "default": "'plain'",
+              "description": "Choice type: plain, check, checkbox.",
               "attribute": "type",
               "reflects": true
             },
@@ -3263,6 +3388,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the list item is checked or not.",
               "attribute": "checked",
               "reflects": true
             },
@@ -3274,6 +3400,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the list item is selectable or not.",
               "attribute": "disabled",
               "reflects": true
             },
@@ -3285,6 +3412,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the list item is hidden or not.",
               "attribute": "hidden",
               "reflects": true
             },
@@ -3314,6 +3442,7 @@
                 "text": "string"
               },
               "default": "'plain'",
+              "description": "Choice type: plain, check, checkbox.",
               "fieldName": "type"
             },
             {
@@ -3322,6 +3451,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the list item is checked or not.",
               "fieldName": "checked"
             },
             {
@@ -3330,6 +3460,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the list item is selectable or not.",
               "fieldName": "disabled"
             },
             {
@@ -3338,6 +3469,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the list item is hidden or not.",
               "fieldName": "hidden"
             },
             {
@@ -3599,9 +3731,10 @@
               "name": "childData",
               "privacy": "public",
               "type": {
-                "text": "string"
+                "text": "Array"
               },
               "default": "''",
+              "description": "Structure data to create child components.",
               "attribute": "childdata"
             },
             {
@@ -3612,6 +3745,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the select supports multiple or not.",
               "attribute": "multiple",
               "reflects": true
             },
@@ -3623,6 +3757,7 @@
                 "text": "string"
               },
               "default": "'plain'",
+              "description": "List item type: plain, check, or checkbox.",
               "attribute": "type",
               "reflects": true
             },
@@ -3634,6 +3769,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "The aria-label for the list container.",
               "attribute": "aria-label"
             }
           ],
@@ -3661,9 +3797,10 @@
             {
               "name": "childdata",
               "type": {
-                "text": "string"
+                "text": "Array"
               },
               "default": "''",
+              "description": "Structure data to create child components.",
               "fieldName": "childData"
             },
             {
@@ -3672,6 +3809,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the select supports multiple or not.",
               "fieldName": "multiple"
             },
             {
@@ -3680,6 +3818,7 @@
                 "text": "string"
               },
               "default": "'plain'",
+              "description": "List item type: plain, check, or checkbox.",
               "fieldName": "type"
             },
             {
@@ -3688,6 +3827,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "The aria-label for the list container.",
               "fieldName": "ariaLabel"
             }
           ],
@@ -3812,6 +3952,7 @@
                 "text": "number"
               },
               "default": "1",
+              "description": "The currently selected page.",
               "attribute": "value",
               "reflects": true
             },
@@ -3823,6 +3964,7 @@
                 "text": "number"
               },
               "default": "1",
+              "description": "The maximum page count.",
               "attribute": "max",
               "reflects": true
             },
@@ -3853,6 +3995,7 @@
                 "text": "number"
               },
               "default": "1",
+              "description": "The currently selected page.",
               "fieldName": "currentPage"
             },
             {
@@ -3861,6 +4004,7 @@
                 "text": "number"
               },
               "default": "1",
+              "description": "The maximum page count.",
               "fieldName": "maxPage"
             },
             {
@@ -4072,6 +4216,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the select supports multiple or not.",
               "attribute": "multiple",
               "reflects": true
             },
@@ -4088,9 +4233,10 @@
               "name": "selectedTexts",
               "privacy": "public",
               "type": {
-                "text": "array"
+                "text": "Array"
               },
               "default": "[]",
+              "description": "Text of selected options.",
               "attribute": "selectedtexts"
             },
             {
@@ -4102,6 +4248,17 @@
               },
               "default": "[]",
               "attribute": "optionlist"
+            },
+            {
+              "kind": "field",
+              "name": "isExpanded",
+              "privacy": "public",
+              "type": {
+                "text": "boolean"
+              },
+              "description": "Whether the select is expanded or not.",
+              "attribute": "open",
+              "reflects": true
             },
             {
               "kind": "field",
@@ -4192,16 +4349,6 @@
                 "text": "string"
               },
               "attribute": "aria-label-list"
-            },
-            {
-              "kind": "field",
-              "name": "isExpanded",
-              "privacy": "public",
-              "type": {
-                "text": "boolean"
-              },
-              "attribute": "open",
-              "reflects": true
             }
           ],
           "events": [
@@ -4219,6 +4366,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the select supports multiple or not.",
               "fieldName": "multiple"
             },
             {
@@ -4296,14 +4444,16 @@
               "type": {
                 "text": "boolean"
               },
+              "description": "Whether the select is expanded or not.",
               "fieldName": "isExpanded"
             },
             {
               "name": "selectedtexts",
               "type": {
-                "text": "array"
+                "text": "Array"
               },
               "default": "[]",
+              "description": "Text of selected options.",
               "fieldName": "selectedTexts"
             },
             {
@@ -4572,6 +4722,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "Associate the label with an ID elsewhere.",
               "attribute": "for"
             },
             {
@@ -4600,6 +4751,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "Associate the label with an ID elsewhere.",
               "fieldName": "for"
             },
             {
@@ -4675,6 +4827,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "href attribute, if this is a topic link.",
               "attribute": "href",
               "reflects": true
             },
@@ -4686,6 +4839,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the preceding sibling is a jump link or not.",
               "attribute": "siblingofjumplink"
             }
           ],
@@ -4696,6 +4850,7 @@
                 "text": "string"
               },
               "default": "''",
+              "description": "href attribute, if this is a topic link.",
               "fieldName": "href"
             },
             {
@@ -4704,6 +4859,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether the preceding sibling is a jump link or not.",
               "fieldName": "siblingOfJumpLink"
             }
           ],
@@ -4758,6 +4914,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether to use the larger tagline appearance.",
               "attribute": "islarge",
               "reflects": true
             }
@@ -4769,6 +4926,7 @@
                 "text": "boolean"
               },
               "default": "false",
+              "description": "Whether to use the larger tagline appearance.",
               "fieldName": "isLarge"
             }
           ],

--- a/test/plugins/element-helpers.js
+++ b/test/plugins/element-helpers.js
@@ -50,7 +50,7 @@ export async function mount(
   mounted.add(elm);
 
   await customElements.whenDefined(tag);
-  if (elm.updatedComplete) await elm.updateComplete;
+  while (elm.updateComplete && !(await elm.updateComplete));
 
   return elm;
 }

--- a/test/plugins/element-helpers.ts
+++ b/test/plugins/element-helpers.ts
@@ -1,0 +1,67 @@
+/**
+ * Helpers shared across the Web Component `index.spec.js` files.
+ *
+ * The rely only on the DOM so they keep working if Storybook is replaced.
+ */
+
+// Everything mount() has added to the document so cleanup() can remove it
+const mounted = new Set();
+
+/**
+ * Mount a custom element and wait for its first render
+ *
+ * The element's `init()` needs to have run so call it once at
+ * the top of the `describe` block.
+ * @param {string} tag - The custom element tag, EG `cfpb-button`.
+ * @param {object} [options] - How to se the element up.
+ * @param {object} [options.attributes] - Attribute name/value pairs and a value of `true` sets bool so `{ disabled: true } works.
+ * @param {object} [options.properties] - Properties assigned directly to the element for anything that has no attr or is not a string.
+ * @param {string} [options.text] - Text content for the default slot.
+ * @param {string} [options.html] - Markup for the default slot. Takes precedence over `text`.
+ * @returns {Promise<HTMLElement>} The mounted, rendered element.
+ */
+export async function mount(
+  tag,
+  { attributes = {}, properties = {}, text, html } = {},
+) {
+  if (!customElements.get(tag)) {
+    throw new Error(
+      `<${tag}> is not registered. Call its init() before mount(), ` +
+        `for example \`CfpbButton.init()\` at the top of the description block.`,
+    );
+  }
+
+  const elm = document.createElement(tag);
+
+  for (const [name, value] of Object.entries(attributes)) {
+    if (value === false || value === undefined || value === null) continue;
+    elm.setAttribute(name, value === true ? '' : value);
+  }
+
+  Object.assign(elm, properties);
+
+  if (html !== undefined) {
+    elm.innerHTML = html;
+  } else if (text !== undefined) {
+    elm.textContent = text;
+  }
+
+  document.body.appendChild(elm);
+  mounted.add(elm);
+
+  await customElements.whenDefined(tag);
+  if (elm.updatedComplete) await elm.updateComplete;
+
+  return elm;
+}
+
+/**
+ * Remove everything mount() added to the document. Pass it straight
+ * to `afterEach(cleanup)`
+ */
+export function cleanup() {
+  for (const elm of mounted) {
+    elm.remove();
+  }
+  mounted.clear();
+}


### PR DESCRIPTION
In order to create more reusable code for testing Ans suggested that we refactor some of the commonly used things. 

Specifically that meant creating `.storybook/plugins/story-helpers.ts` and `test/plugins/element-helpers.js`

| File| Use |
|----|-----------|
|`story-helpers.ts`| Storybook specific.  `iconNames` - Every icon the DS ships is taken from SVG filenames. `iconControl` - A Storybook select control listing every icon name. `reserveOverlayRoom` - Storybook sizes the canvas iframe based on the story content. That means things with menus _could_ extend beyond the iframe and appear cut off. This sets a `minHeight` so that doesn't happen. |
|`element-helpers.js`| Unit test specific. `mount` - Mount a custom element and wait for first render.  `cleanup` - Remove everything mount added to the document |

The CEM analyzer was generating a CEM without descriptions. That in turn mean that Storybook was not getting descriptions either. In order for that to work , `CEM analyzer `wants what were the static property JSDoc comments in either the block above the class or `//` comments in the static properties.  I have opted to move the static property JSDoc comments to the class block in all our WCs. 

The result is that now the CEM and the generated types have descriptions and in the case of the CEM descriptions they properly populate Storybook descriptions using the `@wc-toolkit story-helpers` so that we do not need to maintain those by hand. 

Finally, hooked all of that up into the existing Storybook stories. 

`yarn storybook` and verify there are no regressions and that we now have Storybook descriptions. Additionally, verify that on the `cfpb-button` story the `icon-left` and `icon-right` Storybook UI controls have the complete list of the SVG files and that making a selection adds one. The first entry in the droplist is empty and selecting it is how you remove icon choice.

Also crack open `storybook/custom-elements.json` and `storybook/custom-elements-types.d.ts` verify that descriptions made it into those files. 

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots

| Before | After  |
| ------ | ------ |
|        |        |

## Notes and todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

Check the [current browser support cutoff list](https://cfpb.github.io/consumerfinance.gov/browser-support#current-browser-support-metrics) for browsers that are advisable
to prioritize for testing.

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
