### PR TITLE
Fix "Multiple versions of Lit loaded" warning when running tests

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -47,6 +47,12 @@ export default {
       css: {
         transformer: 'lightningcss',
       },
+      // Vitest turns off Vite's dep discovery so any Lit entry point missing from the
+      // pre-bundle is served from node_modules and loads a second lit-html. AKA
+      // "Multipe versions of Lit loaded".
+      optimizeDeps: {
+        include: ['lit/directive-helpers.js', 'lit/directives/if-defined.js'],
+      },
       resolve: {
         alias: {
           '@cfpb/cfpb-design-system': path.resolve(


### PR DESCRIPTION
`yarn storybook` and use the UI controls to run tests. Notice there is no longer a "Multiple versions of Lit loaded" warning in the terminal output. Verify that all tests pass with no regressions. 

`yarn test` and confirm the same behavior as above. No warning, all passing. 

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots

| Before | After  |
| ------ | ------ |
|        |        |

## Notes and todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

Check the [current browser support cutoff list](https://cfpb.github.io/consumerfinance.gov/browser-support#current-browser-support-metrics) for browsers that are advisable
to prioritize for testing.

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
